### PR TITLE
add list selector

### DIFF
--- a/src/fmt_str.rs
+++ b/src/fmt_str.rs
@@ -2,9 +2,8 @@ use crate::tree::{Inline, TextVariant};
 use std::borrow::Borrow;
 
 pub fn inlines_to_plain_string<N: Borrow<Inline>>(inlines: &[N]) -> String {
-    let mut result = String::with_capacity(inlines.len() * 10); // random guess
+    let mut result = String::with_capacity(inlines.len() * 5); // random guess
     build_inlines(&mut result, inlines);
-
     result
 }
 

--- a/src/select.rs
+++ b/src/select.rs
@@ -13,7 +13,7 @@ pub enum Selector {
     // Image { text: Matcher, href: Matcher },
     // Link { text: Matcher, href: Matcher },
     // CodeBlock(Matcher),
-    Heading(HeadingSelector),
+    Section(SectionSelector),
 }
 
 impl Selector {
@@ -27,7 +27,7 @@ impl Selector {
 
     pub fn build_output<'a>(&self, out: &mut Vec<MdqNodeRef<'a>>, node: MdqNodeRef<'a>) {
         let found = match (self, node.clone()) {
-            (Selector::Heading(selector), MdqNodeRef::Section(header)) => {
+            (Selector::Section(selector), MdqNodeRef::Section(header)) => {
                 let header_text = inlines_to_plain_string(&header.title);
                 if selector.matcher.matches(&header_text) {
                     header.body.iter().for_each(|child| out.push(child.into()));
@@ -96,7 +96,7 @@ impl Selector {
 }
 
 #[derive(Debug, PartialEq)]
-pub struct HeadingSelector {
+pub struct SectionSelector {
     matcher: Matcher,
 }
 
@@ -137,7 +137,7 @@ impl Selector {
 
     fn parse_header<C: Iterator<Item = char>>(chars: &mut ParsingIterator<C>) -> ParseResult<Selector> {
         let matcher = Matcher::parse_matcher(chars)?;
-        Ok(Selector::Heading(HeadingSelector { matcher }))
+        Ok(Selector::Section(SectionSelector { matcher }))
     }
 }
 
@@ -150,7 +150,7 @@ mod test {
     fn header() {
         parse_and_check(
             "# foo",
-            Selector::Heading(HeadingSelector {
+            Selector::Section(SectionSelector {
                 matcher: Matcher::Substring(SubstringMatcher {
                     look_for: "foo".to_string(),
                 }),
@@ -158,11 +158,11 @@ mod test {
             "",
         );
 
-        parse_and_check("# ", Selector::Heading(HeadingSelector { matcher: Matcher::Any }), "");
+        parse_and_check("# ", Selector::Section(SectionSelector { matcher: Matcher::Any }), "");
 
         parse_and_check(
             "# | next",
-            Selector::Heading(HeadingSelector { matcher: Matcher::Any }),
+            Selector::Section(SectionSelector { matcher: Matcher::Any }),
             " next",
         );
     }

--- a/src/select.rs
+++ b/src/select.rs
@@ -2,7 +2,7 @@ use crate::fmt_str::inlines_to_plain_string;
 use crate::matcher::Matcher;
 use crate::parse_common::{ParseError, ParseErrorReason, ParseResult};
 use crate::parsing_iter::ParsingIterator;
-use crate::tree::Inline;
+use crate::tree::{Inline, ListItem};
 use crate::tree_ref::MdqNodeRef;
 use crate::wrap_mdq_refs;
 
@@ -13,7 +13,29 @@ pub enum Selector {
     // Image { text: Matcher, href: Matcher },
     // Link { text: Matcher, href: Matcher },
     // CodeBlock(Matcher),
+    /// Selects the content of a section identified by its heading.
+    ///
+    /// Format: `# <string_matcher>`
+    ///
+    /// In bareword form, the string matcher terminates with the
+    /// [selector delimiter character](parse_common::SELECTOR_SEPARATOR).
     Section(SectionSelector),
+
+    /// Selects a list item.
+    ///
+    /// Format: `<type> [checkbox] <string_matcher>` where:
+    /// - _type_ is either `-` for unordered lists or `1.` for ordered lists. Note that ordered lists are _only_
+    ///   identified by `1.`. Other digits are invalid.
+    /// - _checkbox_, if provided, must be one of:
+    ///   - `[ ]` for an unchecked box
+    ///   - `[x]` for a checked box
+    ///   - `[?]` for a box that may be checked or unchecked
+    ///
+    /// If the checkbox specifier is provided, the selector will only select list items with a checkbox. If the
+    /// checkbox specifier is omitted, the selector will only select list items without a checkbox.
+    ///
+    /// In bareword form, the string matcher terminates with the [selector delimiter character](SELECTOR_SEPARATOR).
+    ListItem(ListItemSelector),
 }
 
 impl Selector {
@@ -36,6 +58,7 @@ impl Selector {
                     false
                 }
             }
+            (Selector::ListItem(selector), MdqNodeRef::ListItem(idx, item)) => selector.matches(&idx, item),
             _ => false,
         };
         if !found {
@@ -102,6 +125,8 @@ pub struct SectionSelector {
 
 #[derive(Debug, PartialEq)]
 pub struct SubstringMatcher {
+    // TODO move to matcher.rs. Or maybe just rm? I have it here in case I want to add anchors later, but YAGNI, and
+    // I can add a struct later if I need it.
     pub look_for: String,
 }
 
@@ -130,14 +155,116 @@ impl Selector {
         match chars.next() {
             None => Ok(Selector::Any), // unexpected, but future-proof
             Some('#') => Self::parse_header(chars),
+            Some('-') => ListItemSelector::read(ListItemType::Unordered, chars),
+            Some('1') => ListItemSelector::read(ListItemType::Ordered, chars),
 
-            Some(other) => Err(ParseErrorReason::UnexpectedCharacter(other)),
+            Some(other) => Err(ParseErrorReason::UnexpectedCharacter(other)), // TODO should be Any w/ bareword if first char is a letter
         }
     }
 
     fn parse_header<C: Iterator<Item = char>>(chars: &mut ParsingIterator<C>) -> ParseResult<Selector> {
+        require_whitespace(chars, "Section specifier")?;
         let matcher = Matcher::parse_matcher(chars)?;
         Ok(Selector::Section(SectionSelector { matcher }))
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct ListItemSelector {
+    li_type: ListItemType,
+    checkbox: CheckboxSpecifier,
+    string_matcher: Matcher,
+}
+
+#[derive(Debug, PartialEq)]
+pub enum ListItemType {
+    Ordered,
+    Unordered,
+}
+
+impl ListItemType {
+    fn matches(&self, idx: &Option<u32>) -> bool {
+        match self {
+            ListItemType::Ordered => idx.is_some(),
+            ListItemType::Unordered => idx.is_none(),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub enum CheckboxSpecifier {
+    CheckboxUnchecked,
+    CheckboxChecked,
+    CheckboxEither,
+    NoCheckbox,
+}
+
+impl CheckboxSpecifier {
+    fn matches(&self, checked: &Option<bool>) -> bool {
+        match self {
+            CheckboxSpecifier::CheckboxUnchecked => checked == &Some(false),
+            CheckboxSpecifier::CheckboxChecked => checked == &Some(true),
+            CheckboxSpecifier::CheckboxEither => checked.is_some(),
+            CheckboxSpecifier::NoCheckbox => checked.is_none(),
+        }
+    }
+}
+
+fn require_whitespace<C: Iterator<Item = char>>(chars: &mut ParsingIterator<C>, description: &str) -> ParseResult<()> {
+    if chars.drop_while(|ch| ch.is_whitespace()).is_empty() {
+        return Err(ParseErrorReason::InvalidSyntax(format!(
+            "{} must be followed by whitespace",
+            description
+        )));
+    } else {
+        Ok(())
+    }
+}
+
+impl ListItemSelector {
+    fn read<C: Iterator<Item = char>>(li_type: ListItemType, chars: &mut ParsingIterator<C>) -> ParseResult<Selector> {
+        if matches!(li_type, ListItemType::Ordered) {
+            if chars.next() != Some('.') {
+                return Err(ParseErrorReason::InvalidSyntax(
+                    "Ordered list item specifier must start with \"1.\"".to_string(),
+                ));
+            }
+        }
+        require_whitespace(chars, "List item specifier")?;
+        let checkbox = if chars.peek() == Some('[') {
+            chars.next(); // consume the '['
+            let spec = match chars.next() {
+                None => return Err(ParseErrorReason::UnexpectedEndOfInput),
+                Some(' ') => CheckboxSpecifier::CheckboxUnchecked,
+                Some('x') => CheckboxSpecifier::CheckboxChecked,
+                Some('?') => CheckboxSpecifier::CheckboxEither,
+                Some(other) => return Err(ParseErrorReason::UnexpectedCharacter(other)),
+            };
+            if chars.next() != Some(']') {
+                return Err(ParseErrorReason::InvalidSyntax("expected \"]\"".to_string()));
+            }
+            require_whitespace(chars, "list item type")?;
+            spec
+        } else {
+            CheckboxSpecifier::NoCheckbox
+        };
+        let string_matcher = Matcher::parse_matcher(chars)?;
+
+        Ok(Selector::ListItem(ListItemSelector {
+            li_type,
+            checkbox,
+            string_matcher,
+        }))
+    }
+
+    fn matches(&self, actual_idx: &Option<u32>, actual_item: &ListItem) -> bool {
+        if !self.li_type.matches(actual_idx) {
+            return false;
+        }
+        if !self.checkbox.matches(&actual_item.checked) {
+            return false;
+        }
+        self.string_matcher.matches_any(&actual_item.item)
     }
 }
 
@@ -147,7 +274,7 @@ mod test {
     use crate::parse_common::parse_and_check_mapped;
 
     #[test]
-    fn header() {
+    fn section() {
         parse_and_check(
             "# foo",
             Selector::Section(SectionSelector {
@@ -165,6 +292,88 @@ mod test {
             Selector::Section(SectionSelector { matcher: Matcher::Any }),
             " next",
         );
+    }
+
+    mod list_item {
+        use super::*;
+        use crate::select::test::parse_and_check;
+
+        // TODO need negative tests
+
+        #[test]
+        fn ordered_no_checkbox() {
+            parse_and_check(
+                "1. foo",
+                Selector::ListItem(ListItemSelector {
+                    li_type: ListItemType::Ordered,
+                    checkbox: CheckboxSpecifier::NoCheckbox,
+                    string_matcher: Matcher::Substring(SubstringMatcher {
+                        look_for: "foo".to_string(),
+                    }),
+                }),
+                "",
+            );
+        }
+
+        #[test]
+        fn unordered_no_checkbox() {
+            parse_and_check(
+                "- foo",
+                Selector::ListItem(ListItemSelector {
+                    li_type: ListItemType::Unordered,
+                    checkbox: CheckboxSpecifier::NoCheckbox,
+                    string_matcher: Matcher::Substring(SubstringMatcher {
+                        look_for: "foo".to_string(),
+                    }),
+                }),
+                "",
+            );
+        }
+
+        #[test]
+        fn unordered_unchecked() {
+            parse_and_check(
+                "- [ ] foo",
+                Selector::ListItem(ListItemSelector {
+                    li_type: ListItemType::Unordered,
+                    checkbox: CheckboxSpecifier::CheckboxUnchecked,
+                    string_matcher: Matcher::Substring(SubstringMatcher {
+                        look_for: "foo".to_string(),
+                    }),
+                }),
+                "",
+            );
+        }
+
+        #[test]
+        fn unordered_checked() {
+            parse_and_check(
+                "- [x] foo",
+                Selector::ListItem(ListItemSelector {
+                    li_type: ListItemType::Unordered,
+                    checkbox: CheckboxSpecifier::CheckboxChecked,
+                    string_matcher: Matcher::Substring(SubstringMatcher {
+                        look_for: "foo".to_string(),
+                    }),
+                }),
+                "",
+            );
+        }
+
+        #[test]
+        fn unordered_maybe_checked() {
+            parse_and_check(
+                "- [?] foo",
+                Selector::ListItem(ListItemSelector {
+                    li_type: ListItemType::Unordered,
+                    checkbox: CheckboxSpecifier::CheckboxEither,
+                    string_matcher: Matcher::Substring(SubstringMatcher {
+                        look_for: "foo".to_string(),
+                    }),
+                }),
+                "",
+            );
+        }
     }
 
     fn parse_and_check(text: &str, expect: Selector, expect_remaining: &str) {


### PR DESCRIPTION
I've played around with it for manual testing and it seems to work, but no automated testing yet. Still, this is a big milestone!

For now, there's minimal (basically no) abstraction to unify list selectors with section selectors. I'll probably do that next, and then add tests, and then add more selectors.