### PR TITLE
set the parse separator to `|`

### DIFF
--- a/src/parse_common.rs
+++ b/src/parse_common.rs
@@ -3,6 +3,8 @@ pub use test_util::*;
 
 pub type ParseResult<T> = Result<T, ParseErrorReason>;
 
+pub const SELECTOR_SEPARATOR: char = '|';
+
 #[derive(Debug, Clone, PartialEq)]
 pub struct ParseError {
     pub position: Position,

--- a/src/select.rs
+++ b/src/select.rs
@@ -112,7 +112,7 @@ mod test {
         parse_and_check("# ", Selector::Heading(HeadingSelector { matcher: Matcher::Any }), "");
 
         parse_and_check(
-            "# // next",
+            "# | next",
             Selector::Heading(HeadingSelector { matcher: Matcher::Any }),
             " next",
         );


### PR DESCRIPTION
(as opposed to `//`, which looks too confusing with regexes.)

Also move it to parse_common.