### PR TITLE
extract MdqNode states to separate structs

### DIFF
--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -6,7 +6,7 @@ use std::io::Write;
 
 use crate::output::{Block, Output};
 use crate::str_utils::{pad_to, standard_align};
-use crate::tree::{CodeVariant, Footnote, Inline, InlineVariant, Link, LinkReference, MdqNode, SpanVariant};
+use crate::tree::*;
 
 #[derive(Default)]
 pub struct MdOptions {
@@ -129,8 +129,8 @@ impl<'a> MdWriterState<'a> {
         W: Write,
     {
         match node {
-            MdqNode::Root { body } => self.write_md(out, body),
-            MdqNode::Header { depth, title, body } => {
+            MdqNode::Root(Root { body }) => self.write_md(out, body),
+            MdqNode::Header(Header { depth, title, body }) => {
                 out.with_block(Block::Plain, |out| {
                     for _ in 0..*depth {
                         out.write_str("#");
@@ -149,17 +149,17 @@ impl<'a> MdWriterState<'a> {
                     self.write_footnote_definitions(out);
                 }
             }
-            MdqNode::Paragraph { body } => {
+            MdqNode::Paragraph(Paragraph { body }) => {
                 out.with_block(Block::Plain, |out| {
                     self.write_line(out, body);
                 });
             }
-            MdqNode::BlockQuote { body } => {
+            MdqNode::BlockQuote(BlockQuote { body }) => {
                 out.with_block(Block::Quote, |out| {
                     self.write_md(out, body);
                 });
             }
-            MdqNode::List { starting_index, items } => {
+            MdqNode::List(List { starting_index, items }) => {
                 out.with_block(Block::Plain, |out| {
                     let mut index = starting_index.clone();
                     let mut prefix = String::with_capacity(8); // enough for "12. [ ] "
@@ -184,7 +184,7 @@ impl<'a> MdWriterState<'a> {
                     }
                 });
             }
-            MdqNode::Table { alignments, rows } => {
+            MdqNode::Table(Table { alignments, rows }) => {
                 let mut row_strs = Vec::with_capacity(rows.len());
 
                 let mut column_widths = [0].repeat(alignments.len());
@@ -277,7 +277,7 @@ impl<'a> MdWriterState<'a> {
             MdqNode::ThematicBreak => {
                 // out.with_block(Block::Plain, |out| out.write_str("***"));
             }
-            MdqNode::CodeBlock { variant, value } => {
+            MdqNode::CodeBlock(CodeBlock { variant, value }) => {
                 let (surround, meta) = match variant {
                     CodeVariant::Code(opts) => {
                         let meta = if let Some(opts) = opts {

--- a/src/select.rs
+++ b/src/select.rs
@@ -1,5 +1,5 @@
 use crate::fmt_json;
-use crate::tree::{CodeVariant, Inline, MdqNode};
+use crate::tree::*;
 
 #[allow(dead_code)]
 pub enum Selector {
@@ -66,8 +66,8 @@ impl Selector {
         }
 
         let result = match node {
-            MdqNode::Root { body } => SelectResult::Recurse(body),
-            MdqNode::Header { title, body, .. } => {
+            MdqNode::Root(Root { body }) => SelectResult::Recurse(body),
+            MdqNode::Header(Header { title, body, .. }) => {
                 if let Selector::Heading(matcher) = self {
                     if matcher.matches(&Self::line_to_string(title)) {
                         SelectResult::Found(body.iter().map(|elem| elem).collect())
@@ -78,11 +78,11 @@ impl Selector {
                     SelectResult::Recurse(body)
                 }
             }
-            MdqNode::Paragraph { .. } => {
+            MdqNode::Paragraph(Paragraph { .. }) => {
                 SelectResult::None // see TODO on Selector
             }
-            MdqNode::BlockQuote { body } => SelectResult::Recurse(body),
-            MdqNode::List { starting_index, items } => {
+            MdqNode::BlockQuote(BlockQuote { body }) => SelectResult::Recurse(body),
+            MdqNode::List(List { starting_index, items }) => {
                 let _is_ordered = starting_index.is_some(); // TODO use in selected
                 SelectResult::RecurseOwned(
                     items
@@ -94,13 +94,13 @@ impl Selector {
                         .collect(),
                 )
             }
-            MdqNode::Table { .. } => {
+            MdqNode::Table(Table { .. }) => {
                 SelectResult::None // TODO need to recurse
             }
             MdqNode::ThematicBreak => {
                 SelectResult::None // can't be selected, doesn't have children
             }
-            MdqNode::CodeBlock { variant, value } => {
+            MdqNode::CodeBlock(CodeBlock { variant, value }) => {
                 let matched = match (self, variant) {
                     (Selector::CodeBlock(matcher), CodeVariant::Code(_)) => matcher.matches(value),
                     (_, _) => false,


### PR DESCRIPTION
This gives them more consistency.

I did this using RustRover's extraction, which doesn't do perfect formatting -- it keeps extra spaces. I left them in, for no reason other than not wanting to go through and change them all manually. `cargo fmt` doesn't care, apparently.