### PR TITLE
add `MdqNode::ListItem`

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -39,6 +39,17 @@ pub struct Output<W: SimpleWrite> {
     writing_state: WritingState,
 }
 
+impl<W: SimpleWrite> SimpleWrite for Output<W> {
+    fn write_str(&mut self, text: &str) -> std::io::Result<()> {
+        Self::write_str(self, text);
+        Ok(())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        self.stream.flush()
+    }
+}
+
 pub struct PreWriter<'a, W: SimpleWrite> {
     output: &'a mut Output<W>,
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -20,6 +20,9 @@ pub enum MdqNode {
     // blocks that contain strings (as opposed to nodes)
     CodeBlock(CodeBlock),
 
+    #[allow(dead_code)] // selectors will create this later
+    ListItem(Option<u32>, ListItem),
+
     // inline spans
     Inline(Inline),
 }


### PR DESCRIPTION
I'm going to go in the opposite direction of what I was thinking before: rather than pulling things out of `MdqNode`, I'm going to pull things _into_ it as needed. This is actually effectively the same my original plan, just with less hierarchy and (importantly!) less "huge diffs that don't actually improve anything".

Long live `MdqNode`!