### PR TITLE
simplify the ParsingIterator

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -72,7 +72,7 @@ impl Matcher {
         }
     }
 
-    pub fn parse_matcher<C: Iterator<Item = char>>(chars: &mut ParsingIterator<C>) -> ParseResult<Matcher> {
+    pub fn parse_matcher(chars: &mut ParsingIterator) -> ParseResult<Matcher> {
         chars.drop_while(|ch| ch.is_whitespace());
         let peek_ch = match chars.peek() {
             None => return Ok(Matcher::Any),
@@ -89,7 +89,7 @@ impl Matcher {
         }
     }
 
-    fn parse_matcher_bare<C: Iterator<Item = char>>(chars: &mut ParsingIterator<C>) -> Matcher {
+    fn parse_matcher_bare(chars: &mut ParsingIterator) -> Matcher {
         let mut result = String::with_capacity(20); // just a guess
         let mut dropped = String::with_capacity(8); // also a guess
 
@@ -108,7 +108,7 @@ impl Matcher {
         Matcher::Substring(result)
     }
 
-    fn parse_regex_matcher<C: Iterator<Item = char>>(chars: &mut ParsingIterator<C>) -> ParseResult<Matcher> {
+    fn parse_regex_matcher(chars: &mut ParsingIterator) -> ParseResult<Matcher> {
         let mut result = String::with_capacity(20); // just a guess
 
         loop {
@@ -186,7 +186,7 @@ mod test {
     }
 
     fn parse_and_check(text: &str, expect: Matcher, expect_remaining: &str) {
-        let mut iter = ParsingIterator::new(text.chars());
+        let mut iter = ParsingIterator::new(text);
         let matcher = Matcher::parse_matcher(&mut iter).unwrap();
         assert_eq!(matcher, expect);
         let remaining: String = iter.collect();
@@ -194,7 +194,7 @@ mod test {
     }
 
     fn expect_err(text: &str, expect: ParseErrorReason, at: Position) {
-        let mut iter = ParsingIterator::new(text.chars());
+        let mut iter = ParsingIterator::new(text);
         let err = Matcher::parse_matcher(&mut iter).expect_err("expected to fail parsing");
         assert_eq!(iter.input_position(), at);
         assert_eq!(err, expect);

--- a/src/select/list_item.rs
+++ b/src/select/list_item.rs
@@ -19,7 +19,7 @@ pub enum ListItemType {
 }
 
 impl ListItemType {
-    pub fn read<C: Iterator<Item = char>>(self, chars: &mut ParsingIterator<C>) -> ParseResult<ListItemSelector> {
+    pub fn read(self, chars: &mut ParsingIterator) -> ParseResult<ListItemSelector> {
         // list-type-specific parsing (ie, the dot after "1" for ordered lists)
         self.read_type(chars)?;
 
@@ -94,7 +94,7 @@ impl ListItemType {
         }
     }
 
-    fn read_type<C: Iterator<Item = char>>(&self, chars: &mut ParsingIterator<C>) -> ParseResult<()> {
+    fn read_type(&self, chars: &mut ParsingIterator) -> ParseResult<()> {
         if matches!(self, ListItemType::Ordered) {
             chars.next().map(|_| ()).ok_or_else(|| {
                 ParseErrorReason::InvalidSyntax("Ordered list item specifier must start with \"1.\"".to_string())

--- a/src/select/section.rs
+++ b/src/select/section.rs
@@ -2,7 +2,6 @@ use crate::fmt_str::inlines_to_plain_string;
 use crate::matcher::Matcher;
 use crate::parsing_iter::ParsingIterator;
 use crate::select::base::Selector;
-use crate::select::util::require_whitespace;
 use crate::select::{ParseResult, SelectResult};
 use crate::tree::Section;
 
@@ -12,9 +11,7 @@ pub struct SectionSelector {
 }
 
 impl SectionSelector {
-    pub fn read<C: Iterator<Item = char>>(chars: &mut ParsingIterator<C>) -> ParseResult<SectionSelector> {
-        require_whitespace(chars, "Section specifier")?;
-
+    pub fn read(chars: &mut ParsingIterator) -> ParseResult<SectionSelector> {
         let matcher = Matcher::parse_matcher(chars)?;
         Ok(Self { matcher })
     }

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -38,7 +38,7 @@ pub enum MdqRefSelector {
 
 impl MdqRefSelector {
     pub fn parse(text: &str) -> Result<Vec<Self>, ParseError> {
-        let mut iter = ParsingIterator::new(text.chars());
+        let mut iter = ParsingIterator::new(text);
         let mut selectors = Vec::with_capacity(5); // just a guess
 
         loop {
@@ -130,7 +130,7 @@ impl MdqRefSelector {
         }
     }
 
-    fn parse_selector<C: Iterator<Item = char>>(chars: &mut ParsingIterator<C>) -> ParseResult<Self> {
+    fn parse_selector(chars: &mut ParsingIterator) -> ParseResult<Self> {
         chars.drop_while(|ch| ch.is_whitespace()); // should already be the case, but this is cheap and future-proof
         match chars.next() {
             None => Ok(MdqRefSelector::Any), // unexpected, but future-proof

--- a/src/select/util.rs
+++ b/src/select/util.rs
@@ -1,10 +1,7 @@
 use crate::parsing_iter::ParsingIterator;
 use crate::select::{ParseErrorReason, ParseResult};
 
-pub fn require_whitespace<C: Iterator<Item = char>>(
-    chars: &mut ParsingIterator<C>,
-    description: &str,
-) -> ParseResult<()> {
+pub fn require_whitespace(chars: &mut ParsingIterator, description: &str) -> ParseResult<()> {
     if chars.drop_while(|ch| ch.is_whitespace()).is_empty() && chars.peek().is_some() {
         return Err(ParseErrorReason::InvalidSyntax(format!(
             "{} must be followed by whitespace",


### PR DESCRIPTION
Chars holds onto the underlying &str, meaning it always comes from a &str eventually. The callers don't care what kind of iterator it is, so why have them worry about it? Just use the concrete type, fetch it directly from the &str (as opposed to having it be passed in), and be done with it.