### PR TITLE
markdown rendering tests and fixes

### DIFF
--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -549,8 +549,39 @@ pub mod tests {
             List(_),
             Table(_),
             ThematicBreak,
-            CodeBlock(_),
-            Inline(_),
+            CodeBlock(crate::tree::CodeBlock{variant: CodeVariant::Code(_), ..}),
+            CodeBlock(crate::tree::CodeBlock{variant: CodeVariant::Math{..}, ..}),
+            CodeBlock(crate::tree::CodeBlock{variant: CodeVariant::Toml, ..}),
+            CodeBlock(crate::tree::CodeBlock{variant: CodeVariant::Yaml, ..}),
+
+            Inline(crate::tree::Inline::Span{variant: SpanVariant::Delete, ..}),
+            Inline(crate::tree::Inline::Span{variant: SpanVariant::Emphasis, ..}),
+            Inline(crate::tree::Inline::Span{variant: SpanVariant::Strong, ..}),
+
+            Inline(crate::tree::Inline::Text{variant: InlineVariant::Text, ..}),
+            Inline(crate::tree::Inline::Text{variant: InlineVariant::Code, ..}),
+            Inline(crate::tree::Inline::Text{variant: InlineVariant::Math, ..}),
+            Inline(crate::tree::Inline::Text{variant: InlineVariant::Html, ..}),
+
+            Inline(crate::tree::Inline::Link{link: Link{title: None, reference: LinkReference::Inline, ..}, ..}),
+            Inline(crate::tree::Inline::Link{link: Link{title: None, reference: LinkReference::Full(_), ..}, ..}),
+            Inline(crate::tree::Inline::Link{link: Link{title: None, reference: LinkReference::Collapsed, ..}, ..}),
+            Inline(crate::tree::Inline::Link{link: Link{title: None, reference: LinkReference::Shortcut, ..}, ..}),
+            Inline(crate::tree::Inline::Link{link: Link{title: Some(_), reference: LinkReference::Inline, ..}, ..}),
+            Inline(crate::tree::Inline::Link{link: Link{title: Some(_), reference: LinkReference::Full(_), ..}, ..}),
+            Inline(crate::tree::Inline::Link{link: Link{title: Some(_), reference: LinkReference::Collapsed, ..}, ..}),
+            Inline(crate::tree::Inline::Link{link: Link{title: Some(_), reference: LinkReference::Shortcut, ..}, ..}),
+
+            Inline(crate::tree::Inline::Image{link: Link{title: None, reference: LinkReference::Inline, ..}, ..}),
+            Inline(crate::tree::Inline::Image{link: Link{title: None, reference: LinkReference::Full(_), ..}, ..}),
+            Inline(crate::tree::Inline::Image{link: Link{title: None, reference: LinkReference::Collapsed, ..}, ..}),
+            Inline(crate::tree::Inline::Image{link: Link{title: None, reference: LinkReference::Shortcut, ..}, ..}),
+            Inline(crate::tree::Inline::Image{link: Link{title: Some(_), reference: LinkReference::Inline, ..}, ..}),
+            Inline(crate::tree::Inline::Image{link: Link{title: Some(_), reference: LinkReference::Full(_), ..}, ..}),
+            Inline(crate::tree::Inline::Image{link: Link{title: Some(_), reference: LinkReference::Collapsed, ..}, ..}),
+            Inline(crate::tree::Inline::Image{link: Link{title: Some(_), reference: LinkReference::Shortcut, ..}, ..}),
+
+            Inline(crate::tree::Inline::Footnote{..}),
         };
     }
 

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -522,7 +522,6 @@ pub mod tests {
     use lazy_static::lazy_static;
 
     use crate::fmt_md::MdOptions;
-    use crate::mdq_node;
     use crate::mdq_nodes;
     use crate::output::Output;
     use crate::tree::*;

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -545,7 +545,6 @@ pub mod tests {
 
         #[test]
         fn one_paragraph() {
-            // one paragraph
             check_render(
                 mdq_nodes![Root {
                     body: mdq_nodes![Paragraph {
@@ -562,31 +561,28 @@ pub mod tests {
 
         #[test]
         fn two_paragraphs() {
-            {
-                // one paragraph
-                check_render(
-                    mdq_nodes![Root {
-                        body: mdq_nodes![
-                            Paragraph {
-                                body: vec![Inline::Text {
-                                    variant: InlineVariant::Text,
-                                    value: "First".to_string()
-                                }]
-                            },
-                            Paragraph {
-                                body: vec![Inline::Text {
-                                    variant: InlineVariant::Text,
-                                    value: "Second".to_string()
-                                }]
-                            },
-                        ]
-                    }],
-                    indoc! {r#"
-                    First
+            check_render(
+                mdq_nodes![Root {
+                    body: mdq_nodes![
+                        Paragraph {
+                            body: vec![Inline::Text {
+                                variant: InlineVariant::Text,
+                                value: "First".to_string()
+                            }]
+                        },
+                        Paragraph {
+                            body: vec![Inline::Text {
+                                variant: InlineVariant::Text,
+                                value: "Second".to_string()
+                            }]
+                        },
+                    ]
+                }],
+                indoc! {r#"
+                First
 
-                    Second"#},
-                );
-            }
+                Second"#},
+            )
         }
     }
 
@@ -654,6 +650,24 @@ pub mod tests {
 
                     > Hello, world."#},
             )
+        }
+    }
+
+    mod paragraph {
+        use super::*;
+
+        #[test]
+        fn simple() {
+            check_render(
+                mdq_nodes![Paragraph {
+                    body: vec![Inline::Text {
+                        variant: InlineVariant::Text,
+                        value: "Hello, world".to_string()
+                    }]
+                }],
+                indoc! {r#"
+                Hello, world"#},
+            );
         }
     }
 

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -877,6 +877,21 @@ pub mod tests {
                                 value: "line 1\nline 2".to_string(),
                             })
                         },
+                        ListItem {
+                            checked: Some(false),
+                            item: mdq_nodes![
+                                Paragraph {
+                                    body: vec![mdq_inline!("closing argument")]
+                                },
+                                BlockQuote {
+                                    body: mdq_nodes!["supporting evidence"]
+                                },
+                                CodeBlock {
+                                    variant: CodeVariant::Code(None),
+                                    value: "line a\nline b".to_string(),
+                                },
+                            ]
+                        },
                     ],
                 }],
                 indoc! {r#"
@@ -889,7 +904,15 @@ pub mod tests {
                 - ```
                   line 1
                   line 2
-                  ```"#},
+                  ```
+                - [ ] closing argument
+
+                      > supporting evidence
+
+                      ```
+                      line a
+                      line b
+                      ```"#},
             )
         }
     }

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -867,14 +867,14 @@ pub mod tests {
                         ListItem {
                             checked: None,
                             item: mdq_nodes!(BlockQuote {
-                                body: mdq_nodes!["quoted block"]
+                                body: mdq_nodes!["quoted block one", "quoted block two"]
                             })
                         },
                         ListItem {
                             checked: None,
                             item: mdq_nodes!(CodeBlock {
                                 variant: CodeVariant::Code(None),
-                                value: "line 1\nline2".to_string(),
+                                value: "line 1\nline 2".to_string(),
                             })
                         },
                     ],
@@ -883,7 +883,9 @@ pub mod tests {
                 - first paragraph
 
                   second paragraph
-                - > quoted block
+                - > quoted block one
+                  >
+                  > quoted block two
                 - ```
                   line 1
                   line 2

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -536,12 +536,22 @@ pub mod tests {
     use crate::mdq_nodes;
     use crate::output::Output;
     use crate::tree::*;
-    use crate::tree_test_utils::*;
+    use crate::utils_for_test::*;
 
     use super::write_md;
 
     lazy_static! {
-        static ref VARIANTS_CHECKER: MdqVariantsChecker = MdqVariantsChecker::new();
+        static ref VARIANTS_CHECKER: VariantsChecker<MdqNode> = crate::new_variants_checker! {MdqNode:
+            Root(_),
+            Header(_),
+            Paragraph(_),
+            BlockQuote(_),
+            List(_),
+            Table(_),
+            ThematicBreak,
+            CodeBlock(_),
+            Inline(_),
+        };
     }
 
     #[test]
@@ -995,6 +1005,10 @@ pub mod tests {
                 after"#},
             );
         }
+    }
+
+    mod code_block {
+        use super::*;
     }
 
     #[test]

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -508,8 +508,6 @@ impl<'a> MdWriterState<'a> {
 
 #[cfg(test)]
 pub mod tests {
-    use std::fmt::Error;
-
     use indoc::indoc;
     use lazy_static::lazy_static;
 
@@ -643,10 +641,9 @@ pub mod tests {
     fn check_render_with(options: &MdOptions, nodes: Vec<MdqNode>, expect: &str) {
         nodes.iter().for_each(|n| VARIANTS_CHECKER.see(n));
 
-        let mut out = Output::new(vec![]);
+        let mut out = Output::new(String::default());
         write_md(options, &mut out, &nodes);
-        let vec = out.take_underlying().unwrap();
-        let actual = String::from_utf8(vec).map_err(|_| Error).unwrap();
+        let actual = out.take_underlying().unwrap();
         assert_eq!(&actual, expect);
     }
 }

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -716,6 +716,101 @@ pub mod tests {
         }
     }
 
+    mod list {
+        use super::*;
+
+        #[test]
+        fn ordered() {
+            check_render(
+                mdq_nodes![List {
+                    starting_index: Some(3),
+                    items: vec![
+                        ListItem {
+                            checked: None,
+                            item: mdq_nodes!("normal")
+                        },
+                        ListItem {
+                            checked: Some(true),
+                            item: mdq_nodes!("checked")
+                        },
+                        ListItem {
+                            checked: Some(false),
+                            item: mdq_nodes!("unchecked")
+                        },
+                    ],
+                }],
+                indoc! {r#"
+                3. normal
+                4. [x] checked
+                5. [ ] unchecked"#},
+            );
+        }
+
+        #[test]
+        fn unordered() {
+            check_render(
+                mdq_nodes![List {
+                    starting_index: None,
+                    items: vec![
+                        ListItem {
+                            checked: None,
+                            item: mdq_nodes!("normal")
+                        },
+                        ListItem {
+                            checked: Some(true),
+                            item: mdq_nodes!("checked")
+                        },
+                        ListItem {
+                            checked: Some(false),
+                            item: mdq_nodes!("unchecked")
+                        },
+                    ],
+                }],
+                indoc! {r#"
+                - normal
+                - [x] checked
+                - [ ] unchecked"#},
+            );
+        }
+
+        #[test]
+        fn block_alignments() {
+            check_render(
+                mdq_nodes![List {
+                    starting_index: None,
+                    items: vec![
+                        ListItem {
+                            checked: None,
+                            item: mdq_nodes!["first paragraph", "second paragraph"],
+                        },
+                        ListItem {
+                            checked: None,
+                            item: mdq_nodes!(BlockQuote {
+                                body: mdq_nodes!["quoted block"]
+                            })
+                        },
+                        ListItem {
+                            checked: None,
+                            item: mdq_nodes!(CodeBlock {
+                                variant: CodeVariant::Code(None),
+                                value: "line 1\nline2".to_string(),
+                            })
+                        },
+                    ],
+                }],
+                indoc! {r#"
+                - first paragraph
+
+                  second paragraph
+                - > quoted block
+                - ```
+                  line 1
+                  line 2
+                  ```"#},
+            )
+        }
+    }
+
     #[test]
     fn all_variants_checked() {
         VARIANTS_CHECKER.wait_for_all();

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -538,12 +538,6 @@ pub mod tests {
         use super::*;
 
         #[test]
-        fn empty() {
-            // empty body
-            check_render(mdq_nodes![Root { body: vec![] }], indoc! {r#""#});
-        }
-
-        #[test]
         fn one_paragraph() {
             // one paragraph
             check_render(
@@ -590,10 +584,11 @@ pub mod tests {
         }
     }
 
-    #[test]
-    fn block_quote() {
-        {
-            // single level
+    mod block_quote {
+        use super::*;
+
+        #[test]
+        fn single_level() {
             check_render(
                 mdq_nodes![BlockQuote {
                     body: mdq_nodes![Paragraph {
@@ -608,8 +603,34 @@ pub mod tests {
                 },
             );
         }
-        {
-            todo!("two levels")
+
+        #[test]
+        fn two_levels() {
+            check_render(
+                mdq_nodes![BlockQuote {
+                    body: mdq_nodes![
+                        Paragraph {
+                            body: vec![Inline::Text {
+                                variant: InlineVariant::Text,
+                                value: "Outer".to_string()
+                            }]
+                        },
+                        BlockQuote {
+                            body: mdq_nodes![Paragraph {
+                                body: vec![Inline::Text {
+                                    variant: InlineVariant::Text,
+                                    value: "Inner".to_string()
+                                }]
+                            },]
+                        },
+                    ]
+                }],
+                indoc! {r#"
+                    > Outer
+                    >
+                    > > Inner"#
+                },
+            );
         }
     }
 

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -284,7 +284,7 @@ impl<'a> MdWriterState<'a> {
                 }
             }
             MdqNode::ThematicBreak => {
-                // out.with_block(Block::Plain, |out| out.write_str("***"));
+                out.with_block(Block::Plain, |out| out.write_str("***"));
             }
             MdqNode::CodeBlock(CodeBlock { variant, value }) => {
                 let (surround, meta) = match variant {
@@ -966,6 +966,33 @@ pub mod tests {
                 |---|----|
                 | 1 |
                 | i | ii | iii |"#},
+            );
+        }
+    }
+
+    mod thematic_break {
+        use super::*;
+        use crate::mdq_node;
+
+        #[test]
+        fn by_itself() {
+            check_render(
+                vec![MdqNode::ThematicBreak],
+                indoc! {r#"
+                ***"#},
+            );
+        }
+
+        #[test]
+        fn with_paragraphs() {
+            check_render(
+                vec![mdq_node!("before"), MdqNode::ThematicBreak, mdq_node!("after")],
+                indoc! {r#"
+                before
+
+                ***
+
+                after"#},
             );
         }
     }

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -534,13 +534,17 @@ pub mod tests {
         check_render(vec![], indoc! {r#""#});
     }
 
-    #[test]
-    fn root() {
-        {
+    mod root {
+        use super::*;
+
+        #[test]
+        fn empty() {
             // empty body
             check_render(mdq_nodes![Root { body: vec![] }], indoc! {r#""#});
         }
-        {
+
+        #[test]
+        fn one_paragraph() {
             // one paragraph
             check_render(
                 mdq_nodes![Root {
@@ -555,30 +559,34 @@ pub mod tests {
                 Hello, world"#},
             );
         }
-        {
-            // one paragraph
-            check_render(
-                mdq_nodes![Root {
-                    body: mdq_nodes![
-                        Paragraph {
-                            body: vec![Inline::Text {
-                                variant: InlineVariant::Text,
-                                value: "First".to_string()
-                            }]
-                        },
-                        Paragraph {
-                            body: vec![Inline::Text {
-                                variant: InlineVariant::Text,
-                                value: "Second".to_string()
-                            }]
-                        },
-                    ]
-                }],
-                indoc! {r#"
+
+        #[test]
+        fn two_paragraphs() {
+            {
+                // one paragraph
+                check_render(
+                    mdq_nodes![Root {
+                        body: mdq_nodes![
+                            Paragraph {
+                                body: vec![Inline::Text {
+                                    variant: InlineVariant::Text,
+                                    value: "First".to_string()
+                                }]
+                            },
+                            Paragraph {
+                                body: vec![Inline::Text {
+                                    variant: InlineVariant::Text,
+                                    value: "Second".to_string()
+                                }]
+                            },
+                        ]
+                    }],
+                    indoc! {r#"
                     First
 
                     Second"#},
-            );
+                );
+            }
         }
     }
 

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -551,7 +551,6 @@ pub mod tests {
                         }]
                     }]
                 }],
-                // TODO fix these extra newlines!
                 indoc! {r#"
                 Hello, world"#},
             );
@@ -575,7 +574,6 @@ pub mod tests {
                         },
                     ]
                 }],
-                // TODO fix these extra newlines!
                 indoc! {r#"
                     First
 

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -351,7 +351,7 @@ impl<'a> MdWriterState<'a> {
             Inline::Span { variant, children } => {
                 let surround = match variant {
                     SpanVariant::Delete => "~~",
-                    SpanVariant::Emphasis => "*",
+                    SpanVariant::Emphasis => "_",
                     SpanVariant::Strong => "**",
                 };
                 out.write_str(surround);
@@ -1158,6 +1158,102 @@ pub mod tests {
                 two
                 ---"#},
             );
+        }
+    }
+
+    mod inline {
+        use super::*;
+
+        mod span {
+            use super::*;
+
+            #[test]
+            fn delete() {
+                check_render(
+                    vec![MdqNode::Inline(mdq_inline!(span Delete [mdq_inline!("hello world")]))],
+                    indoc! {"~~hello world~~"},
+                );
+            }
+
+            #[test]
+            fn emphasis() {
+                check_render(
+                    vec![MdqNode::Inline(mdq_inline!(span Emphasis [mdq_inline!("hello world")]))],
+                    indoc! {"_hello world_"},
+                );
+            }
+
+            #[test]
+            fn strong() {
+                check_render(
+                    vec![MdqNode::Inline(mdq_inline!(span Strong [mdq_inline!("hello world")]))],
+                    indoc! {"**hello world**"},
+                );
+            }
+
+            #[test]
+            fn mixed() {
+                check_render(
+                    vec![MdqNode::Inline(mdq_inline!(span Emphasis [
+                        mdq_inline!("one "),
+                        mdq_inline!(span Strong [
+                            mdq_inline!("two "),
+                            mdq_inline!(span Delete [
+                                mdq_inline!("three")
+                            ]),
+                        ]),
+                    ]))],
+                    indoc! {"_one **two ~~three~~**_"},
+                );
+            }
+        }
+
+        mod text {
+            use super::*;
+
+            #[test]
+            fn text() {
+                check_render(
+                    vec![MdqNode::Inline(Inline::Text {
+                        variant: InlineVariant::Text,
+                        value: "hello world".to_string(),
+                    })],
+                    indoc! {"hello world"},
+                );
+            }
+
+            #[test]
+            fn code() {
+                check_render(
+                    vec![MdqNode::Inline(Inline::Text {
+                        variant: InlineVariant::Code,
+                        value: "hello world".to_string(),
+                    })],
+                    indoc! {"`hello world`"},
+                );
+            }
+
+            #[test]
+            fn math() {
+                check_render(
+                    vec![MdqNode::Inline(Inline::Text {
+                        variant: InlineVariant::Math,
+                        value: "hello world".to_string(),
+                    })],
+                    indoc! {"$hello world$"},
+                );
+            }
+
+            #[test]
+            fn html() {
+                check_render(
+                    vec![MdqNode::Inline(Inline::Text {
+                        variant: InlineVariant::Html,
+                        value: "<a hello />".to_string(),
+                    })],
+                    indoc! {"<a hello />"},
+                );
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::io::{stdin, Read};
+use std::io::{Read, stdin};
 use std::string::ToString;
 
 use crate::fmt_json::TextOnly;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use std::io;
-use std::io::{Read, stdin};
+use std::io::{stdin, Read};
 use std::string::ToString;
 
 use crate::fmt_json::TextOnly;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod output;
 mod select;
 mod str_utils;
 mod tree;
+mod tree_test_utils;
 
 fn main() {
     let mut contents = String::new();

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ mod select;
 mod str_utils;
 mod tree;
 mod tree_test_utils;
+mod utils_for_test;
 
 fn main() {
     let mut contents = String::new();

--- a/src/output.rs
+++ b/src/output.rs
@@ -167,6 +167,7 @@ impl<W: SimpleWrite> Output<W> {
 
         // Append the new blocks, and then write the indent if we need it
         // When we write that indent, though, only write it until the first new Inlined (exclusive).
+        // TODO this is wrong -- block_alignments test fails due to this
         let indent_end_idx = self.blocks.len()
             + self
                 .pending_blocks

--- a/src/output.rs
+++ b/src/output.rs
@@ -239,6 +239,9 @@ impl<W: SimpleWrite> Output<W> {
             eprintln!("error while writing output: {}", e);
             self.writing_state = WritingState::Error;
         }
+        if matches!(self.writing_state, WritingState::HaveNotWrittenAnything) {
+            self.writing_state = WritingState::Normal;
+        }
     }
 }
 
@@ -354,6 +357,23 @@ mod tests {
                 > world
 
                 after"#}
+        );
+    }
+
+    #[test]
+    fn quote_block_one_char_at_a_time_as_initial_output() {
+        // We haven't written anything, and then we start writing quote blocks
+        assert_eq!(
+            out_to_str(|out| {
+                out.with_block(Block::Quote, |out| {
+                    out.write_str(""); // empty prefix char
+                    "hello\nworld".chars().for_each(|c| out.write_char(c));
+                    out.write_str(""); // empty suffix char
+                });
+            }),
+            indoc! {r#"
+                > hello
+                > world"#}
         );
     }
 

--- a/src/str_utils.rs
+++ b/src/str_utils.rs
@@ -17,59 +17,57 @@ where
     let padding = min_width - input.len();
 
     match standard_align(alignment) {
-        Alignment::Left => {
+        Some(Alignment::Left) | None => {
             output.write_str(input);
             (0..padding).for_each(|_| output.write_char(' '));
         }
-        Alignment::Center => {
+        Some(Alignment::Center) => {
             let left_pad = padding / 2; // round down
             let right_pad = padding - left_pad;
             (0..left_pad).for_each(|_| output.write_char(' '));
             output.write_str(input);
             (0..right_pad).for_each(|_| output.write_char(' '));
         }
-        Alignment::Right => {
+        Some(Alignment::Right) => {
             (0..padding).for_each(|_| output.write_char(' '));
             output.write_str(input);
         }
     }
 }
 
-pub fn standard_align<A>(mdast_align: A) -> Alignment
+pub fn standard_align<A>(mdast_align: A) -> Option<Alignment>
 where
     A: ToAlignment,
 {
     mdast_align.to_alignment()
 }
 
-const DEFAULT_ALIGNMENT: Alignment = Alignment::Left;
-
 pub trait ToAlignment {
-    fn to_alignment(&self) -> Alignment;
+    fn to_alignment(&self) -> Option<Alignment>;
 }
 
 impl ToAlignment for Alignment {
-    fn to_alignment(&self) -> Alignment {
-        *self
+    fn to_alignment(&self) -> Option<Alignment> {
+        Some(*self)
     }
 }
 
 impl ToAlignment for &AlignKind {
-    fn to_alignment(&self) -> Alignment {
+    fn to_alignment(&self) -> Option<Alignment> {
         match self {
-            AlignKind::Left => Alignment::Left,
-            AlignKind::Right => Alignment::Right,
-            AlignKind::Center => Alignment::Center,
-            _ => DEFAULT_ALIGNMENT,
+            AlignKind::Left => Some(Alignment::Left),
+            AlignKind::Right => Some(Alignment::Right),
+            AlignKind::Center => Some(Alignment::Center),
+            AlignKind::None => None,
         }
     }
 }
 
 impl<A: Borrow<AlignKind>> ToAlignment for Option<A> {
-    fn to_alignment(&self) -> Alignment {
+    fn to_alignment(&self) -> Option<Alignment> {
         match self {
             Some(a) => a.borrow().to_alignment(),
-            None => DEFAULT_ALIGNMENT,
+            None => None,
         }
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -23,7 +23,7 @@ pub enum MdqNode {
     CodeBlock(CodeBlock),
 
     // inline spans
-    Inline(Inline), // TODO rename to "span"?
+    Inline(Inline),
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -1,0 +1,99 @@
+pub use test_utils::*;
+
+#[cfg(test)]
+mod test_utils {
+    use std::collections::HashSet;
+    use std::sync::{Arc, Mutex};
+    use std::{thread, time};
+
+    use regex::Regex;
+
+    use crate::tree::MdqNode;
+
+    macro_rules! nodes_matcher {
+        {$($variant:ident$(($payload:pat))?),* $(,)?} => {
+            {
+                let variant_to_name = Regex::new("\\(.*").unwrap();
+                None.map(|n: MdqNode| match n {
+                    $(MdqNode::$variant$(($payload))? => {},)*
+                });
+                vec![$(variant_to_name.replace(stringify!($variant), "").to_string(),)*].into_iter().collect()
+            }
+        };
+    }
+
+    #[macro_export]
+    macro_rules! mdq_node {
+        ($node_type:tt {$($attr:ident: $val:expr),*}) => {
+            MdqNode::$node_type($node_type{$($attr: $val),*})
+        };
+    }
+
+    #[macro_export]
+    macro_rules! mdq_nodes {
+        [$($node_type:tt {$($attr:ident: $val:expr),*}$(,)?),*] => {
+            vec![$(
+                mdq_node!($node_type {
+                    $($attr: $val),*
+                })
+                ),*
+            ]
+        };
+    }
+
+    pub struct MdqVariantsChecker {
+        require: Arc<Mutex<HashSet<String>>>,
+    }
+
+    // TODO unify this with the one in tree.rs
+    impl MdqVariantsChecker {
+        pub fn new() -> Self {
+            let all_node_names = nodes_matcher! {
+                Root(_),
+                Header(_),
+                Paragraph(_),
+                BlockQuote(_),
+                List(_),
+                Table(_),
+                ThematicBreak,
+                CodeBlock(_),
+                Inline(_),
+            };
+            Self {
+                require: Arc::new(Mutex::new(all_node_names)),
+            }
+        }
+
+        pub fn see(&self, node: &MdqNode) {
+            let node_debug = format!("{:?}", node);
+            let re = Regex::new(r"^\w+").unwrap();
+            let node_name = re.find(&node_debug).unwrap().as_str();
+            self.require.lock().map(|mut set| set.remove(node_name)).unwrap();
+        }
+
+        pub fn wait_for_all(&self) {
+            let timeout = time::Duration::from_millis(500);
+            let retry_delay = time::Duration::from_millis(50);
+            let start = time::Instant::now();
+            loop {
+                if self.require.lock().map(|set| set.is_empty()).unwrap() {
+                    break;
+                }
+                if start.elapsed() >= timeout {
+                    let mut remaining: Vec<String> = self
+                        .require
+                        .lock()
+                        .map(|set| set.iter().map(|s| s.to_owned()).collect())
+                        .unwrap();
+                    remaining.sort();
+                    panic!(
+                        "Timed out, and missing {} variants:\n- {}",
+                        remaining.len(),
+                        remaining.join("\n- ")
+                    )
+                }
+                thread::sleep(retry_delay);
+            }
+        }
+    }
+}

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -33,13 +33,29 @@ mod test_utils {
 
     #[macro_export]
     macro_rules! mdq_nodes {
-        [$($node_type:tt {$($attr:ident: $val:expr),*}$(,)?),*] => {
+        [$($node_type:tt {$($attr:ident: $val:expr),*$(,)?}),*$(,)?] => {
             vec![$(
                 crate::mdq_node!($node_type {
                     $($attr: $val),*
                 })
                 ),*
             ]
+        };
+    }
+
+    #[macro_export]
+    macro_rules! mdq_inline {
+        (span $which:ident [$($contents:expr),*$(,)?]) => {
+            crate::tree::Inline::Span {
+                variant: crate::tree::SpanVariant::$which,
+                children: vec![$($contents),*],
+            }
+        };
+        ($text:literal) => {
+            crate::tree::Inline::Text {
+                variant: crate::tree::InlineVariant::Text,
+                value: $text.to_string(),
+            }
         };
     }
 

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -31,7 +31,7 @@ mod test_utils {
         };
         ($paragraph_text:literal) => {
             crate::mdq_node!(Paragraph{body: vec![crate::mdq_inline!($paragraph_text)]})
-        }
+        };
     }
 
     #[macro_export]

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -1,5 +1,7 @@
 pub use test_utils::*;
 
+// We this file's contents from prod by putting them in a submodule guarded by cfg(test), but then "pub use" it to
+// export its contents.
 #[cfg(test)]
 mod test_utils {
     use std::collections::HashSet;

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -4,9 +4,9 @@ pub use test_utils::*;
 // export its contents.
 #[cfg(test)]
 mod test_utils {
-    use std::{thread, time};
     use std::collections::HashSet;
     use std::sync::{Arc, Mutex};
+    use std::{thread, time};
 
     use regex::Regex;
 

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -29,6 +29,9 @@ mod test_utils {
         ($node_type:tt {$($attr:ident: $val:expr),*}) => {
             MdqNode::$node_type($node_type{$($attr: $val),*})
         };
+        ($paragraph_text:literal) => {
+            crate::mdq_node!(Paragraph{body: vec![crate::mdq_inline!($paragraph_text)]})
+        }
     }
 
     #[macro_export]
@@ -41,6 +44,12 @@ mod test_utils {
                 ),*
             ]
         };
+        [$($paragraph_text:literal),*$(,)?] => {
+            vec![$(
+                    crate::mdq_node!($paragraph_text)
+                ),*
+            ]
+        }
     }
 
     #[macro_export]

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -1,21 +1,5 @@
-pub use test_utils::*;
-
-// We this file's contents from prod by putting them in a submodule guarded by cfg(test), but then "pub use" it to
-// export its contents.
 #[cfg(test)]
 mod test_utils {
-
-    macro_rules! nodes_matcher {
-        {$($variant:ident$(($payload:pat))?),* $(,)?} => {
-            {
-                let variant_to_name = Regex::new("\\(.*").unwrap();
-                None.map(|n: MdqNode| match n {
-                    $(MdqNode::$variant$(($payload))? => {},)*
-                });
-                vec![$(variant_to_name.replace(stringify!($variant), "").to_string(),)*].into_iter().collect()
-            }
-        };
-    }
 
     #[macro_export]
     macro_rules! mdq_node {

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -4,9 +4,9 @@ pub use test_utils::*;
 // export its contents.
 #[cfg(test)]
 mod test_utils {
+    use std::{thread, time};
     use std::collections::HashSet;
     use std::sync::{Arc, Mutex};
-    use std::{thread, time};
 
     use regex::Regex;
 
@@ -47,7 +47,9 @@ mod test_utils {
         require: Arc<Mutex<HashSet<String>>>,
     }
 
-    // TODO unify this with the one in tree.rs
+    // TODO unify this with the one in tree.rs.
+    // I can do that by making this generic, as well as making nodes_matcher! work with generics by having it pass in
+    // the type as an arg (e.g. `mdast::Node` or `MdqNode`
     impl MdqVariantsChecker {
         pub fn new() -> Self {
             let all_node_names = nodes_matcher! {

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -35,7 +35,7 @@ mod test_utils {
     macro_rules! mdq_nodes {
         [$($node_type:tt {$($attr:ident: $val:expr),*}$(,)?),*] => {
             vec![$(
-                mdq_node!($node_type {
+                crate::mdq_node!($node_type {
                     $($attr: $val),*
                 })
                 ),*

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -4,13 +4,6 @@ pub use test_utils::*;
 // export its contents.
 #[cfg(test)]
 mod test_utils {
-    use std::collections::HashSet;
-    use std::sync::{Arc, Mutex};
-    use std::{thread, time};
-
-    use regex::Regex;
-
-    use crate::tree::MdqNode;
 
     macro_rules! nodes_matcher {
         {$($variant:ident$(($payload:pat))?),* $(,)?} => {
@@ -66,63 +59,5 @@ mod test_utils {
                 value: $text.to_string(),
             }
         };
-    }
-
-    pub struct MdqVariantsChecker {
-        require: Arc<Mutex<HashSet<String>>>,
-    }
-
-    // TODO unify this with the one in tree.rs.
-    // I can do that by making this generic, as well as making nodes_matcher! work with generics by having it pass in
-    // the type as an arg (e.g. `mdast::Node` or `MdqNode`
-    impl MdqVariantsChecker {
-        pub fn new() -> Self {
-            let all_node_names = nodes_matcher! {
-                Root(_),
-                Header(_),
-                Paragraph(_),
-                BlockQuote(_),
-                List(_),
-                Table(_),
-                ThematicBreak,
-                CodeBlock(_),
-                Inline(_),
-            };
-            Self {
-                require: Arc::new(Mutex::new(all_node_names)),
-            }
-        }
-
-        pub fn see(&self, node: &MdqNode) {
-            let node_debug = format!("{:?}", node);
-            let re = Regex::new(r"^\w+").unwrap();
-            let node_name = re.find(&node_debug).unwrap().as_str();
-            self.require.lock().map(|mut set| set.remove(node_name)).unwrap();
-        }
-
-        pub fn wait_for_all(&self) {
-            let timeout = time::Duration::from_millis(500);
-            let retry_delay = time::Duration::from_millis(50);
-            let start = time::Instant::now();
-            loop {
-                if self.require.lock().map(|set| set.is_empty()).unwrap() {
-                    break;
-                }
-                if start.elapsed() >= timeout {
-                    let mut remaining: Vec<String> = self
-                        .require
-                        .lock()
-                        .map(|set| set.iter().map(|s| s.to_owned()).collect())
-                        .unwrap();
-                    remaining.sort();
-                    panic!(
-                        "Timed out, and missing {} variants:\n- {}",
-                        remaining.len(),
-                        remaining.join("\n- ")
-                    )
-                }
-                thread::sleep(retry_delay);
-            }
-        }
     }
 }

--- a/src/utils_for_test.rs
+++ b/src/utils_for_test.rs
@@ -1,0 +1,72 @@
+pub use test_utils::*;
+
+// We this file's contents from prod by putting them in a submodule guarded by cfg(test), but then "pub use" it to
+// export its contents.
+#[cfg(test)]
+mod test_utils {
+    use std::{thread, time};
+
+    // TODO unify this with the one in tree.rs.
+    pub struct VariantsChecker<E> {
+        require: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
+        resolver: fn(&E) -> &str,
+    }
+
+    impl<E> VariantsChecker<E> {
+        pub fn new<I>(require: I, resolver: fn(&E) -> &str) -> Self
+        where
+            I: IntoIterator<Item = String>,
+        {
+            Self {
+                require: std::sync::Arc::new(std::sync::Mutex::new(require.into_iter().collect())),
+                resolver,
+            }
+        }
+
+        pub fn see(&self, node: &E) {
+            let node_str = (self.resolver)(node);
+            self.require.lock().map(|mut set| set.remove(node_str)).unwrap();
+        }
+
+        pub fn wait_for_all(&self) {
+            let timeout = time::Duration::from_millis(500);
+            let retry_delay = time::Duration::from_millis(50);
+            let start = time::Instant::now();
+            loop {
+                if self.require.lock().map(|set| set.is_empty()).unwrap() {
+                    break;
+                }
+                if start.elapsed() >= timeout {
+                    let mut remaining: Vec<String> = self
+                        .require
+                        .lock()
+                        .map(|set| set.iter().map(|s| s.to_owned()).collect())
+                        .unwrap();
+                    remaining.sort();
+                    panic!(
+                        "Timed out, and missing {} variants:\n- {}",
+                        remaining.len(),
+                        remaining.join("\n- ")
+                    )
+                }
+                thread::sleep(retry_delay);
+            }
+        }
+    }
+
+    #[macro_export]
+    macro_rules! new_variants_checker {
+        {$enum_type:ty : $($variant:pat),* $(,)?} => {
+            {
+                use $enum_type::*;
+
+                VariantsChecker::new(
+                    vec![$(stringify!($variant).to_string(),)*],
+                    {|elem| match elem {
+                        $($variant => stringify!($variant),)*
+                    }}
+                )
+            }
+        };
+    }
+}

--- a/src/utils_for_test.rs
+++ b/src/utils_for_test.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 pub use test_utils::*;
 
 // We this file's contents from prod by putting them in a submodule guarded by cfg(test), but then "pub use" it to


### PR DESCRIPTION
- Add a more generic version of the variants checker I wrote for the Node -> MdqNode conversions
- Add unit tests for all the MdqNode -> markdown renderings
- Various fixes to the prod code that shook out from those tests