### PR TITLE
remove a TODO

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -25,7 +25,6 @@ impl PartialEq for StringMatcher {
 
 impl StringMatcher {
     pub fn matches(&self, haystack: &str) -> bool {
-        // TODO deprecate in favor of matches_inlines
         match self {
             StringMatcher::Any => true,
             StringMatcher::Substring(look_for) => haystack.contains(look_for),

--- a/src/select/section.rs
+++ b/src/select/section.rs
@@ -19,8 +19,7 @@ impl SectionSelector {
 
 impl<'a> Selector<'a, &'a Section> for SectionSelector {
     fn matches(&self, section: &'a Section) -> bool {
-        let header_text = inlines_to_plain_string(&section.title);
-        self.matcher.matches(&header_text)
+        self.matcher.matches_inlines(&section.title)
     }
 
     fn pick(&self, item: &'a Section) -> SelectResult<'a> {

--- a/src/select/section.rs
+++ b/src/select/section.rs
@@ -1,4 +1,3 @@
-use crate::fmt_str::inlines_to_plain_string;
 use crate::matcher::StringMatcher;
 use crate::parsing_iter::ParsingIterator;
 use crate::select::base::Selector;


### PR DESCRIPTION
Despite the comment, I don't want to remove the `&str` version: it'll be useful when I want to write a matcher against URLs, for links and images (and also for alt text for images). But, anywhere that I'm using it to check for an inline, I should use `matches_inlines` instead.