### PR TITLE
unify VariantsChecker and NodesChecker

### DIFF
--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -569,7 +569,7 @@ pub mod tests {
     use super::write_md;
 
     lazy_static! {
-        static ref VARIANTS_CHECKER: VariantsChecker<MdqNode> = crate::new_variants_checker! {MdqNode:
+        static ref VARIANTS_CHECKER: VariantsChecker<MdqNode> = crate::new_variants_checker! (MdqNode {
             Root(_),
             Header(_),
             Paragraph(_),
@@ -613,7 +613,7 @@ pub mod tests {
             Inline(crate::tree::Inline::Image{link: Link{title: Some(_), reference: LinkReference::Shortcut, ..}, ..}),
 
             Inline(crate::tree::Inline::Footnote{..}),
-        };
+        });
     }
 
     #[test]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1648,7 +1648,7 @@ mod tests {
         }
 
         lazy_static! {
-            static ref NODES_CHECKER: VariantsChecker<Node> = crate::new_variants_checker!(Node:
+            static ref NODES_CHECKER: VariantsChecker<Node> = crate::new_variants_checker!(Node {
                     BlockQuote(_),
                     Break(_),
                     Code(_),
@@ -1679,7 +1679,7 @@ mod tests {
                     Toml(_),
                     Yaml(_),
                     mdx_nodes!(),
-            );
+            });
         }
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1570,7 +1570,6 @@ mod tests {
             });
         }
 
-        #[ignore]
         #[test]
         fn thematic_break() {
             let (root, lookups) = parse_with(
@@ -1649,36 +1648,37 @@ mod tests {
 
         lazy_static! {
             static ref NODES_CHECKER: VariantsChecker<Node> = crate::new_variants_checker!(Node {
-                    BlockQuote(_),
-                    Break(_),
-                    Code(_),
-                    Definition(_),
-                    Delete(_),
-                    Emphasis(_),
-                    FootnoteDefinition(_),
-                    FootnoteReference(_),
-                    Heading(_),
-                    Html(_),
-                    Image(_),
-                    ImageReference(_),
-                    InlineCode(_),
-                    InlineMath(_),
-                    Link(_),
-                    LinkReference(_),
-                    List(_),
-                    ListItem(_),
-                    Math(_),
-                    Paragraph(_),
-                    Root(_),
-                    Strong(_),
-                    Table(_),
-                    TableCell(_),
-                    TableRow(_),
-                    Text(_),
-                    ThematicBreak(_),
-                    Toml(_),
-                    Yaml(_),
-                    mdx_nodes!(),
+                BlockQuote(_),
+                Break(_),
+                Code(_),
+                Definition(_),
+                Delete(_),
+                Emphasis(_),
+                FootnoteDefinition(_),
+                FootnoteReference(_),
+                Heading(_),
+                Html(_),
+                Image(_),
+                ImageReference(_),
+                InlineCode(_),
+                InlineMath(_),
+                Link(_),
+                LinkReference(_),
+                List(_),
+                ListItem(_),
+                Math(_),
+                Paragraph(_),
+                Root(_),
+                Strong(_),
+                Table(_),
+                TableCell(_),
+                TableRow(_),
+                Text(_),
+                ThematicBreak(_),
+                Toml(_),
+                Yaml(_),
+            } ignore {
+                mdx_nodes!(),
             });
         }
     }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1598,6 +1598,7 @@ mod tests {
             });
         }
 
+        #[ignore]
         #[test]
         fn thematic_break() {
             let (root, lookups) = parse_with(

--- a/src/utils_for_test.rs
+++ b/src/utils_for_test.rs
@@ -67,7 +67,7 @@ mod test_utils {
     /// dead-code branches.
     #[macro_export]
     macro_rules! new_variants_checker {
-        {$enum_type:ty : $($variant:pat),* $(,)?} => {
+        ($enum_type:ty { $($variant:pat),* $(,)? }) => {
             {
                 use $enum_type::*;
 

--- a/src/utils_for_test.rs
+++ b/src/utils_for_test.rs
@@ -56,6 +56,17 @@ mod test_utils {
 
     /// Creates a new `VariantsChecker` that looks for all the variants of enum `E`.
     ///
+    /// ```
+    /// new_variants_checker(MyEnum: { Variant1, Variant2(_), ... })
+    /// ```
+    ///
+    /// You can also mark some variants as ignored; these will be added to the pattern match, but not be required to
+    /// be seen:
+    ///
+    /// ```
+    /// new_variants_checker(MyEnum: { Variant1, ... } ignore { Variant2, ... } )
+    /// ```
+    ///
     /// If you see a compilation failure here, it means the call site is missing variants (or has an unknown
     /// variant).
     ///
@@ -67,7 +78,7 @@ mod test_utils {
     /// dead-code branches.
     #[macro_export]
     macro_rules! new_variants_checker {
-        ($enum_type:ty { $($variant:pat),* $(,)? }) => {
+        ($enum_type:ty { $($variant:pat),* $(,)? } $(ignore { $($ignore_variant:pat),* $(,)? })?) => {
             {
                 use $enum_type::*;
 
@@ -75,6 +86,7 @@ mod test_utils {
                     vec![$(stringify!($variant).to_string(),)*],
                     {|elem| match elem {
                         $($variant => stringify!($variant),)*
+                        $($($ignore_variant => {""},)*)?
                     }}
                 )
             }

--- a/src/utils_for_test.rs
+++ b/src/utils_for_test.rs
@@ -7,7 +7,6 @@ pub use test_utils::*;
 mod test_utils {
     use std::{thread, time};
 
-    // TODO unify this with the one in tree.rs.
     pub struct VariantsChecker<E> {
         require: std::sync::Arc<std::sync::Mutex<std::collections::HashSet<String>>>,
         resolver: fn(&E) -> &str,
@@ -55,6 +54,17 @@ mod test_utils {
         }
     }
 
+    /// Creates a new `VariantsChecker` that looks for all the variants of enum `E`.
+    ///
+    /// If you see a compilation failure here, it means the call site is missing variants (or has an unknown
+    /// variant).
+    ///
+    /// We can't use strum to do this for mdast::Node, because we don't own the Node code. Instead, we rely on a bit of
+    /// trickery: we pass in a bunch of arms, and each gets [stringify!]'d and added to a set. Whenever we [see] an
+    /// item, we remove the corresponding string from the set.
+    ///
+    /// This requires that each pattern matches exactly one shape of item; in other words, that there aren't any
+    /// dead-code branches.
     #[macro_export]
     macro_rules! new_variants_checker {
         {$enum_type:ty : $($variant:pat),* $(,)?} => {


### PR DESCRIPTION
`NodesChecker` was specific to `mdast::Node`. PR #30 added `VariantsChecker` as a more general form of the same thing; this change completes it by replacing `NodesChecker` with `VariantsChecker.