### PR TITLE
MdqNode reorg: part 01

### DIFF
--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -128,7 +128,7 @@ impl<'a> MdWriterState<'a> {
     {
         match node {
             MdqNode::Root(Root { body }) => self.write_md(out, body),
-            MdqNode::Header(Header { depth, title, body }) => {
+            MdqNode::Section(Section { depth, title, body }) => {
                 out.with_block(Block::Plain, |out| {
                     for _ in 0..*depth {
                         out.write_str("#");
@@ -571,7 +571,7 @@ pub mod tests {
     lazy_static! {
         static ref VARIANTS_CHECKER: VariantsChecker<MdqNode> = crate::new_variants_checker! (MdqNode {
             Root(_),
-            Header(_),
+            Section(_),
             Paragraph(_),
             BlockQuote(_),
             List(_),
@@ -674,7 +674,7 @@ pub mod tests {
         #[test]
         fn totally_empty() {
             check_render(
-                mdq_nodes![Header {
+                mdq_nodes![Section {
                     depth: 3,
                     title: vec![],
                     body: vec![],
@@ -687,7 +687,7 @@ pub mod tests {
         #[test]
         fn only_title() {
             check_render(
-                mdq_nodes![Header {
+                mdq_nodes![Section {
                     depth: 3,
                     title: vec![mdq_inline!("My header")],
                     body: vec![],
@@ -700,7 +700,7 @@ pub mod tests {
         #[test]
         fn only_body() {
             check_render(
-                mdq_nodes![Header {
+                mdq_nodes![Section {
                     depth: 3,
                     title: vec![],
                     body: mdq_nodes![Paragraph {
@@ -717,7 +717,7 @@ pub mod tests {
         #[test]
         fn title_and_body() {
             check_render(
-                mdq_nodes![Header {
+                mdq_nodes![Section {
                     depth: 1,
                     title: vec![mdq_inline!("My title")],
                     body: mdq_nodes![BlockQuote {
@@ -1782,7 +1782,7 @@ pub mod tests {
 
         fn link_and_footnote_markdown() -> Vec<MdqNode> {
             mdq_nodes![
-                Header {
+                Section {
                     depth: 1,
                     title: vec![mdq_inline!("First section")],
                     body: mdq_nodes![Paragraph {
@@ -1806,7 +1806,7 @@ pub mod tests {
                         ],
                     }],
                 },
-                Header {
+                Section {
                     depth: 1,
                     title: vec![mdq_inline!("Second section")],
                     body: mdq_nodes![Paragraph {

--- a/src/fmt_str.rs
+++ b/src/fmt_str.rs
@@ -37,7 +37,7 @@ mod tests {
     use super::*;
     use indoc::indoc;
 
-    use crate::tree::{Inline, MdqNode, SpanVariant, TextVariant};
+    use crate::tree::{Inline, MdqNode, ReadOptions, SpanVariant, TextVariant};
     use crate::unwrap;
     use crate::utils_for_test::VariantsChecker;
     use lazy_static::lazy_static;
@@ -76,7 +76,7 @@ mod tests {
     #[test]
     fn text_html() {
         let node = markdown::to_mdast("<foo>", &ParseOptions::gfm()).unwrap();
-        let mdq_node: MdqNode = node.try_into().unwrap();
+        let mdq_node: MdqNode = MdqNode::read(node, &ReadOptions::default()).unwrap().pop().unwrap();
         unwrap!(mdq_node, MdqNode::Root(root));
         unwrap!(&root.body[0], MdqNode::Inline(inline));
         VARIANTS_CHECKER.see(inline);
@@ -132,7 +132,7 @@ mod tests {
         let mut options = ParseOptions::gfm();
         options.constructs.math_text = true;
         let node = markdown::to_mdast(md, &options).unwrap();
-        let mdq_node: MdqNode = node.try_into().unwrap();
+        let mdq_node: MdqNode = MdqNode::read(node, &ReadOptions::default()).unwrap().pop().unwrap();
         unwrap!(mdq_node, MdqNode::Root(root));
         unwrap!(&root.body[0], MdqNode::Paragraph(p));
         p.body.iter().for_each(|inline| VARIANTS_CHECKER.see(inline));

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::{env, io};
 use crate::fmt_md::MdOptions;
 use crate::output::Stream;
 use crate::select::Selector;
-use crate::tree::MdqNode;
+use crate::tree::{MdqNode, ReadOptions};
 
 mod fmt_md;
 mod fmt_str;
@@ -22,7 +22,7 @@ fn main() {
     let mut contents = String::new();
     stdin().read_to_string(&mut contents).expect("invalid input (not utf8)");
     let ast = markdown::to_mdast(&mut contents, &markdown::ParseOptions::gfm()).unwrap();
-    let mdq: MdqNode = ast.try_into().unwrap();
+    let mdq: MdqNode = MdqNode::read(ast, &ReadOptions::default()).unwrap().pop().unwrap();
     let mut out = output::Output::new(Stream(io::stdout()));
 
     let selectors_str = env::args().nth(1).unwrap_or("".to_string());

--- a/src/select.rs
+++ b/src/select.rs
@@ -28,7 +28,7 @@ impl Selector {
     // TODO need better name -- here but also in all the other methods
     pub fn find_nodes_one<'a>(&self, out: &mut Vec<&'a MdqNode>, node: &'a MdqNode) {
         match (self, node) {
-            (Selector::Heading(selector), MdqNode::Header(header)) => {
+            (Selector::Heading(selector), MdqNode::Section(header)) => {
                 let header_text = inlines_to_plain_string(&header.title);
                 if selector.matcher.matches(&header_text) {
                     header.body.iter().for_each(|child| out.push(child));


### PR DESCRIPTION
- rename `Header` -> `Section`, to better reflect that it's a whole section (and not just the `# header text` line)
- make `MdqNode::read` return a `Vec<MdqNode>`, instead of just one. This is in anticipation of a larger reorg that formalizes blocks, leaf blocks, inlines, etc.

The impetus for this came from trying to improve the Selector logic. I realized I need a better version of MdqNode: one that is both tighter constrained for ease of rendering (as I already have with the various things that take a `Vec<Inline>`, but can also cut across the hierarchy so that I can do things like selecting individual spans (like list elements, links, etc).