### PR TITLE
split MdqNode up into more precise enums

### DIFF
--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -960,7 +960,7 @@ pub mod tests {
         #[test]
         fn simple() {
             check_render(
-                mdq_nodes![Table {
+                mdq_nodes![Block::LeafBlock::Table {
                     alignments: vec![
                         mdast::AlignKind::Left,
                         mdast::AlignKind::Right,
@@ -997,7 +997,7 @@ pub mod tests {
         fn single_char_cells() {
             // This checks the minimum padding aspects
             check_render(
-                mdq_nodes![Table {
+                mdq_nodes![Block::LeafBlock::Table {
                     alignments: vec![
                         mdast::AlignKind::Left,
                         mdast::AlignKind::Right,
@@ -1034,7 +1034,7 @@ pub mod tests {
         fn empty_cells() {
             // This checks the minimum padding aspects
             check_render(
-                mdq_nodes![Table {
+                mdq_nodes![Block::LeafBlock::Table {
                     alignments: vec![
                         mdast::AlignKind::Left,
                         mdast::AlignKind::Right,
@@ -1071,7 +1071,7 @@ pub mod tests {
         fn row_counts_inconsistent() {
             // This is an invalid table, but we should still support it
             check_render(
-                mdq_nodes![Table {
+                mdq_nodes![Block::LeafBlock::Table {
                     alignments: vec![mdast::AlignKind::None, mdast::AlignKind::None,],
                     rows: vec![
                         // Header row: two values

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -684,7 +684,7 @@ pub mod tests {
         #[test]
         fn totally_empty() {
             check_render(
-                mdq_nodes![Section {
+                mdq_nodes![Block::Container::Section {
                     depth: 3,
                     title: vec![],
                     body: vec![],
@@ -697,7 +697,7 @@ pub mod tests {
         #[test]
         fn only_title() {
             check_render(
-                mdq_nodes![Section {
+                mdq_nodes![Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("My header")],
                     body: vec![],
@@ -710,7 +710,7 @@ pub mod tests {
         #[test]
         fn only_body() {
             check_render(
-                mdq_nodes![Section {
+                mdq_nodes![Block::Container::Section {
                     depth: 3,
                     title: vec![],
                     body: mdq_nodes!["Hello, world."],
@@ -725,7 +725,7 @@ pub mod tests {
         #[test]
         fn title_and_body() {
             check_render(
-                mdq_nodes![Section {
+                mdq_nodes![Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("My title")],
                     body: mdq_nodes![Block::Container::BlockQuote {
@@ -1863,7 +1863,7 @@ pub mod tests {
 
         fn link_and_footnote_markdown() -> Vec<MdqNode> {
             mdq_nodes![
-                Section {
+                Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("First section")],
                     body: mdq_nodes![Block::LeafBlock::Paragraph {
@@ -1885,7 +1885,7 @@ pub mod tests {
                         ],
                     }],
                 },
-                Section {
+                Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("Second section")],
                     body: mdq_nodes!["Second section contents."],

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -795,7 +795,7 @@ pub mod tests {
         #[test]
         fn ordered() {
             check_render(
-                mdq_nodes![List {
+                mdq_nodes![Block::Container::List {
                     starting_index: Some(3),
                     items: vec![
                         ListItem {
@@ -822,7 +822,7 @@ pub mod tests {
         #[test]
         fn unordered() {
             check_render(
-                mdq_nodes![List {
+                mdq_nodes![Block::Container::List {
                     starting_index: None,
                     items: vec![
                         ListItem {
@@ -849,7 +849,7 @@ pub mod tests {
         #[test]
         fn block_alignments() {
             check_render(
-                mdq_nodes![List {
+                mdq_nodes![Block::Container::List {
                     starting_index: None,
                     items: vec![
                         ListItem {

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -653,12 +653,7 @@ pub mod tests {
         #[test]
         fn one_paragraph() {
             check_render(
-                mdq_nodes![Paragraph {
-                    body: vec![Inline::Text {
-                        variant: TextVariant::Plain,
-                        value: "Hello, world".to_string()
-                    }]
-                }],
+                mdq_nodes!["Hello, world"],
                 indoc! {r#"
                 Hello, world"#},
             );
@@ -667,20 +662,7 @@ pub mod tests {
         #[test]
         fn two_paragraphs() {
             check_render(
-                mdq_nodes![
-                    Paragraph {
-                        body: vec![Inline::Text {
-                            variant: TextVariant::Plain,
-                            value: "First".to_string()
-                        }]
-                    },
-                    Paragraph {
-                        body: vec![Inline::Text {
-                            variant: TextVariant::Plain,
-                            value: "Second".to_string()
-                        }]
-                    },
-                ],
+                mdq_nodes!["First", "Second",],
                 indoc! {r#"
                 First
 
@@ -726,9 +708,7 @@ pub mod tests {
                 mdq_nodes![Section {
                     depth: 3,
                     title: vec![],
-                    body: mdq_nodes![Paragraph {
-                        body: vec![mdq_inline!("Hello, world.")]
-                    },],
+                    body: mdq_nodes!["Hello, world."],
                 }],
                 indoc! {r#"
                     ###
@@ -744,9 +724,7 @@ pub mod tests {
                     depth: 1,
                     title: vec![mdq_inline!("My title")],
                     body: mdq_nodes![BlockQuote {
-                        body: mdq_nodes![Paragraph {
-                            body: vec![mdq_inline!("Hello, world.")]
-                        },],
+                        body: mdq_nodes!["Hello, world."],
                     },],
                 }],
                 indoc! {r#"
@@ -763,12 +741,7 @@ pub mod tests {
         #[test]
         fn simple() {
             check_render(
-                mdq_nodes![Paragraph {
-                    body: vec![Inline::Text {
-                        variant: TextVariant::Plain,
-                        value: "Hello, world".to_string()
-                    }]
-                }],
+                mdq_nodes!["Hello, world"],
                 indoc! {r#"
                 Hello, world"#},
             );
@@ -776,7 +749,6 @@ pub mod tests {
     }
 
     mod block_quote {
-        use crate::mdq_inline;
 
         use super::*;
 
@@ -784,12 +756,7 @@ pub mod tests {
         fn single_level() {
             check_render(
                 mdq_nodes![BlockQuote {
-                    body: mdq_nodes![Paragraph {
-                        body: vec![Inline::Text {
-                            variant: TextVariant::Plain,
-                            value: "Hello, world".to_string()
-                        }]
-                    }]
+                    body: mdq_nodes!["Hello, world"]
                 }],
                 indoc! {
                     r#"> Hello, world"#
@@ -802,13 +769,9 @@ pub mod tests {
             check_render(
                 mdq_nodes![BlockQuote {
                     body: mdq_nodes![
-                        Paragraph {
-                            body: vec![mdq_inline!("Outer")],
-                        },
+                        "Outer",
                         BlockQuote {
-                            body: mdq_nodes![Paragraph {
-                                body: vec![mdq_inline!("Inner")],
-                            },]
+                            body: mdq_nodes!["Inner"],
                         },
                     ]
                 }],
@@ -904,9 +867,7 @@ pub mod tests {
                         ListItem {
                             checked: Some(false),
                             item: mdq_nodes![
-                                Paragraph {
-                                    body: vec![mdq_inline!("closing argument")]
-                                },
+                                "closing argument",
                                 BlockQuote {
                                     body: mdq_nodes!["supporting evidence"]
                                 },
@@ -1691,9 +1652,7 @@ pub mod tests {
                 vec![
                     MdqNode::Inline(Inline::Footnote(Footnote {
                         label: "a".to_string(),
-                        text: mdq_nodes![Paragraph {
-                            body: vec![mdq_inline!("Hello, world.")]
-                        }],
+                        text: mdq_nodes!["Hello, world."],
                     })),
                     m_node!(MdqNode::Block::LeafBlock::ThematicBreak),
                 ],
@@ -1712,9 +1671,7 @@ pub mod tests {
                 vec![
                     MdqNode::Inline(Inline::Footnote(Footnote {
                         label: "a".to_string(),
-                        text: mdq_nodes![Paragraph {
-                            body: vec![mdq_inline!("Hello,\nworld.")]
-                        }],
+                        text: mdq_nodes!["Hello,\nworld."],
                     })),
                     m_node!(MdqNode::Block::LeafBlock::ThematicBreak),
                 ],
@@ -1736,7 +1693,7 @@ pub mod tests {
         #[test]
         fn link_and_footnote() {
             check_render(
-                mdq_nodes![Paragraph {
+                mdq_nodes![Block::LeafBlock::Paragraph {
                     body: vec![
                         mdq_inline!("Hello, "),
                         Inline::Link {
@@ -1750,9 +1707,7 @@ pub mod tests {
                         mdq_inline!("! This is interesting"),
                         Inline::Footnote(Footnote {
                             label: "a".to_string(),
-                            text: mdq_nodes![Paragraph {
-                                body: vec![mdq_inline!("this is my note")]
-                            }],
+                            text: mdq_nodes!["this is my note"],
                         }),
                         mdq_inline!("."),
                     ],
@@ -1863,7 +1818,7 @@ pub mod tests {
                     footnote_reference_options: ReferencePlacement::BottomOfDoc,
                 },
                 // Define them in the opposite order that we'd expect them
-                mdq_nodes![Paragraph {
+                mdq_nodes![Block::LeafBlock::Paragraph {
                     body: vec![
                         Inline::Footnote(Footnote {
                             label: "d".to_string(),
@@ -1906,7 +1861,7 @@ pub mod tests {
                 Section {
                     depth: 1,
                     title: vec![mdq_inline!("First section")],
-                    body: mdq_nodes![Paragraph {
+                    body: mdq_nodes![Block::LeafBlock::Paragraph {
                         body: vec![
                             Inline::Link {
                                 text: vec![mdq_inline!("link description")],
@@ -1919,9 +1874,7 @@ pub mod tests {
                             mdq_inline!(" and then a thought"),
                             Inline::Footnote(Footnote {
                                 label: "a".to_string(),
-                                text: mdq_nodes![Paragraph {
-                                    body: vec![mdq_inline!("the footnote")]
-                                }],
+                                text: mdq_nodes!["the footnote"],
                             }),
                             mdq_inline!("."),
                         ],
@@ -1930,9 +1883,7 @@ pub mod tests {
                 Section {
                     depth: 1,
                     title: vec![mdq_inline!("Second section")],
-                    body: mdq_nodes![Paragraph {
-                        body: vec![mdq_inline!("Second section contents.")]
-                    }],
+                    body: mdq_nodes!["Second section contents."],
                 },
             ]
         }

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -728,7 +728,7 @@ pub mod tests {
                 mdq_nodes![Section {
                     depth: 1,
                     title: vec![mdq_inline!("My title")],
-                    body: mdq_nodes![BlockQuote {
+                    body: mdq_nodes![Block::Container::BlockQuote {
                         body: mdq_nodes!["Hello, world."],
                     },],
                 }],
@@ -760,7 +760,7 @@ pub mod tests {
         #[test]
         fn single_level() {
             check_render(
-                mdq_nodes![BlockQuote {
+                mdq_nodes![Block::Container::BlockQuote {
                     body: mdq_nodes!["Hello, world"]
                 }],
                 indoc! {
@@ -772,10 +772,10 @@ pub mod tests {
         #[test]
         fn two_levels() {
             check_render(
-                mdq_nodes![BlockQuote {
+                mdq_nodes![Block::Container::BlockQuote {
                     body: mdq_nodes![
                         "Outer",
-                        BlockQuote {
+                        Block::Container::BlockQuote {
                             body: mdq_nodes!["Inner"],
                         },
                     ]
@@ -858,7 +858,7 @@ pub mod tests {
                         },
                         ListItem {
                             checked: None,
-                            item: mdq_nodes!(BlockQuote {
+                            item: mdq_nodes!(Block::Container::BlockQuote {
                                 body: mdq_nodes!["quoted block one", "quoted block two"]
                             })
                         },
@@ -873,7 +873,7 @@ pub mod tests {
                             checked: Some(false),
                             item: mdq_nodes![
                                 "closing argument",
-                                BlockQuote {
+                                Block::Container::BlockQuote {
                                     body: mdq_nodes!["supporting evidence"]
                                 },
                                 Block::LeafBlock::CodeBlock {

--- a/src/fmt_str.rs
+++ b/src/fmt_str.rs
@@ -36,7 +36,7 @@ mod tests {
     use super::*;
     use indoc::indoc;
 
-    use crate::tree::{Inline, MdqNode, ReadOptions, SpanVariant, TextVariant};
+    use crate::tree::{Block, Inline, LeafBlock, MdqNode, ReadOptions, SpanVariant, TextVariant};
     use crate::unwrap;
     use markdown::ParseOptions;
 
@@ -122,7 +122,7 @@ mod tests {
         options.constructs.math_text = true;
         let node = markdown::to_mdast(md, &options).unwrap();
         let mdq_nodes = MdqNode::read(node, &ReadOptions::default()).unwrap();
-        unwrap!(&mdq_nodes[0], MdqNode::Paragraph(p));
+        unwrap!(&mdq_nodes[0], MdqNode::Block(Block::LeafBlock(LeafBlock::Paragraph(p)))); // TODO can I use m_node here?
         p.body.iter().for_each(|inline| VARIANTS_CHECKER.see(inline));
         let actual = inlines_to_plain_string(&p.body);
         assert_eq!(&actual, expect);

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -58,6 +58,7 @@ impl StringMatcher {
                 false
             }
             Block::Container(Container::List(list)) => list.items.iter().any(|li| self.matches_any(&li.item)),
+            Block::Container(Container::BlockQuote(block)) => self.matches_any(&block.body),
         }
     }
 
@@ -71,7 +72,6 @@ impl StringMatcher {
                 }
                 self.matches_any(&section.body)
             }
-            MdqNode::BlockQuote(block) => self.matches_any(&block.body),
             MdqNode::Inline(inline) => self.matches_inlines(&[inline]),
         }
     }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,7 +1,7 @@
 use crate::fmt_str::inlines_to_plain_string;
 use crate::parsing_iter::ParsingIterator;
 use crate::select::{ParseErrorReason, ParseResult, SELECTOR_SEPARATOR};
-use crate::tree::{Inline, MdqNode};
+use crate::tree::{Block, Inline, MdqNode};
 use regex::Regex;
 use std::borrow::Borrow;
 
@@ -43,8 +43,16 @@ impl StringMatcher {
         haystacks.iter().any(|node| self.matches_node(node.borrow()))
     }
 
+    fn matches_block(&self, block: &Block) -> bool {
+        match block {
+            Block::LeafBlock(c) => todo!("53"),
+        };
+    }
+
     fn matches_node(&self, node: &MdqNode) -> bool {
         match node {
+            MdqNode::Block(block) => self.matches_block(block),
+
             MdqNode::Section(section) => {
                 if self.matches_inlines(&section.title) {
                     return true;

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -47,6 +47,16 @@ impl StringMatcher {
         match block {
             Block::LeafBlock(LeafBlock::Paragraph(p)) => self.matches_inlines(&p.body),
             Block::LeafBlock(LeafBlock::ThematicBreak | LeafBlock::CodeBlock(_)) => false,
+            Block::LeafBlock(LeafBlock::Table(table)) => {
+                for row in &table.rows {
+                    for cell in row {
+                        if self.matches_inlines(cell) {
+                            return true;
+                        }
+                    }
+                }
+                false
+            }
         }
     }
 
@@ -62,16 +72,6 @@ impl StringMatcher {
             }
             MdqNode::BlockQuote(block) => self.matches_any(&block.body),
             MdqNode::List(list) => list.items.iter().any(|li| self.matches_any(&li.item)),
-            MdqNode::Table(table) => {
-                for row in &table.rows {
-                    for cell in row {
-                        if self.matches_inlines(cell) {
-                            return true;
-                        }
-                    }
-                }
-                false
-            }
             MdqNode::Inline(inline) => self.matches_inlines(&[inline]),
         }
     }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -59,19 +59,18 @@ impl StringMatcher {
             }
             Block::Container(Container::List(list)) => list.items.iter().any(|li| self.matches_any(&li.item)),
             Block::Container(Container::BlockQuote(block)) => self.matches_any(&block.body),
+            Block::Container(Container::Section(section)) => {
+                if self.matches_inlines(&section.title) {
+                    return true;
+                }
+                self.matches_any(&section.body)
+            }
         }
     }
 
     fn matches_node(&self, node: &MdqNode) -> bool {
         match node {
             MdqNode::Block(block) => self.matches_block(block),
-
-            MdqNode::Section(section) => {
-                if self.matches_inlines(&section.title) {
-                    return true;
-                }
-                self.matches_any(&section.body)
-            }
             MdqNode::Inline(inline) => self.matches_inlines(&[inline]),
         }
     }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,7 +1,7 @@
 use crate::fmt_str::inlines_to_plain_string;
 use crate::parsing_iter::ParsingIterator;
 use crate::select::{ParseErrorReason, ParseResult, SELECTOR_SEPARATOR};
-use crate::tree::{Block, Inline, MdqNode};
+use crate::tree::{Block, Inline, LeafBlock, MdqNode};
 use regex::Regex;
 use std::borrow::Borrow;
 
@@ -45,8 +45,8 @@ impl StringMatcher {
 
     fn matches_block(&self, block: &Block) -> bool {
         match block {
-            Block::LeafBlock(c) => todo!("53"),
-        };
+            Block::LeafBlock(LeafBlock::ThematicBreak) => false,
+        }
     }
 
     fn matches_node(&self, node: &MdqNode) -> bool {
@@ -72,7 +72,6 @@ impl StringMatcher {
                 }
                 false
             }
-            MdqNode::ThematicBreak => false,
             MdqNode::CodeBlock(_) => false,
             MdqNode::Inline(inline) => self.matches_inlines(&[inline]),
         }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -45,8 +45,8 @@ impl StringMatcher {
 
     fn matches_block(&self, block: &Block) -> bool {
         match block {
-            Block::LeafBlock(LeafBlock::ThematicBreak) => false,
             Block::LeafBlock(LeafBlock::Paragraph(p)) => self.matches_inlines(&p.body),
+            Block::LeafBlock(LeafBlock::ThematicBreak | LeafBlock::CodeBlock(_)) => false,
         }
     }
 
@@ -72,7 +72,6 @@ impl StringMatcher {
                 }
                 false
             }
-            MdqNode::CodeBlock(_) => false,
             MdqNode::Inline(inline) => self.matches_inlines(&[inline]),
         }
     }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -46,6 +46,7 @@ impl StringMatcher {
     fn matches_block(&self, block: &Block) -> bool {
         match block {
             Block::LeafBlock(LeafBlock::ThematicBreak) => false,
+            Block::LeafBlock(LeafBlock::Paragraph(p)) => self.matches_inlines(&p.body),
         }
     }
 
@@ -59,7 +60,6 @@ impl StringMatcher {
                 }
                 self.matches_any(&section.body)
             }
-            MdqNode::Paragraph(paragraph) => self.matches_inlines(&paragraph.body),
             MdqNode::BlockQuote(block) => self.matches_any(&block.body),
             MdqNode::List(list) => list.items.iter().any(|li| self.matches_any(&li.item)),
             MdqNode::Table(table) => {

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,7 +1,7 @@
 use crate::fmt_str::inlines_to_plain_string;
 use crate::parsing_iter::ParsingIterator;
 use crate::select::{ParseErrorReason, ParseResult, SELECTOR_SEPARATOR};
-use crate::tree::{Block, Inline, LeafBlock, MdqNode};
+use crate::tree::{Block, Container, Inline, LeafBlock, MdqNode};
 use regex::Regex;
 use std::borrow::Borrow;
 
@@ -57,6 +57,7 @@ impl StringMatcher {
                 }
                 false
             }
+            Block::Container(Container::List(list)) => list.items.iter().any(|li| self.matches_any(&li.item)),
         }
     }
 
@@ -71,7 +72,6 @@ impl StringMatcher {
                 self.matches_any(&section.body)
             }
             MdqNode::BlockQuote(block) => self.matches_any(&block.body),
-            MdqNode::List(list) => list.items.iter().any(|li| self.matches_any(&li.item)),
             MdqNode::Inline(inline) => self.matches_inlines(&[inline]),
         }
     }

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -115,7 +115,6 @@ impl MdqRefSelector {
                 }
                 result
             }
-            MdqNodeRef::CodeBlock(_) => Vec::new(),
             MdqNodeRef::ListItem(ListItemRef(_, item)) => MdqNodeRef::wrap_vec(&item.item),
             MdqNodeRef::Inline(inline) => match inline {
                 Inline::Span { children, .. } => children.iter().map(|child| MdqNodeRef::Inline(child)).collect(),

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -115,7 +115,6 @@ impl MdqRefSelector {
                 }
                 result
             }
-            MdqNodeRef::ThematicBreak => Vec::new(),
             MdqNodeRef::CodeBlock(_) => Vec::new(),
             MdqNodeRef::ListItem(ListItemRef(_, item)) => MdqNodeRef::wrap_vec(&item.item),
             MdqNodeRef::Inline(inline) => match inline {
@@ -127,6 +126,7 @@ impl MdqRefSelector {
                 }
                 Inline::Text { .. } | Inline::Image { .. } => Vec::new(),
             },
+            MdqNodeRef::NonSelectable(_) => Vec::new(),
         }
     }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -10,7 +10,6 @@ use markdown::mdast;
 pub enum MdqNode {
     Block(Block),
     Section(Section),
-    BlockQuote(BlockQuote),
     Inline(Inline),
 }
 
@@ -31,6 +30,7 @@ pub enum LeafBlock {
 #[derive(Debug, PartialEq)]
 pub enum Container {
     List(List),
+    BlockQuote(BlockQuote),
 }
 
 #[derive(Debug, PartialEq)]
@@ -269,7 +269,7 @@ impl MdqNode {
     fn from_mdast_0(node: mdast::Node, lookups: &Lookups) -> Result<Vec<Self>, InvalidMd> {
         let result = match node {
             mdast::Node::Root(node) => return MdqNode::all(node.children, lookups),
-            mdast::Node::BlockQuote(node) => MdqNode::BlockQuote(BlockQuote {
+            mdast::Node::BlockQuote(node) => m_node!(MdqNode::Block::Container::BlockQuote {
                 body: MdqNode::all(node.children, lookups)?,
             }),
             mdast::Node::FootnoteDefinition(_) => return Ok(Vec::new()),
@@ -765,8 +765,8 @@ mod tests {
         fn block_quote() {
             let (root, lookups) = parse("> hello");
             let child = &root.children[0];
-            check!(child, Node::BlockQuote(_), lookups => MdqNode::BlockQuote(bq)= {
-                assert_eq!(bq.body, mdq_nodes!["hello"]);
+            check!(child, Node::BlockQuote(_), lookups => m_node!(MdqNode::Block::Container::BlockQuote{body}) = {
+                assert_eq!(body, mdq_nodes!["hello"]);
             });
         }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -9,17 +9,15 @@ use markdown::mdast;
 #[derive(Debug, PartialEq)]
 pub enum MdqNode {
     Block(Block),
-    // paragraphs with child nodes
     Section(Section),
     BlockQuote(BlockQuote),
-    List(List),
     Inline(Inline),
 }
 
 #[derive(Debug, PartialEq)]
 pub enum Block {
     LeafBlock(LeafBlock),
-    // TODO #53 container blocks
+    Container(Container),
 }
 
 #[derive(Debug, PartialEq)]
@@ -28,6 +26,11 @@ pub enum LeafBlock {
     Paragraph(Paragraph),
     CodeBlock(CodeBlock),
     Table(Table),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Container {
+    List(List),
 }
 
 #[derive(Debug, PartialEq)]
@@ -282,7 +285,7 @@ impl MdqNode {
                     };
                     li_nodes.push(li_mdq);
                 }
-                MdqNode::List(List {
+                m_node!(MdqNode::Block::Container::List {
                     starting_index: node.start,
                     items: li_nodes,
                 })
@@ -801,7 +804,7 @@ mod tests {
                     assert_eq!(footnote, Inline::Footnote(Footnote{
                         label: "a".to_string(),
                         text: vec![
-                            MdqNode::List(List{
+                            m_node!(MdqNode::Block::Container::List{
                                 starting_index: None,
                                 items: vec![
                                     ListItem{
@@ -835,7 +838,7 @@ mod tests {
             );
             assert_eq!(root.children.len(), 2); // unordered list, then ordered
 
-            check!(&root.children[0], Node::List(ul), lookups => MdqNode::List(List{starting_index, items}) = {
+            check!(&root.children[0], Node::List(ul), lookups => m_node!(MdqNode::Block::Container::List{starting_index, items}) = {
                 for child in &ul.children {
                     check!(error: child, Node::ListItem(_), lookups => InvalidMd::InternalError);
                 }
@@ -855,7 +858,7 @@ mod tests {
                     },
                 ]);
             });
-            check!(&root.children[1], Node::List(ol), lookups => MdqNode::List(List{starting_index, items}) = {
+            check!(&root.children[1], Node::List(ol), lookups => m_node!(MdqNode::Block::Container::List{starting_index, items}) = {
                 for child in &ol.children {
                     check!(error: child, Node::ListItem(_), lookups => InvalidMd::InternalError);
                 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -13,18 +13,13 @@ pub enum MdqNode {
     Section(Section),
     BlockQuote(BlockQuote),
     List(List),
-    Table(Table),
-
-    // blocks that contain strings (as opposed to nodes)
-
-    // inline spans
     Inline(Inline),
 }
 
 #[derive(Debug, PartialEq)]
 pub enum Block {
     LeafBlock(LeafBlock),
-    // TODO #53 leaf blocks
+    // TODO #53 container blocks
 }
 
 #[derive(Debug, PartialEq)]
@@ -32,7 +27,7 @@ pub enum LeafBlock {
     ThematicBreak,
     Paragraph(Paragraph),
     CodeBlock(CodeBlock),
-    // TODO #53
+    Table(Table),
 }
 
 #[derive(Debug, PartialEq)]
@@ -396,7 +391,7 @@ impl MdqNode {
                     }
                     rows.push(column);
                 }
-                MdqNode::Table(Table {
+                m_node!(MdqNode::Block::LeafBlock::Table {
                     alignments: align,
                     rows,
                 })
@@ -1667,7 +1662,7 @@ mod tests {
                     "#},
             );
             assert_eq!(root.children.len(), 1);
-            check!(&root.children[0], Node::Table(table_node), lookups => MdqNode::Table(Table{alignments, rows}) = {
+            check!(&root.children[0], Node::Table(table_node), lookups => m_node!(MdqNode::Block::LeafBlock::Table{alignments, rows}) = {
                 assert_eq!(alignments, vec![mdast::AlignKind::Left, mdast::AlignKind::Center, mdast::AlignKind::Right, mdast::AlignKind::None]);
                 assert_eq!(rows,
                     vec![ // rows

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -14,28 +14,23 @@ pub enum MdqNode {
 
 #[derive(Debug, PartialEq)]
 pub enum Block {
-    LeafBlock(LeafBlock),
     Container(Container),
+    LeafBlock(LeafBlock),
 }
 
 #[derive(Debug, PartialEq)]
 pub enum LeafBlock {
-    ThematicBreak,
-    Paragraph(Paragraph),
     CodeBlock(CodeBlock),
+    Paragraph(Paragraph),
     Table(Table),
+    ThematicBreak,
 }
 
 #[derive(Debug, PartialEq)]
 pub enum Container {
-    Section(Section),
-    List(List),
     BlockQuote(BlockQuote),
-}
-
-#[derive(Debug, PartialEq)]
-pub struct Root {
-    pub body: Vec<MdqNode>,
+    List(List),
+    Section(Section),
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -8,6 +8,7 @@ use markdown::mdast;
 
 #[derive(Debug, PartialEq)]
 pub enum MdqNode {
+    Block(Block),
     // paragraphs with child nodes
     Section(Section),
     Paragraph(Paragraph),
@@ -22,6 +23,17 @@ pub enum MdqNode {
 
     // inline spans
     Inline(Inline),
+}
+
+#[derive(Debug, PartialEq)]
+pub enum Block {
+    LeafBlock(LeafBlock),
+    // TODO #53 leaf blocks
+}
+
+#[derive(Debug, PartialEq)]
+pub enum LeafBlock {
+    // TODO #53
 }
 
 #[derive(Debug, PartialEq)]

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -1,5 +1,5 @@
 use crate::tree::{
-    Block, BlockQuote, CodeBlock, Inline, LeafBlock, List, ListItem, MdqNode, Paragraph, Section, Table,
+    Block, BlockQuote, CodeBlock, Container, Inline, LeafBlock, List, ListItem, MdqNode, Paragraph, Section, Table,
 };
 
 /// An MdqNodeRef is a slice into an MdqNode tree, where each element can be outputted, and certain elements can be
@@ -40,10 +40,12 @@ impl<'a> From<&'a MdqNode> for MdqNodeRef<'a> {
                     LeafBlock::CodeBlock(c) => Self::NonSelectable(NonSelectable::CodeBlock(c)),
                     LeafBlock::Table(t) => Self::Table(t),
                 },
+                Block::Container(container) => match container {
+                    Container::List(list) => Self::List(list),
+                },
             },
             MdqNode::Section(v) => Self::Section(v),
             MdqNode::BlockQuote(v) => Self::BlockQuote(v),
-            MdqNode::List(v) => Self::List(v),
             MdqNode::Inline(v) => Self::Inline(v),
         }
     }

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -42,10 +42,10 @@ impl<'a> From<&'a MdqNode> for MdqNodeRef<'a> {
                 },
                 Block::Container(container) => match container {
                     Container::List(list) => Self::List(list),
+                    Container::BlockQuote(block) => Self::BlockQuote(block),
                 },
             },
             MdqNode::Section(v) => Self::Section(v),
-            MdqNode::BlockQuote(v) => Self::BlockQuote(v),
             MdqNode::Inline(v) => Self::Inline(v),
         }
     }

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -33,11 +33,13 @@ pub struct ListItemRef<'a>(pub Option<u32>, pub &'a ListItem);
 impl<'a> From<&'a MdqNode> for MdqNodeRef<'a> {
     fn from(value: &'a MdqNode) -> Self {
         match value {
-            MdqNode::Block(Block::LeafBlock(LeafBlock::ThematicBreak)) => {
-                Self::NonSelectable(NonSelectable::ThematicBreak)
-            }
+            MdqNode::Block(block) => match block {
+                Block::LeafBlock(leaf) => match leaf {
+                    LeafBlock::ThematicBreak => Self::NonSelectable(NonSelectable::ThematicBreak),
+                    LeafBlock::Paragraph(p) => Self::Paragraph(p),
+                },
+            },
             MdqNode::Section(v) => Self::Section(v),
-            MdqNode::Paragraph(v) => Self::Paragraph(v),
             MdqNode::BlockQuote(v) => Self::BlockQuote(v),
             MdqNode::List(v) => Self::List(v),
             MdqNode::Table(v) => Self::Table(v),

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -2,6 +2,8 @@ use crate::tree::{
     Block, BlockQuote, CodeBlock, Inline, LeafBlock, List, ListItem, MdqNode, Paragraph, Section, Table,
 };
 
+/// An MdqNodeRef is a slice into an MdqNode tree, where each element can be outputted, and certain elements can be
+/// selected.
 #[derive(Debug, Clone)]
 pub enum MdqNodeRef<'a> {
     // paragraphs with child nodes
@@ -11,20 +13,18 @@ pub enum MdqNodeRef<'a> {
     List(&'a List),
     Table(&'a Table),
 
-    // blocks that contain strings (&'a as opposed to nodes)
-    CodeBlock(&'a CodeBlock),
-
     ListItem(ListItemRef<'a>),
 
     // inline spans
     Inline(&'a Inline),
 
-    NonSelectable(NonSelectable),
+    NonSelectable(NonSelectable<'a>),
 }
 
 #[derive(Debug, Clone)]
-pub enum NonSelectable {
+pub enum NonSelectable<'a> {
     ThematicBreak,
+    CodeBlock(&'a CodeBlock),
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -37,13 +37,13 @@ impl<'a> From<&'a MdqNode> for MdqNodeRef<'a> {
                 Block::LeafBlock(leaf) => match leaf {
                     LeafBlock::ThematicBreak => Self::NonSelectable(NonSelectable::ThematicBreak),
                     LeafBlock::Paragraph(p) => Self::Paragraph(p),
+                    LeafBlock::CodeBlock(c) => Self::NonSelectable(NonSelectable::CodeBlock(c)),
                 },
             },
             MdqNode::Section(v) => Self::Section(v),
             MdqNode::BlockQuote(v) => Self::BlockQuote(v),
             MdqNode::List(v) => Self::List(v),
             MdqNode::Table(v) => Self::Table(v),
-            MdqNode::CodeBlock(v) => Self::CodeBlock(v),
             MdqNode::Inline(v) => Self::Inline(v),
         }
     }

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -26,6 +26,7 @@ pub struct ListItemRef<'a>(pub Option<u32>, pub &'a ListItem);
 impl<'a> From<&'a MdqNode> for MdqNodeRef<'a> {
     fn from(value: &'a MdqNode) -> Self {
         match value {
+            MdqNode::Block(block) => todo!("#53"),
             MdqNode::Section(v) => Self::Section(v),
             MdqNode::Paragraph(v) => Self::Paragraph(v),
             MdqNode::BlockQuote(v) => Self::BlockQuote(v),

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -43,9 +43,9 @@ impl<'a> From<&'a MdqNode> for MdqNodeRef<'a> {
                 Block::Container(container) => match container {
                     Container::List(list) => Self::List(list),
                     Container::BlockQuote(block) => Self::BlockQuote(block),
+                    Container::Section(section) => Self::Section(section),
                 },
             },
-            MdqNode::Section(v) => Self::Section(v),
             MdqNode::Inline(v) => Self::Inline(v),
         }
     }

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -1,4 +1,6 @@
-use crate::tree::{BlockQuote, CodeBlock, Inline, List, ListItem, MdqNode, Paragraph, Section, Table};
+use crate::tree::{
+    Block, BlockQuote, CodeBlock, Inline, LeafBlock, List, ListItem, MdqNode, Paragraph, Section, Table,
+};
 
 #[derive(Debug, Clone)]
 pub enum MdqNodeRef<'a> {
@@ -9,8 +11,6 @@ pub enum MdqNodeRef<'a> {
     List(&'a List),
     Table(&'a Table),
 
-    ThematicBreak,
-
     // blocks that contain strings (&'a as opposed to nodes)
     CodeBlock(&'a CodeBlock),
 
@@ -18,6 +18,13 @@ pub enum MdqNodeRef<'a> {
 
     // inline spans
     Inline(&'a Inline),
+
+    NonSelectable(NonSelectable),
+}
+
+#[derive(Debug, Clone)]
+pub enum NonSelectable {
+    ThematicBreak,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -26,13 +33,14 @@ pub struct ListItemRef<'a>(pub Option<u32>, pub &'a ListItem);
 impl<'a> From<&'a MdqNode> for MdqNodeRef<'a> {
     fn from(value: &'a MdqNode) -> Self {
         match value {
-            MdqNode::Block(block) => todo!("#53"),
+            MdqNode::Block(Block::LeafBlock(LeafBlock::ThematicBreak)) => {
+                Self::NonSelectable(NonSelectable::ThematicBreak)
+            }
             MdqNode::Section(v) => Self::Section(v),
             MdqNode::Paragraph(v) => Self::Paragraph(v),
             MdqNode::BlockQuote(v) => Self::BlockQuote(v),
             MdqNode::List(v) => Self::List(v),
             MdqNode::Table(v) => Self::Table(v),
-            MdqNode::ThematicBreak => Self::ThematicBreak,
             MdqNode::CodeBlock(v) => Self::CodeBlock(v),
             MdqNode::Inline(v) => Self::Inline(v),
         }

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -38,12 +38,12 @@ impl<'a> From<&'a MdqNode> for MdqNodeRef<'a> {
                     LeafBlock::ThematicBreak => Self::NonSelectable(NonSelectable::ThematicBreak),
                     LeafBlock::Paragraph(p) => Self::Paragraph(p),
                     LeafBlock::CodeBlock(c) => Self::NonSelectable(NonSelectable::CodeBlock(c)),
+                    LeafBlock::Table(t) => Self::Table(t),
                 },
             },
             MdqNode::Section(v) => Self::Section(v),
             MdqNode::BlockQuote(v) => Self::BlockQuote(v),
             MdqNode::List(v) => Self::List(v),
-            MdqNode::Table(v) => Self::Table(v),
             MdqNode::Inline(v) => Self::Inline(v),
         }
     }

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -3,30 +3,28 @@ mod test_utils {
 
     #[macro_export]
     macro_rules! mdq_node {
-        ($node_type:tt {$($attr:ident: $val:expr),*}) => {
-            MdqNode::$node_type($node_type{$($attr: $val),*})
+        ( $($node_names:ident)::* {$($attr:ident: $val:expr),*}) => {
+            crate::m_node!(MdqNode::$($node_names)::* {$($attr: $val),*})
         };
         ($paragraph_text:literal) => {
-            crate::mdq_node!(Paragraph{body: vec![crate::mdq_inline!($paragraph_text)]})
+            crate::m_node!(MdqNode::Block::LeafBlock::Paragraph{body: vec![crate::mdq_inline!($paragraph_text)]})
         };
     }
 
     #[macro_export]
     macro_rules! mdq_nodes {
-        [$($node_type:tt {$($attr:ident: $val:expr),*$(,)?}),*$(,)?] => {
+        [$($first:tt $( $(:: $($rest:ident)::* )? {$($attr:ident: $val:expr),*$(,)?})? ),*$(,)?] => {
             vec![$(
-                crate::mdq_node!($node_type {
-                    $($attr: $val),*
-                })
+                crate::mdq_node!($first$( $(:: $($rest)::*)? { $($attr: $val),* })?)
                 ),*
             ]
         };
-        [$($paragraph_text:literal),*$(,)?] => {
-            vec![$(
-                    crate::mdq_node!($paragraph_text)
-                ),*
-            ]
-        }
+        // [$($paragraph_text:literal),*$(,)?] => {
+        //     vec![$(
+        //             crate::mdq_node!($paragraph_text)
+        //         ),*
+        //     ]
+        // } TODO rm if I don't need this
     }
 
     #[macro_export]


### PR DESCRIPTION
- MdqNode is either Block or Inline
- Blocks are either Leafs Blocks or Containers
- sort the various node types into those leafs and containers

In service of #53.