### PR TITLE
add SimpleWrite trait

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::string::ToString;
 
 use crate::fmt_json::TextOnly;
 use crate::fmt_md::MdOptions;
+use crate::output::Stream;
 use crate::tree::MdqNode;
 
 mod fmt_json;
@@ -19,7 +20,7 @@ fn main() {
     let ast = markdown::to_mdast(&mut contents, &markdown::ParseOptions::gfm()).unwrap();
     let mdq: MdqNode = ast.try_into().unwrap();
 
-    let mut out = output::Output::new(io::stdout());
+    let mut out = output::Output::new(Stream(io::stdout()));
 
     let selector = select::Selector::Heading(select::Matcher::Substring {
         look_for: "Hello".to_string(),

--- a/src/str_utils.rs
+++ b/src/str_utils.rs
@@ -1,15 +1,14 @@
 use std::borrow::Borrow;
 use std::fmt::Alignment;
-use std::io::Write;
 
 use markdown::mdast::AlignKind;
 
-use crate::output::Output;
+use crate::output::{Output, SimpleWrite};
 
 pub fn pad_to<A, W>(output: &mut Output<W>, input: &str, min_width: usize, alignment: A)
 where
     A: ToAlignment,
-    W: Write,
+    W: SimpleWrite,
 {
     if input.len() >= min_width {
         return output.write_str(input);
@@ -117,12 +116,10 @@ mod test {
 
     fn output_and_get<F>(action: F) -> String
     where
-        F: FnOnce(&mut Output<Vec<u8>>),
+        F: FnOnce(&mut Output<String>),
     {
-        let vec = Vec::with_capacity(16);
-        let mut output = Output::new(vec);
+        let mut output = Output::new(String::new());
         action(&mut output);
-        let vec = output.take_underlying().unwrap();
-        String::from_utf8(vec).unwrap()
+        output.take_underlying().unwrap()
     }
 }


### PR DESCRIPTION
For now, this only supports writing &str. Later, I may add a single-char variant, and pipe that down through the various Output methods.

This resolves #27.