### PR TITLE
get rid of `MdqNode::Root`

### DIFF
--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -127,7 +127,6 @@ impl<'a> MdWriterState<'a> {
         W: SimpleWrite,
     {
         match node {
-            MdqNode::Root(Root { body }) => self.write_md(out, body),
             MdqNode::Section(Section { depth, title, body }) => {
                 out.with_block(Block::Plain, |out| {
                     for _ in 0..*depth {
@@ -570,7 +569,6 @@ pub mod tests {
 
     lazy_static! {
         static ref VARIANTS_CHECKER: VariantsChecker<MdqNode> = crate::new_variants_checker! (MdqNode {
-            Root(_),
             Section(_),
             Paragraph(_),
             BlockQuote(_),
@@ -627,12 +625,10 @@ pub mod tests {
         #[test]
         fn one_paragraph() {
             check_render(
-                mdq_nodes![Root {
-                    body: mdq_nodes![Paragraph {
-                        body: vec![Inline::Text {
-                            variant: TextVariant::Plain,
-                            value: "Hello, world".to_string()
-                        }]
+                mdq_nodes![Paragraph {
+                    body: vec![Inline::Text {
+                        variant: TextVariant::Plain,
+                        value: "Hello, world".to_string()
                     }]
                 }],
                 indoc! {r#"
@@ -643,22 +639,20 @@ pub mod tests {
         #[test]
         fn two_paragraphs() {
             check_render(
-                mdq_nodes![Root {
-                    body: mdq_nodes![
-                        Paragraph {
-                            body: vec![Inline::Text {
-                                variant: TextVariant::Plain,
-                                value: "First".to_string()
-                            }]
-                        },
-                        Paragraph {
-                            body: vec![Inline::Text {
-                                variant: TextVariant::Plain,
-                                value: "Second".to_string()
-                            }]
-                        },
-                    ]
-                }],
+                mdq_nodes![
+                    Paragraph {
+                        body: vec![Inline::Text {
+                            variant: TextVariant::Plain,
+                            value: "First".to_string()
+                        }]
+                    },
+                    Paragraph {
+                        body: vec![Inline::Text {
+                            variant: TextVariant::Plain,
+                            value: "Second".to_string()
+                        }]
+                    },
+                ],
                 indoc! {r#"
                 First
 

--- a/src/fmt_str.rs
+++ b/src/fmt_str.rs
@@ -76,9 +76,8 @@ mod tests {
     #[test]
     fn text_html() {
         let node = markdown::to_mdast("<foo>", &ParseOptions::gfm()).unwrap();
-        let mdq_node: MdqNode = MdqNode::read(node, &ReadOptions::default()).unwrap().pop().unwrap();
-        unwrap!(mdq_node, MdqNode::Root(root));
-        unwrap!(&root.body[0], MdqNode::Inline(inline));
+        let mdq_nodes = MdqNode::read(node, &ReadOptions::default()).unwrap();
+        unwrap!(&mdq_nodes[0], MdqNode::Inline(inline));
         VARIANTS_CHECKER.see(inline);
         let actual = inlines_to_plain_string(&[inline]);
         assert_eq!(&actual, "");
@@ -132,9 +131,8 @@ mod tests {
         let mut options = ParseOptions::gfm();
         options.constructs.math_text = true;
         let node = markdown::to_mdast(md, &options).unwrap();
-        let mdq_node: MdqNode = MdqNode::read(node, &ReadOptions::default()).unwrap().pop().unwrap();
-        unwrap!(mdq_node, MdqNode::Root(root));
-        unwrap!(&root.body[0], MdqNode::Paragraph(p));
+        let mdq_nodes = MdqNode::read(node, &ReadOptions::default()).unwrap();
+        unwrap!(&mdq_nodes[0], MdqNode::Paragraph(p));
         p.body.iter().for_each(|inline| VARIANTS_CHECKER.see(inline));
         let actual = inlines_to_plain_string(&p.body);
         assert_eq!(&actual, expect);

--- a/src/select.rs
+++ b/src/select.rs
@@ -34,11 +34,6 @@ impl Selector {
                     header.body.iter().for_each(|child| out.push(child));
                 }
             }
-            (_, MdqNode::Root(root)) => {
-                for node in &root.body {
-                    self.find_nodes_one(out, node);
-                }
-            }
             _ => {
                 // TODO better recursion
             }


### PR DESCRIPTION
Selectors will work on streams of md elements, which they'll flatmap into other streams of md elements. That means we're going to be working with iterators of elements (or for now, Vecs of them), meaning that we don't really need a special element that's just "a stream of elements".

In other words, we don't actually want to think of a doc as a single element with a list of elements -- we want to think of it as the stream of those elements.