### PR TITLE
write link references

### DIFF
--- a/examples/hello.md
+++ b/examples/hello.md
@@ -10,6 +10,12 @@ In fact, I'm doing very well!
 This line isn't a new paragraph, just some
 wrapping that mdq should unwrap.
 
+### Sub-section with link
+
+This is [my referenced link][a1].
+
+[a1]: https://example.com/reference
+
 ### Here's a *cool* table
 
 | Column Left | Column Middle | Column Right |
@@ -20,13 +26,7 @@ This is [my inline link](https://example.com/inline).
 
 This is [my inline link with title](https://example.com/inline "its title").
 
-This is [my referenced link][a1].
-
 This is [my referenced link with title][a2].
-
-[a1]: https://example.com/reference
-
-[a2]: https://example.com/reference "its reference title"
 
 ## Hello lists
 
@@ -37,6 +37,8 @@ This is [my referenced link with title][a2].
 
 - [x] checked
 - [ ] unchecked
+
+[a2]: https://example.com/reference "from the previous section"
 
 > This is so great
 

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -98,17 +98,17 @@ where
     N: Borrow<MdqNode>,
     W: Write,
 {
-    let mut writer = MdWriterImpl {
+    let mut writer_state = MdWriterState {
         opts: options,
         seen_links: HashSet::with_capacity(8), // just a guess at capacity
         seen_footnotes: HashSet::with_capacity(8),
         section_references: Default::default(),
         eof_references: Default::default(),
     };
-    writer.write_md(out, nodes);
+    writer_state.write_md(out, nodes);
 }
 
-struct MdWriterImpl<'a> {
+struct MdWriterState<'a> {
     opts: &'a MdOptions,
     seen_links: HashSet<&'a String>,
     seen_footnotes: HashSet<&'a String>,
@@ -130,7 +130,7 @@ impl<'a> Default for PendingReferences<'a> {
     }
 }
 
-impl<'a> MdWriterImpl<'a> {
+impl<'a> MdWriterState<'a> {
     fn write_md<N, W>(&mut self, out: &mut Output<W>, nodes: &[N])
     where
         N: Borrow<MdqNode>,

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -348,11 +348,11 @@ impl<'a> MdWriterImpl<'a> {
                 out.write_str(surround);
             }
             Inline::Link { text, link } => {
-                self.write_link_inline(out, link, |out| self.write_line(out, text));
+                self.write_link_inline(out, link, |me, out| me.write_line(out, text));
             }
             Inline::Image { alt, link } => {
                 out.write_char('!');
-                self.write_link_inline(out, link, |out| out.write_str(alt));
+                self.write_link_inline(out, link, |_, out| out.write_str(alt));
             }
             Inline::Footnote { label, .. } => {
                 out.write_str("[^");
@@ -376,10 +376,10 @@ impl<'a> MdWriterImpl<'a> {
     fn write_link_inline<W, F>(&mut self, out: &mut Output<W>, link: &Link, contents: F)
     where
         W: Write,
-        F: FnOnce(&mut Output<W>),
+        F: FnOnce(&mut Self, &mut Output<W>),
     {
         out.write_str("![");
-        contents(out);
+        contents(self, out);
         out.write_char(']');
         match &link.reference {
             LinkReference::Inline => {

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -5,8 +5,8 @@ use std::fmt::Alignment;
 use std::io::Write;
 
 use crate::fmt_str::{pad_to, standard_align};
-use crate::output::{Block, Output};
 use crate::output::Block::Inlined;
+use crate::output::{Block, Output};
 use crate::tree::{CodeVariant, Footnote, Inline, InlineVariant, Link, LinkReference, MdqNode, SpanVariant};
 
 #[derive(Default)]

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -16,14 +16,6 @@ pub struct MdOptions {
 }
 
 pub enum LinkReferencePlacement {
-    /// Show link URLs inline with their usages.
-    ///
-    /// ```
-    /// [foo](https://example.com)
-    ///      ^^^^^^^^^^^^^^^^^^^^^
-    /// ```
-    Inline,
-
     /// Show links as references defined in the first section that uses the link.
     ///
     /// ```
@@ -87,10 +79,7 @@ where
     N: Borrow<MdqNode>,
     W: Write,
 {
-    let pending_refs_capacity = match options.link_reference_options {
-        LinkReferencePlacement::Inline => 0,
-        _ => 8, // just a guess
-    };
+    let pending_refs_capacity = 8; // arbitrary guess
 
     let mut writer_state = MdWriterState {
         opts: options,
@@ -98,7 +87,7 @@ where
         seen_footnotes: HashSet::with_capacity(pending_refs_capacity),
         pending_references: PendingReferences {
             links: HashMap::with_capacity(pending_refs_capacity),
-            footnotes: HashMap::with_capacity(8), // footnotes are never inline (as above, 8 is just a guess here)
+            footnotes: HashMap::with_capacity(pending_refs_capacity),
         },
     };
     writer_state.write_md(out, nodes);

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,9 @@
 use std::io;
-use std::io::{stdin, Read};
+use std::io::{Read, stdin};
 use std::string::ToString;
 
 use crate::fmt_json::TextOnly;
+use crate::fmt_md::MdOptions;
 use crate::tree::MdqNode;
 
 mod fmt_json;
@@ -31,6 +32,6 @@ fn main() {
     let jsons = fmt_json::nodes_to_json::<_, TextOnly>(&found);
     println!("{}", jsons);
     out.write_str("\n\n=======================================\n\n");
-    fmt_md::MdWriterImpl::write_md(&mut out, &found);
+    fmt_md::write_md(&MdOptions::default(), &mut out, &found);
     out.write_str("\n");
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::io::{Read, stdin};
+use std::io::{stdin, Read};
 use std::string::ToString;
 
 use crate::fmt_json::TextOnly;

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -125,12 +125,14 @@ pub struct Footnote {
     pub text: Vec<MdqNode>,
 }
 
+/// Note that [Footnote]'s [Eq] and [Hash] only key off of its label, _not_ its text content.
 impl Hash for Footnote {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.label.hash(state);
     }
 }
 
+/// Note that [Footnote]'s [Eq] and [Hash] only key off of its label, _not_ its text content.
 impl PartialEq for Footnote {
     fn eq(&self, other: &Self) -> bool {
         self.label == other.label


### PR DESCRIPTION
- write link references, with options of whether to write the link definitions at the bottom of the doc or at the end of the section in which they're first referenced
- some groundwork for footnotes
- tests are TBD and will come soon, comprehensively for `fmd_md`