### PR TITLE
various renames

### DIFF
--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -98,7 +98,7 @@ struct MdWriterState<'a> {
 struct PendingReferences<'a> {
     links: HashMap<ReifiedLabel<'a>, ReifiedLink<'a>>,
     #[allow(dead_code)]
-    footnotes: HashMap<&'a String, &'a Vec<MdqElem>>,
+    footnotes: HashMap<&'a String, &'a Vec<MdElem>>,
 }
 
 #[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
@@ -723,7 +723,7 @@ pub mod tests {
                 md_elems![Block::Container::Section {
                     depth: 3,
                     title: vec![],
-                    body: mdq_nodes!["Hello, world."],
+                    body: md_elems!["Hello, world."],
                 }],
                 indoc! {r#"
                     ###
@@ -738,8 +738,8 @@ pub mod tests {
                 md_elems![Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("My title")],
-                    body: mdq_nodes![Block::Container::BlockQuote {
-                        body: mdq_nodes!["Hello, world."],
+                    body: md_elems![Block::Container::BlockQuote {
+                        body: md_elems!["Hello, world."],
                     },],
                 }],
                 indoc! {r#"
@@ -771,7 +771,7 @@ pub mod tests {
         fn single_level() {
             check_render(
                 md_elems![Block::Container::BlockQuote {
-                    body: mdq_nodes!["Hello, world"]
+                    body: md_elems!["Hello, world"]
                 }],
                 indoc! {
                     r#"> Hello, world"#
@@ -783,10 +783,10 @@ pub mod tests {
         fn two_levels() {
             check_render(
                 md_elems![Block::Container::BlockQuote {
-                    body: mdq_nodes![
+                    body: md_elems![
                         "Outer",
                         Block::Container::BlockQuote {
-                            body: mdq_nodes!["Inner"],
+                            body: md_elems!["Inner"],
                         },
                     ]
                 }],
@@ -810,15 +810,15 @@ pub mod tests {
                     items: vec![
                         ListItem {
                             checked: None,
-                            item: mdq_nodes!("normal")
+                            item: md_elems!("normal")
                         },
                         ListItem {
                             checked: Some(true),
-                            item: mdq_nodes!("checked")
+                            item: md_elems!("checked")
                         },
                         ListItem {
                             checked: Some(false),
-                            item: mdq_nodes!("unchecked")
+                            item: md_elems!("unchecked")
                         },
                     ],
                 }],
@@ -837,15 +837,15 @@ pub mod tests {
                     items: vec![
                         ListItem {
                             checked: None,
-                            item: mdq_nodes!("normal")
+                            item: md_elems!("normal")
                         },
                         ListItem {
                             checked: Some(true),
-                            item: mdq_nodes!("checked")
+                            item: md_elems!("checked")
                         },
                         ListItem {
                             checked: Some(false),
-                            item: mdq_nodes!("unchecked")
+                            item: md_elems!("unchecked")
                         },
                     ],
                 }],
@@ -864,27 +864,27 @@ pub mod tests {
                     items: vec![
                         ListItem {
                             checked: None,
-                            item: mdq_nodes!["first paragraph", "second paragraph"],
+                            item: md_elems!["first paragraph", "second paragraph"],
                         },
                         ListItem {
                             checked: None,
-                            item: mdq_nodes!(Block::Container::BlockQuote {
-                                body: mdq_nodes!["quoted block one", "quoted block two"]
+                            item: md_elems!(Block::Container::BlockQuote {
+                                body: md_elems!["quoted block one", "quoted block two"]
                             })
                         },
                         ListItem {
                             checked: None,
-                            item: mdq_nodes!(Block::LeafBlock::CodeBlock {
+                            item: md_elems!(Block::LeafBlock::CodeBlock {
                                 variant: CodeVariant::Code(None),
                                 value: "line 1\nline 2".to_string(),
                             })
                         },
                         ListItem {
                             checked: Some(false),
-                            item: mdq_nodes![
+                            item: md_elems![
                                 "closing argument",
                                 Block::Container::BlockQuote {
-                                    body: mdq_nodes!["supporting evidence"]
+                                    body: md_elems!["supporting evidence"]
                                 },
                                 Block::LeafBlock::CodeBlock {
                                     variant: CodeVariant::Code(None),
@@ -952,7 +952,7 @@ pub mod tests {
             create_li_singleton(Some(3), Some(true), md_elems!("plain text"), "3. [x] plain text");
         }
 
-        fn create_li_singleton<'a>(idx: Option<u32>, checked: Option<bool>, item: Vec<MdqElem>, expected: &str) {
+        fn create_li_singleton<'a>(idx: Option<u32>, checked: Option<bool>, item: Vec<MdElem>, expected: &str) {
             let li = ListItem { checked, item };
             check_render_with_refs(
                 &MdOptions::default(),
@@ -1119,7 +1119,7 @@ pub mod tests {
         #[test]
         fn by_itself() {
             check_render(
-                vec![m_node!(MdqElem::Block::LeafBlock::ThematicBreak)],
+                vec![m_node!(MdElem::Block::LeafBlock::ThematicBreak)],
                 indoc! {r#"
                 ***"#},
             );
@@ -1130,7 +1130,7 @@ pub mod tests {
             check_render(
                 vec![
                     md_elem!("before"),
-                    m_node!(MdqElem::Block::LeafBlock::ThematicBreak),
+                    m_node!(MdElem::Block::LeafBlock::ThematicBreak),
                     md_elem!("after"),
                 ],
                 indoc! {r#"
@@ -1269,7 +1269,7 @@ pub mod tests {
             #[test]
             fn delete() {
                 check_render(
-                    vec![MdqElem::Inline(mdq_inline!(span Delete [mdq_inline!("hello world")]))],
+                    vec![MdElem::Inline(mdq_inline!(span Delete [mdq_inline!("hello world")]))],
                     indoc! {"~~hello world~~"},
                 );
             }
@@ -1277,7 +1277,7 @@ pub mod tests {
             #[test]
             fn emphasis() {
                 check_render(
-                    vec![MdqElem::Inline(mdq_inline!(span Emphasis [mdq_inline!("hello world")]))],
+                    vec![MdElem::Inline(mdq_inline!(span Emphasis [mdq_inline!("hello world")]))],
                     indoc! {"_hello world_"},
                 );
             }
@@ -1285,7 +1285,7 @@ pub mod tests {
             #[test]
             fn strong() {
                 check_render(
-                    vec![MdqElem::Inline(mdq_inline!(span Strong [mdq_inline!("hello world")]))],
+                    vec![MdElem::Inline(mdq_inline!(span Strong [mdq_inline!("hello world")]))],
                     indoc! {"**hello world**"},
                 );
             }
@@ -1293,7 +1293,7 @@ pub mod tests {
             #[test]
             fn mixed() {
                 check_render(
-                    vec![MdqElem::Inline(mdq_inline!(span Emphasis [
+                    vec![MdElem::Inline(mdq_inline!(span Emphasis [
                         mdq_inline!("one "),
                         mdq_inline!(span Strong [
                             mdq_inline!("two "),
@@ -1313,7 +1313,7 @@ pub mod tests {
             #[test]
             fn text() {
                 check_render(
-                    vec![MdqElem::Inline(Inline::Text {
+                    vec![MdElem::Inline(Inline::Text {
                         variant: TextVariant::Plain,
                         value: "hello world".to_string(),
                     })],
@@ -1324,7 +1324,7 @@ pub mod tests {
             #[test]
             fn code() {
                 check_render(
-                    vec![MdqElem::Inline(Inline::Text {
+                    vec![MdElem::Inline(Inline::Text {
                         variant: TextVariant::Code,
                         value: "hello world".to_string(),
                     })],
@@ -1335,7 +1335,7 @@ pub mod tests {
             #[test]
             fn math() {
                 check_render(
-                    vec![MdqElem::Inline(Inline::Text {
+                    vec![MdElem::Inline(Inline::Text {
                         variant: TextVariant::Math,
                         value: "hello world".to_string(),
                     })],
@@ -1346,7 +1346,7 @@ pub mod tests {
             #[test]
             fn html() {
                 check_render(
-                    vec![MdqElem::Inline(Inline::Text {
+                    vec![MdElem::Inline(Inline::Text {
                         variant: TextVariant::Html,
                         value: "<a hello />".to_string(),
                     })],
@@ -1356,7 +1356,7 @@ pub mod tests {
         }
 
         mod link {
-            use crate::tree::{Inline, LinkDefinition, MdqElem};
+            use crate::tree::{Inline, LinkDefinition, MdElem};
 
             use super::*;
 
@@ -1494,7 +1494,7 @@ pub mod tests {
 
             fn check_link(link: LinkDefinition, expect: &str) {
                 let nodes = vec![
-                    MdqElem::Inline(Inline::Link {
+                    MdElem::Inline(Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
                             mdq_inline!(span Emphasis [mdq_inline!("world")]),
@@ -1502,14 +1502,14 @@ pub mod tests {
                         ],
                         link_definition: link,
                     }),
-                    m_node!(MdqElem::Block::LeafBlock::ThematicBreak),
+                    m_node!(MdElem::Block::LeafBlock::ThematicBreak),
                 ];
                 check_render(nodes, expect);
             }
         }
 
         mod image {
-            use crate::tree::{Inline, LinkDefinition, MdqElem};
+            use crate::tree::{Inline, LinkDefinition, MdElem};
 
             use super::*;
 
@@ -1647,11 +1647,11 @@ pub mod tests {
 
             fn check_image(link: LinkDefinition, expect: &str) {
                 let nodes = vec![
-                    MdqElem::Inline(Inline::Image {
+                    MdElem::Inline(Inline::Image {
                         alt: "hello _world_!".to_string(),
                         link,
                     }),
-                    m_node!(MdqElem::Block::LeafBlock::ThematicBreak),
+                    m_node!(MdElem::Block::LeafBlock::ThematicBreak),
                 ];
                 check_render(nodes, expect);
             }
@@ -1665,11 +1665,11 @@ pub mod tests {
         fn single_line() {
             check_render(
                 vec![
-                    MdqElem::Inline(Inline::Footnote(Footnote {
+                    MdElem::Inline(Inline::Footnote(Footnote {
                         label: "a".to_string(),
                         text: md_elems!["Hello, world."],
                     })),
-                    m_node!(MdqElem::Block::LeafBlock::ThematicBreak),
+                    m_node!(MdElem::Block::LeafBlock::ThematicBreak),
                 ],
                 indoc! {r#"
                     [^a]
@@ -1684,11 +1684,11 @@ pub mod tests {
         fn two_lines() {
             check_render(
                 vec![
-                    MdqElem::Inline(Inline::Footnote(Footnote {
+                    MdElem::Inline(Inline::Footnote(Footnote {
                         label: "a".to_string(),
                         text: md_elems!["Hello,\nworld."],
                     })),
-                    m_node!(MdqElem::Block::LeafBlock::ThematicBreak),
+                    m_node!(MdElem::Block::LeafBlock::ThematicBreak),
                 ],
                 indoc! {r#"
                     [^a]
@@ -1722,7 +1722,7 @@ pub mod tests {
                         mdq_inline!("! This is interesting"),
                         Inline::Footnote(Footnote {
                             label: "a".to_string(),
-                            text: mdq_nodes!["this is my note"],
+                            text: md_elems!["this is my note"],
                         }),
                         mdq_inline!("."),
                     ],
@@ -1837,11 +1837,11 @@ pub mod tests {
                     body: vec![
                         Inline::Footnote(Footnote {
                             label: "d".to_string(),
-                            text: mdq_nodes!["footnote 1"]
+                            text: md_elems!["footnote 1"]
                         }),
                         Inline::Footnote(Footnote {
                             label: "c".to_string(),
-                            text: mdq_nodes!["footnote 2"]
+                            text: md_elems!["footnote 2"]
                         }),
                         Inline::Link {
                             text: vec![mdq_inline!("b-text")],
@@ -1871,12 +1871,12 @@ pub mod tests {
             );
         }
 
-        fn link_and_footnote_markdown() -> Vec<MdqElem> {
+        fn link_and_footnote_markdown() -> Vec<MdElem> {
             md_elems![
                 Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("First section")],
-                    body: mdq_nodes![Block::LeafBlock::Paragraph {
+                    body: md_elems![Block::LeafBlock::Paragraph {
                         body: vec![
                             Inline::Link {
                                 text: vec![mdq_inline!("link description")],
@@ -1889,7 +1889,7 @@ pub mod tests {
                             mdq_inline!(" and then a thought"),
                             Inline::Footnote(Footnote {
                                 label: "a".to_string(),
-                                text: mdq_nodes!["the footnote"],
+                                text: md_elems!["the footnote"],
                             }),
                             mdq_inline!("."),
                         ],
@@ -1898,17 +1898,17 @@ pub mod tests {
                 Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("Second section")],
-                    body: mdq_nodes!["Second section contents."],
+                    body: md_elems!["Second section contents."],
                 },
             ]
         }
     }
 
-    fn check_render(nodes: Vec<MdqElem>, expect: &str) {
+    fn check_render(nodes: Vec<MdElem>, expect: &str) {
         check_render_with(&MdOptions::default(), nodes, expect);
     }
 
-    fn check_render_with(options: &MdOptions, nodes: Vec<MdqElem>, expect: &str) {
+    fn check_render_with(options: &MdOptions, nodes: Vec<MdElem>, expect: &str) {
         check_render_with_refs(options, MdElemRef::wrap_vec(&nodes), expect)
     }
 

--- a/src/fmt_str.rs
+++ b/src/fmt_str.rs
@@ -36,7 +36,7 @@ mod tests {
     use super::*;
     use indoc::indoc;
 
-    use crate::tree::{Block, Inline, LeafBlock, MdqNode, ReadOptions, SpanVariant, TextVariant};
+    use crate::tree::{Block, Inline, LeafBlock, MdqElem, ReadOptions, SpanVariant, TextVariant};
     use crate::unwrap;
     use markdown::ParseOptions;
 
@@ -71,8 +71,8 @@ mod tests {
     #[test]
     fn text_html() {
         let node = markdown::to_mdast("<foo>", &ParseOptions::gfm()).unwrap();
-        let mdq_nodes = MdqNode::read(node, &ReadOptions::default()).unwrap();
-        unwrap!(&mdq_nodes[0], MdqNode::Inline(inline));
+        let mdq_nodes = MdqElem::read(node, &ReadOptions::default()).unwrap();
+        unwrap!(&mdq_nodes[0], MdqElem::Inline(inline));
         VARIANTS_CHECKER.see(inline);
         let actual = inlines_to_plain_string(&[inline]);
         assert_eq!(&actual, "");
@@ -121,8 +121,8 @@ mod tests {
         let mut options = ParseOptions::gfm();
         options.constructs.math_text = true;
         let node = markdown::to_mdast(md, &options).unwrap();
-        let mdq_nodes = MdqNode::read(node, &ReadOptions::default()).unwrap();
-        unwrap!(&mdq_nodes[0], MdqNode::Block(Block::LeafBlock(LeafBlock::Paragraph(p)))); // TODO can I use m_node here?
+        let mdq_nodes = MdqElem::read(node, &ReadOptions::default()).unwrap();
+        unwrap!(&mdq_nodes[0], MdqElem::Block(Block::LeafBlock(LeafBlock::Paragraph(p)))); // TODO can I use m_node here?
         p.body.iter().for_each(|inline| VARIANTS_CHECKER.see(inline));
         let actual = inlines_to_plain_string(&p.body);
         assert_eq!(&actual, expect);

--- a/src/fmt_str.rs
+++ b/src/fmt_str.rs
@@ -36,7 +36,7 @@ mod tests {
     use super::*;
     use indoc::indoc;
 
-    use crate::tree::{Block, Inline, LeafBlock, MdqElem, ReadOptions, SpanVariant, TextVariant};
+    use crate::tree::{Block, Inline, LeafBlock, MdElem, ReadOptions, SpanVariant, TextVariant};
     use crate::unwrap;
     use markdown::ParseOptions;
 
@@ -71,8 +71,8 @@ mod tests {
     #[test]
     fn text_html() {
         let node = markdown::to_mdast("<foo>", &ParseOptions::gfm()).unwrap();
-        let mdq_nodes = MdqElem::read(node, &ReadOptions::default()).unwrap();
-        unwrap!(&mdq_nodes[0], MdqElem::Inline(inline));
+        let md_elems = MdElem::read(node, &ReadOptions::default()).unwrap();
+        unwrap!(&md_elems[0], MdElem::Inline(inline));
         VARIANTS_CHECKER.see(inline);
         let actual = inlines_to_plain_string(&[inline]);
         assert_eq!(&actual, "");
@@ -121,8 +121,8 @@ mod tests {
         let mut options = ParseOptions::gfm();
         options.constructs.math_text = true;
         let node = markdown::to_mdast(md, &options).unwrap();
-        let mdq_nodes = MdqElem::read(node, &ReadOptions::default()).unwrap();
-        unwrap!(&mdq_nodes[0], MdqElem::Block(Block::LeafBlock(LeafBlock::Paragraph(p)))); // TODO can I use m_node here?
+        let md_elems = MdElem::read(node, &ReadOptions::default()).unwrap();
+        unwrap!(&md_elems[0], MdElem::Block(Block::LeafBlock(LeafBlock::Paragraph(p)))); // TODO can I use m_node here?
         p.body.iter().for_each(|inline| VARIANTS_CHECKER.see(inline));
         let actual = inlines_to_plain_string(&p.body);
         assert_eq!(&actual, expect);

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use std::{env, io};
 use crate::fmt_md::MdOptions;
 use crate::output::Stream;
 use crate::select::selector::MdqRefSelector;
-use crate::tree::{MdqElem, ReadOptions};
+use crate::tree::{MdElem, ReadOptions};
 use crate::tree_ref::MdElemRef;
 
 mod fmt_md;
@@ -24,7 +24,7 @@ fn main() {
     let mut contents = String::new();
     stdin().read_to_string(&mut contents).expect("invalid input (not utf8)");
     let ast = markdown::to_mdast(&mut contents, &markdown::ParseOptions::gfm()).unwrap();
-    let mdqs = MdqElem::read(ast, &ReadOptions::default()).unwrap();
+    let mdqs = MdElem::read(ast, &ReadOptions::default()).unwrap();
     let mut out = output::Output::new(Stream(io::stdout()));
 
     let selectors_str = env::args().nth(1).unwrap_or("".to_string());

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,8 +4,8 @@ use std::{env, io};
 use crate::fmt_md::MdOptions;
 use crate::output::Stream;
 use crate::select::selector::MdqRefSelector;
-use crate::tree::{MdqNode, ReadOptions};
-use crate::tree_ref::MdqNodeRef;
+use crate::tree::{MdqElem, ReadOptions};
+use crate::tree_ref::MdElemRef;
 
 mod fmt_md;
 mod fmt_str;
@@ -24,13 +24,13 @@ fn main() {
     let mut contents = String::new();
     stdin().read_to_string(&mut contents).expect("invalid input (not utf8)");
     let ast = markdown::to_mdast(&mut contents, &markdown::ParseOptions::gfm()).unwrap();
-    let mdqs = MdqNode::read(ast, &ReadOptions::default()).unwrap();
+    let mdqs = MdqElem::read(ast, &ReadOptions::default()).unwrap();
     let mut out = output::Output::new(Stream(io::stdout()));
 
     let selectors_str = env::args().nth(1).unwrap_or("".to_string());
     let selectors = MdqRefSelector::parse(&selectors_str).expect("failed to parse selector");
 
-    let mut pipeline_nodes = MdqNodeRef::wrap_vec(&mdqs);
+    let mut pipeline_nodes = MdElemRef::wrap_vec(&mdqs);
     for selector in selectors {
         let new_pipeline = selector.find_nodes(pipeline_nodes);
         pipeline_nodes = new_pipeline;

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,7 +1,7 @@
 use crate::fmt_str::inlines_to_plain_string;
 use crate::parsing_iter::ParsingIterator;
 use crate::select::{ParseErrorReason, ParseResult, SELECTOR_SEPARATOR};
-use crate::tree::{Block, Container, Inline, LeafBlock, MdqNode};
+use crate::tree::{Block, Container, Inline, LeafBlock, MdqElem};
 use regex::Regex;
 use std::borrow::Borrow;
 
@@ -36,7 +36,7 @@ impl StringMatcher {
         self.matches(&inlines_to_plain_string(haystack))
     }
 
-    pub fn matches_any<N: Borrow<MdqNode>>(&self, haystacks: &[N]) -> bool {
+    pub fn matches_any<N: Borrow<MdqElem>>(&self, haystacks: &[N]) -> bool {
         if matches!(self, StringMatcher::Any) {
             return true;
         }
@@ -68,10 +68,10 @@ impl StringMatcher {
         }
     }
 
-    fn matches_node(&self, node: &MdqNode) -> bool {
+    fn matches_node(&self, node: &MdqElem) -> bool {
         match node {
-            MdqNode::Block(block) => self.matches_block(block),
-            MdqNode::Inline(inline) => self.matches_inlines(&[inline]),
+            MdqElem::Block(block) => self.matches_block(block),
+            MdqElem::Inline(inline) => self.matches_inlines(&[inline]),
         }
     }
 

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -1,7 +1,7 @@
 use crate::fmt_str::inlines_to_plain_string;
 use crate::parsing_iter::ParsingIterator;
 use crate::select::{ParseErrorReason, ParseResult, SELECTOR_SEPARATOR};
-use crate::tree::{Block, Container, Inline, LeafBlock, MdqElem};
+use crate::tree::{Block, Container, Inline, LeafBlock, MdElem};
 use regex::Regex;
 use std::borrow::Borrow;
 
@@ -36,7 +36,7 @@ impl StringMatcher {
         self.matches(&inlines_to_plain_string(haystack))
     }
 
-    pub fn matches_any<N: Borrow<MdqElem>>(&self, haystacks: &[N]) -> bool {
+    pub fn matches_any<N: Borrow<MdElem>>(&self, haystacks: &[N]) -> bool {
         if matches!(self, StringMatcher::Any) {
             return true;
         }
@@ -68,10 +68,10 @@ impl StringMatcher {
         }
     }
 
-    fn matches_node(&self, node: &MdqElem) -> bool {
+    fn matches_node(&self, node: &MdElem) -> bool {
         match node {
-            MdqElem::Block(block) => self.matches_block(block),
-            MdqElem::Inline(inline) => self.matches_inlines(&[inline]),
+            MdElem::Block(block) => self.matches_block(block),
+            MdElem::Inline(inline) => self.matches_inlines(&[inline]),
         }
     }
 

--- a/src/select/interface.rs
+++ b/src/select/interface.rs
@@ -1,10 +1,10 @@
 use crate::parse_common::Position;
-use crate::tree::MdqNode;
-use crate::tree_ref::MdqNodeRef;
+use crate::tree::MdqElem;
+use crate::tree_ref::MdElemRef;
 
 pub enum SelectResult<'a> {
-    One(MdqNodeRef<'a>),
-    Multi(&'a Vec<MdqNode>),
+    One(MdElemRef<'a>),
+    Multi(&'a Vec<MdqElem>),
 }
 
 pub type ParseResult<T> = Result<T, ParseErrorReason>;

--- a/src/select/interface.rs
+++ b/src/select/interface.rs
@@ -1,10 +1,10 @@
 use crate::parse_common::Position;
-use crate::tree::MdqElem;
+use crate::tree::MdElem;
 use crate::tree_ref::MdElemRef;
 
 pub enum SelectResult<'a> {
     One(MdElemRef<'a>),
-    Multi(&'a Vec<MdqElem>),
+    Multi(&'a Vec<MdElem>),
 }
 
 pub type ParseResult<T> = Result<T, ParseErrorReason>;

--- a/src/select/list_item.rs
+++ b/src/select/list_item.rs
@@ -2,7 +2,7 @@ use crate::matcher::StringMatcher;
 use crate::parsing_iter::ParsingIterator;
 use crate::select::base::Selector;
 use crate::select::{ParseErrorReason, ParseResult, SelectResult};
-use crate::tree_ref::{ListItemRef, MdqNodeRef};
+use crate::tree_ref::{ListItemRef, MdElemRef};
 
 #[derive(Debug, PartialEq)]
 pub struct ListItemSelector {
@@ -78,7 +78,7 @@ impl<'a> Selector<'a, ListItemRef<'a>> for ListItemSelector {
     }
 
     fn pick(&self, item: ListItemRef<'a>) -> SelectResult<'a> {
-        SelectResult::One(MdqNodeRef::ListItem(item))
+        SelectResult::One(MdElemRef::ListItem(item))
     }
 }
 

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -7,7 +7,7 @@ use std::vec::IntoIter;
 use markdown::mdast;
 
 #[derive(Debug, PartialEq)]
-pub enum MdqElem {
+pub enum MdElem {
     Block(Block),
     Inline(Inline),
 }
@@ -37,7 +37,7 @@ pub enum Container {
 pub struct Section {
     pub depth: u8,
     pub title: Vec<Inline>,
-    pub body: Vec<MdqElem>,
+    pub body: Vec<MdElem>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -47,7 +47,7 @@ pub struct Paragraph {
 
 #[derive(Debug, PartialEq)]
 pub struct BlockQuote {
-    pub body: Vec<MdqElem>,
+    pub body: Vec<MdElem>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -144,7 +144,7 @@ pub enum Inline {
 #[derive(Debug)]
 pub struct Footnote {
     pub label: String,
-    pub text: Vec<MdqElem>,
+    pub text: Vec<MdElem>,
 }
 
 /// Note that [Footnote]'s [Eq] and [Hash] only key off of its label, _not_ its text content.
@@ -176,7 +176,7 @@ pub struct LinkDefinition {
 #[derive(Debug, PartialEq)]
 pub struct ListItem {
     pub checked: Option<bool>,
-    pub item: Vec<MdqElem>,
+    pub item: Vec<MdElem>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -255,7 +255,7 @@ macro_rules! m_node {
     };
 }
 
-impl MdqElem {
+impl MdElem {
     pub fn read(node: mdast::Node, opts: &ReadOptions) -> Result<Vec<Self>, InvalidMd> {
         let lookups = Lookups::new(&node, opts)?;
         Self::from_mdast_0(node, &lookups)
@@ -263,9 +263,9 @@ impl MdqElem {
 
     fn from_mdast_0(node: mdast::Node, lookups: &Lookups) -> Result<Vec<Self>, InvalidMd> {
         let result = match node {
-            mdast::Node::Root(node) => return MdqElem::all(node.children, lookups),
-            mdast::Node::BlockQuote(node) => m_node!(MdqElem::Block::Container::BlockQuote {
-                body: MdqElem::all(node.children, lookups)?,
+            mdast::Node::Root(node) => return MdElem::all(node.children, lookups),
+            mdast::Node::BlockQuote(node) => m_node!(MdElem::Block::Container::BlockQuote {
+                body: MdElem::all(node.children, lookups)?,
             }),
             mdast::Node::FootnoteDefinition(_) => return Ok(Vec::new()),
             mdast::Node::List(node) => {
@@ -276,36 +276,36 @@ impl MdqElem {
                     };
                     let li_mdq = ListItem {
                         checked: li_node.checked,
-                        item: MdqElem::all(li_node.children, lookups)?,
+                        item: MdElem::all(li_node.children, lookups)?,
                     };
                     li_nodes.push(li_mdq);
                 }
-                m_node!(MdqElem::Block::Container::List {
+                m_node!(MdElem::Block::Container::List {
                     starting_index: node.start,
                     items: li_nodes,
                 })
             }
-            mdast::Node::Break(_) => MdqElem::Inline(Inline::Text {
+            mdast::Node::Break(_) => MdElem::Inline(Inline::Text {
                 variant: TextVariant::Plain,
                 value: "\n".to_string(),
             }),
-            mdast::Node::InlineCode(node) => MdqElem::Inline(Inline::Text {
+            mdast::Node::InlineCode(node) => MdElem::Inline(Inline::Text {
                 variant: TextVariant::Code,
                 value: node.value,
             }),
-            mdast::Node::InlineMath(node) => MdqElem::Inline(Inline::Text {
+            mdast::Node::InlineMath(node) => MdElem::Inline(Inline::Text {
                 variant: TextVariant::Math,
                 value: node.value,
             }),
-            mdast::Node::Delete(node) => MdqElem::Inline(Inline::Span {
+            mdast::Node::Delete(node) => MdElem::Inline(Inline::Span {
                 variant: SpanVariant::Delete,
-                children: MdqElem::inlines(node.children, lookups)?,
+                children: MdElem::inlines(node.children, lookups)?,
             }),
-            mdast::Node::Emphasis(node) => MdqElem::Inline(Inline::Span {
+            mdast::Node::Emphasis(node) => MdElem::Inline(Inline::Span {
                 variant: SpanVariant::Emphasis,
-                children: MdqElem::inlines(node.children, lookups)?,
+                children: MdElem::inlines(node.children, lookups)?,
             }),
-            mdast::Node::Image(node) => MdqElem::Inline(Inline::Image {
+            mdast::Node::Image(node) => MdElem::Inline(Inline::Image {
                 alt: node.alt,
                 link: LinkDefinition {
                     url: node.url,
@@ -313,40 +313,40 @@ impl MdqElem {
                     reference: LinkReference::Inline,
                 },
             }),
-            mdast::Node::ImageReference(node) => MdqElem::Inline(Inline::Image {
+            mdast::Node::ImageReference(node) => MdElem::Inline(Inline::Image {
                 alt: node.alt,
                 link: lookups.resolve_link(node.identifier, node.label, node.reference_kind)?,
             }),
-            mdast::Node::Link(node) => MdqElem::Inline(Inline::Link {
-                text: MdqElem::inlines(node.children, lookups)?,
+            mdast::Node::Link(node) => MdElem::Inline(Inline::Link {
+                text: MdElem::inlines(node.children, lookups)?,
                 link_definition: LinkDefinition {
                     url: node.url,
                     title: node.title,
                     reference: LinkReference::Inline,
                 },
             }),
-            mdast::Node::LinkReference(node) => MdqElem::Inline(Inline::Link {
-                text: MdqElem::inlines(node.children, lookups)?,
+            mdast::Node::LinkReference(node) => MdElem::Inline(Inline::Link {
+                text: MdElem::inlines(node.children, lookups)?,
                 link_definition: lookups.resolve_link(node.identifier, node.label, node.reference_kind)?,
             }),
             mdast::Node::FootnoteReference(node) => {
                 let definition = lookups.resolve_footnote(&node.identifier, &node.label)?;
-                MdqElem::Inline(Inline::Footnote(Footnote {
+                MdElem::Inline(Inline::Footnote(Footnote {
                     label: node.label.unwrap_or(node.identifier),
-                    text: MdqElem::all(definition.children.clone(), lookups)?,
+                    text: MdElem::all(definition.children.clone(), lookups)?,
                 }))
             }
-            mdast::Node::Strong(node) => MdqElem::Inline(Inline::Span {
+            mdast::Node::Strong(node) => MdElem::Inline(Inline::Span {
                 variant: SpanVariant::Strong,
-                children: MdqElem::inlines(node.children, lookups)?,
+                children: MdElem::inlines(node.children, lookups)?,
             }),
-            mdast::Node::Text(node) => MdqElem::Inline(Inline::Text {
+            mdast::Node::Text(node) => MdElem::Inline(Inline::Text {
                 variant: TextVariant::Plain,
                 value: node.value,
             }),
             mdast::Node::Code(node) => {
                 let mdast::Code { value, lang, meta, .. } = node;
-                m_node!(MdqElem::Block::LeafBlock::CodeBlock {
+                m_node!(MdElem::Block::LeafBlock::CodeBlock {
                     value,
                     variant: CodeVariant::Code(match lang {
                         None => None,
@@ -359,12 +359,12 @@ impl MdqElem {
             }
             mdast::Node::Math(node) => {
                 let mdast::Math { value, meta, .. } = node;
-                m_node!(MdqElem::Block::LeafBlock::CodeBlock {
+                m_node!(MdElem::Block::LeafBlock::CodeBlock {
                     value,
                     variant: CodeVariant::Math { metadata: meta },
                 })
             }
-            mdast::Node::Heading(node) => m_node!(MdqElem::Block::Container::Section {
+            mdast::Node::Heading(node) => m_node!(MdElem::Block::Container::Section {
                 depth: node.depth,
                 title: Self::inlines(node.children, lookups)?,
                 body: Vec::new(),
@@ -389,28 +389,28 @@ impl MdqElem {
                     }
                     rows.push(column);
                 }
-                m_node!(MdqElem::Block::LeafBlock::Table {
+                m_node!(MdElem::Block::LeafBlock::Table {
                     alignments: align,
                     rows,
                 })
             }
-            mdast::Node::ThematicBreak(_) => m_node!(MdqElem::Block::LeafBlock::ThematicBreak),
+            mdast::Node::ThematicBreak(_) => m_node!(MdElem::Block::LeafBlock::ThematicBreak),
             mdast::Node::TableRow(_) | mdast::Node::TableCell(_) | mdast::Node::ListItem(_) => {
                 return Err(InvalidMd::InternalError); // should have been handled by Node::Table
             }
             mdast::Node::Definition(_) => return Ok(Vec::new()),
-            mdast::Node::Paragraph(node) => m_node!(MdqElem::Block::LeafBlock::Paragraph {
+            mdast::Node::Paragraph(node) => m_node!(MdElem::Block::LeafBlock::Paragraph {
                 body: Self::inlines(node.children, lookups)?,
             }),
-            mdast::Node::Toml(node) => m_node!(MdqElem::Block::LeafBlock::CodeBlock {
+            mdast::Node::Toml(node) => m_node!(MdElem::Block::LeafBlock::CodeBlock {
                 variant: CodeVariant::Toml,
                 value: node.value,
             }),
-            mdast::Node::Yaml(node) => m_node!(MdqElem::Block::LeafBlock::CodeBlock {
+            mdast::Node::Yaml(node) => m_node!(MdElem::Block::LeafBlock::CodeBlock {
                 variant: CodeVariant::Yaml,
                 value: node.value,
             }),
-            mdast::Node::Html(node) => MdqElem::Inline(Inline::Text {
+            mdast::Node::Html(node) => MdElem::Inline(Inline::Text {
                 variant: TextVariant::Html,
                 value: node.value,
             }),
@@ -434,7 +434,7 @@ impl MdqElem {
 
     fn all_from_iter<I>(iter: I) -> Result<Vec<Self>, InvalidMd>
     where
-        I: Iterator<Item = Result<MdqElem, InvalidMd>>,
+        I: Iterator<Item = Result<MdElem, InvalidMd>>,
     {
         // This is just a struct that reflects the struct-variant of MdqNode::Header. If that
         // enum variant used the tuple-style with an explicitly defined struct, we wouldn't need
@@ -442,14 +442,14 @@ impl MdqElem {
         struct HContainer {
             depth: u8,
             title: Vec<Inline>,
-            children: Vec<MdqElem>,
+            children: Vec<MdElem>,
         }
 
         let mut result = Vec::with_capacity(16); // arbitrary capacity guess
         let mut headers: Vec<HContainer> = Vec::with_capacity(result.capacity());
         for child_mdq in iter {
             let child_mdq = child_mdq?;
-            if let m_node!(MdqElem::Block::Container::Section {
+            if let m_node!(MdElem::Block::Container::Section {
                 depth,
                 title,
                 body: children,
@@ -473,7 +473,7 @@ impl MdqElem {
                         // to the new previous, or else to the top-level results if there is no new
                         // previous. Then, we'll just loop back around.
                         let HContainer { depth, title, children } = headers.pop().unwrap(); // "let Some(prev)" above guarantees that this works
-                        let prev = m_node!(MdqElem::Block::Container::Section {
+                        let prev = m_node!(MdElem::Block::Container::Section {
                             depth,
                             title,
                             body: children,
@@ -499,7 +499,7 @@ impl MdqElem {
 
         // At this point, we still have our last tree branch of headers. Fold it up into the results.
         while let Some(HContainer { depth, title, children }) = headers.pop() {
-            let mdq_header = m_node!(MdqElem::Block::Container::Section {
+            let mdq_header = m_node!(MdElem::Block::Container::Section {
                 depth,
                 title,
                 body: children,
@@ -514,7 +514,7 @@ impl MdqElem {
         headers
             .drain(..)
             .map(|HContainer { depth, title, children }| {
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth,
                     title,
                     body: children,
@@ -530,7 +530,7 @@ impl MdqElem {
         let mdq_children = Self::all(children, lookups)?;
         let mut result = Vec::with_capacity(mdq_children.len());
         for child in mdq_children {
-            let MdqElem::Inline(inline) = child else {
+            let MdElem::Inline(inline) = child else {
                 return Err(InvalidMd::NonInlineWhereInlineExpected);
             };
             // If both this and the previous were plain text, then just combine the texts. This can happen if there was
@@ -560,7 +560,7 @@ where
     I: Iterator<Item = mdast::Node>,
 {
     children: I,
-    pending: IntoIter<MdqElem>,
+    pending: IntoIter<MdElem>,
     lookups: &'a Lookups,
 }
 
@@ -568,7 +568,7 @@ impl<'a, I> Iterator for NodeToMdqIter<'a, I>
 where
     I: Iterator<Item = mdast::Node>,
 {
-    type Item = Result<MdqElem, InvalidMd>;
+    type Item = Result<MdElem, InvalidMd>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -578,7 +578,7 @@ where
             let Some(next_node) = self.children.next() else {
                 return None;
             };
-            match MdqElem::from_mdast_0(next_node, self.lookups) {
+            match MdElem::from_mdast_0(next_node, self.lookups) {
                 Ok(mdq_node) => {
                     self.pending = mdq_node.into_iter();
                 }
@@ -722,7 +722,7 @@ mod tests {
                 NODES_CHECKER.see(&node);
                 unwrap!(node, $enum_variant);
                 let node_clone = node.clone();
-                let mdq_err = MdqElem::from_mdast_0(node_clone, &$lookups).err().expect("expected no MdqNode");
+                let mdq_err = MdElem::from_mdast_0(node_clone, &$lookups).err().expect("expected no MdqNode");
                 assert_eq!(mdq_err, $err);
                 $($body)?
             }};
@@ -732,7 +732,7 @@ mod tests {
                 NODES_CHECKER.see(&node);
                 unwrap!(node, $enum_variant);
                 let node_clone = node.clone();
-                let mdqs = MdqElem::from_mdast_0(node_clone, &$lookups).unwrap();
+                let mdqs = MdElem::from_mdast_0(node_clone, &$lookups).unwrap();
                 assert_eq!(mdqs, Vec::new());
             }};
 
@@ -741,7 +741,7 @@ mod tests {
                 NODES_CHECKER.see(&node);
                 unwrap!(node, $enum_variant);
                 let node_clone = node.clone();
-                let mut mdqs = MdqElem::from_mdast_0(node_clone, &$lookups).unwrap();
+                let mut mdqs = MdElem::from_mdast_0(node_clone, &$lookups).unwrap();
                 assert_eq!(mdqs.len(), 1, "expected exactly one element, but found: {:?}", mdqs);
                 let mdq = mdqs.pop().unwrap();
                 if let $mdq_pat = mdq $mdq_body else {
@@ -760,7 +760,7 @@ mod tests {
         fn block_quote() {
             let (root, lookups) = parse("> hello");
             let child = &root.children[0];
-            check!(child, Node::BlockQuote(_), lookups => m_node!(MdqElem::Block::Container::BlockQuote{body}) = {
+            check!(child, Node::BlockQuote(_), lookups => m_node!(MdElem::Block::Container::BlockQuote{body}) = {
                 assert_eq!(body, md_elems!["hello"]);
             });
         }
@@ -777,7 +777,7 @@ mod tests {
                       with two lines."#},
                 );
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[1], Node::FootnoteReference(_), lookups => MdqElem::Inline(footnote) = {
+                check!(&p.children[1], Node::FootnoteReference(_), lookups => MdElem::Inline(footnote) = {
                     assert_eq!(footnote, Inline::Footnote(Footnote{
                         label: "a".to_string(),
                         text: md_elems!["My footnote\nwith two lines."],
@@ -795,11 +795,11 @@ mod tests {
                 );
                 unwrap!(&root.children[0], Node::Paragraph(p));
 
-                check!(&p.children[1], Node::FootnoteReference(_), lookups => MdqElem::Inline(footnote) = {
+                check!(&p.children[1], Node::FootnoteReference(_), lookups => MdElem::Inline(footnote) = {
                     assert_eq!(footnote, Inline::Footnote(Footnote{
                         label: "a".to_string(),
                         text: vec![
-                            m_node!(MdqElem::Block::Container::List{
+                            m_node!(MdElem::Block::Container::List{
                                 starting_index: None,
                                 items: vec![
                                     ListItem{
@@ -833,7 +833,7 @@ mod tests {
             );
             assert_eq!(root.children.len(), 2); // unordered list, then ordered
 
-            check!(&root.children[0], Node::List(ul), lookups => m_node!(MdqElem::Block::Container::List{starting_index, items}) = {
+            check!(&root.children[0], Node::List(ul), lookups => m_node!(MdElem::Block::Container::List{starting_index, items}) = {
                 for child in &ul.children {
                     check!(error: child, Node::ListItem(_), lookups => InvalidMd::InternalError);
                 }
@@ -853,7 +853,7 @@ mod tests {
                     },
                 ]);
             });
-            check!(&root.children[1], Node::List(ol), lookups => m_node!(MdqElem::Block::Container::List{starting_index, items}) = {
+            check!(&root.children[1], Node::List(ol), lookups => m_node!(MdElem::Block::Container::List{starting_index, items}) = {
                 for child in &ol.children {
                     check!(error: child, Node::ListItem(_), lookups => InvalidMd::InternalError);
                 }
@@ -888,15 +888,15 @@ mod tests {
                 "#},
             );
 
-            check!(&root.children[0], Node::Paragraph(p), lookups => m_node!(MdqElem::Block::LeafBlock::Paragraph{body}) = {
+            check!(&root.children[0], Node::Paragraph(p), lookups => m_node!(MdElem::Block::LeafBlock::Paragraph{body}) = {
                 assert_eq!(p.children.len(), 3);
-                check!(&p.children[0], Node::Text(_), lookups => MdqElem::Inline(text) = {
+                check!(&p.children[0], Node::Text(_), lookups => MdElem::Inline(text) = {
                     assert_eq!(text, Inline::Text {variant: TextVariant::Plain, value: "hello ".to_string()});
                 });
-                check!(&p.children[1], Node::Break(_), lookups => MdqElem::Inline(text) = {
+                check!(&p.children[1], Node::Break(_), lookups => MdElem::Inline(text) = {
                     assert_eq!(text, Inline::Text {variant: TextVariant::Plain, value: "\n".to_string()});
                 });
-                check!(&p.children[2], Node::Text(_), lookups => MdqElem::Inline(text) = {
+                check!(&p.children[2], Node::Text(_), lookups => MdElem::Inline(text) = {
                     assert_eq!(text, Inline::Text {variant: TextVariant::Plain, value: "world".to_string()});
                 });
                 assert_eq!(body, vec![
@@ -911,7 +911,7 @@ mod tests {
             let (root, lookups) = parse("`foo`");
 
             unwrap!(&root.children[0], Node::Paragraph(p));
-            check!(&p.children[0], Node::InlineCode(_), lookups => MdqElem::Inline(inline) = {
+            check!(&p.children[0], Node::InlineCode(_), lookups => MdElem::Inline(inline) = {
                 assert_eq!(inline, Inline::Text { variant: TextVariant::Code, value: "foo".to_string() });
             });
         }
@@ -923,7 +923,7 @@ mod tests {
             let (root, lookups) = parse_with(&opts, r#"$ 0 \ne 1 $"#);
 
             unwrap!(&root.children[0], Node::Paragraph(p));
-            check!(&p.children[0], Node::InlineMath(_), lookups => MdqElem::Inline(inline) = {
+            check!(&p.children[0], Node::InlineMath(_), lookups => MdElem::Inline(inline) = {
                 assert_eq!(inline, Inline::Text { variant: TextVariant::Math, value: r#" 0 \ne 1 "#.to_string() });
             });
         }
@@ -933,7 +933,7 @@ mod tests {
             let (root, lookups) = parse_with(&ParseOptions::gfm(), "~~86 me~~");
 
             unwrap!(&root.children[0], Node::Paragraph(p));
-            check!(&p.children[0], Node::Delete(_), lookups => MdqElem::Inline(inline) = {
+            check!(&p.children[0], Node::Delete(_), lookups => MdElem::Inline(inline) = {
                 assert_eq!(inline, Inline::Span {
                     variant: SpanVariant::Delete,
                     children: vec![
@@ -948,7 +948,7 @@ mod tests {
             let (root, lookups) = parse("_86 me_");
 
             unwrap!(&root.children[0], Node::Paragraph(p));
-            check!(&p.children[0], Node::Emphasis(_), lookups => MdqElem::Inline(inline) = {
+            check!(&p.children[0], Node::Emphasis(_), lookups => MdElem::Inline(inline) = {
                 assert_eq!(inline, Inline::Span {
                     variant: SpanVariant::Emphasis,
                     children: vec![
@@ -963,7 +963,7 @@ mod tests {
             let (root, lookups) = parse("**strongman**");
 
             unwrap!(&root.children[0], Node::Paragraph(p));
-            check!(&p.children[0], Node::Strong(_), lookups => MdqElem::Inline(inline) = {
+            check!(&p.children[0], Node::Strong(_), lookups => MdElem::Inline(inline) = {
                 assert_eq!(inline, Inline::Span {
                     variant: SpanVariant::Strong,
                     children: vec![
@@ -978,7 +978,7 @@ mod tests {
             {
                 let (root, lookups) = parse("<a href>");
 
-                check!(&root.children[0], Node::Html(_), lookups => MdqElem::Inline(inline) = {
+                check!(&root.children[0], Node::Html(_), lookups => MdElem::Inline(inline) = {
                     assert_eq!(inline, Inline::Text {
                         variant: TextVariant::Html,
                         value: "<a href>".to_string(),
@@ -990,7 +990,7 @@ mod tests {
                 let (root, lookups) = parse(indoc! {r#"
                 In <em>a paragraph.</em>
                 "#});
-                check!(&root.children[0], Node::Paragraph(_), lookups => m_node!(MdqElem::Block::LeafBlock::Paragraph{body}) = {
+                check!(&root.children[0], Node::Paragraph(_), lookups => m_node!(MdElem::Block::LeafBlock::Paragraph{body}) = {
                     assert_eq!(body.len(), 4);
                     assert_eq!(body, vec![
                         mdq_inline!("In "),
@@ -1010,7 +1010,7 @@ mod tests {
                 In <em
                 newline  >a paragraph.</em>
                 "#});
-                check!(&root.children[0], Node::Paragraph(_), lookups => m_node!(MdqElem::Block::LeafBlock::Paragraph{body}) = {
+                check!(&root.children[0], Node::Paragraph(_), lookups => m_node!(MdElem::Block::LeafBlock::Paragraph{body}) = {
                     assert_eq!(body.len(), 4);
                     assert_eq!(body, vec![
                         mdq_inline!("In "),
@@ -1031,7 +1031,7 @@ mod tests {
             {
                 let (root, lookups) = parse("![]()");
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::Image(_), lookups => MdqElem::Inline(img) = {
+                check!(&p.children[0], Node::Image(_), lookups => MdElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "".to_string(),
                         link: LinkDefinition{
@@ -1045,7 +1045,7 @@ mod tests {
             {
                 let (root, lookups) = parse("![](https://example.com/foo.png)");
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::Image(_), lookups => MdqElem::Inline(img) = {
+                check!(&p.children[0], Node::Image(_), lookups => MdElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "".to_string(),
                         link: LinkDefinition{
@@ -1059,7 +1059,7 @@ mod tests {
             {
                 let (root, lookups) = parse("![alt text]()");
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::Image(_), lookups => MdqElem::Inline(img) = {
+                check!(&p.children[0], Node::Image(_), lookups => MdElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "alt text".to_string(),
                         link: LinkDefinition{
@@ -1073,7 +1073,7 @@ mod tests {
             {
                 let (root, lookups) = parse(r#"![](https://example.com/foo.png "my tooltip")"#);
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::Image(_), lookups => MdqElem::Inline(img) = {
+                check!(&p.children[0], Node::Image(_), lookups => MdElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "".to_string(),
                         link: LinkDefinition{
@@ -1087,7 +1087,7 @@ mod tests {
             {
                 // This isn't an image, though it almost looks like one
                 let (root, lookups) = parse(r#"![]("only a tooltip")"#);
-                check!(&root.children[0], Node::Paragraph(_), lookups => p @ m_node!(MdqElem::Block::LeafBlock::Paragraph{ .. }) = {
+                check!(&root.children[0], Node::Paragraph(_), lookups => p @ m_node!(MdElem::Block::LeafBlock::Paragraph{ .. }) = {
                     assert_eq!(p, md_elem!(r#"![]("only a tooltip")"#));
                 });
             }
@@ -1100,7 +1100,7 @@ mod tests {
                 let (root, lookups) = parse("[hello _world_](https://example.com)");
                 assert_eq!(root.children.len(), 1);
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::Link(_), lookups => MdqElem::Inline(link) = {
+                check!(&p.children[0], Node::Link(_), lookups => MdElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
@@ -1122,7 +1122,7 @@ mod tests {
                 let (root, lookups) = parse(r#"[hello _world_](https://example.com "the title")"#);
                 assert_eq!(root.children.len(), 1);
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::Link(_), lookups => MdqElem::Inline(link) = {
+                check!(&p.children[0], Node::Link(_), lookups => MdElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
@@ -1151,7 +1151,7 @@ mod tests {
                 );
                 assert_eq!(root.children.len(), 2);
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
@@ -1181,7 +1181,7 @@ mod tests {
                 );
                 assert_eq!(root.children.len(), 2);
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
@@ -1211,7 +1211,7 @@ mod tests {
                 );
                 assert_eq!(root.children.len(), 2);
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
@@ -1237,7 +1237,7 @@ mod tests {
                 let (root, lookups) = parse("<https://example.com>");
                 unwrap!(&root.children[0], Node::Paragraph(p));
                 assert_eq!(p.children.len(), 1);
-                check!(&p.children[0], Node::Link(_), lookups => MdqElem::Inline(Inline::Link{text, link_definition}) = {
+                check!(&p.children[0], Node::Link(_), lookups => MdElem::Inline(Inline::Link{text, link_definition}) = {
                     assert_eq!(text, vec![mdq_inline!("https://example.com")]);
                     assert_eq!(link_definition, LinkDefinition{
                         url: "https://example.com".to_string(),
@@ -1249,7 +1249,7 @@ mod tests {
                 let (root, lookups) = parse("<mailto:md@example.com>");
                 unwrap!(&root.children[0], Node::Paragraph(p));
                 assert_eq!(p.children.len(), 1);
-                check!(&p.children[0], Node::Link(_), lookups => MdqElem::Inline(Inline::Link{text, link_definition}) = {
+                check!(&p.children[0], Node::Link(_), lookups => MdElem::Inline(Inline::Link{text, link_definition}) = {
                     assert_eq!(text, vec![mdq_inline!("mailto:md@example.com")]);
                     assert_eq!(link_definition, LinkDefinition{
                         url: "mailto:md@example.com".to_string(),
@@ -1262,7 +1262,7 @@ mod tests {
                 let (root, lookups) = parse_with(&ParseOptions::default(), "https://example.com");
                 unwrap!(&root.children[0], Node::Paragraph(p));
                 assert_eq!(p.children.len(), 1);
-                check!(&p.children[0], Node::Text(_), lookups => MdqElem::Inline(Inline::Text{variant: TextVariant::Plain, value}) = {
+                check!(&p.children[0], Node::Text(_), lookups => MdElem::Inline(Inline::Text{variant: TextVariant::Plain, value}) = {
                     assert_eq!(value, "https://example.com".to_string());
                 });
             }
@@ -1271,7 +1271,7 @@ mod tests {
                 let (root, lookups) = parse_with(&ParseOptions::gfm(), "https://example.com");
                 unwrap!(&root.children[0], Node::Paragraph(p));
                 assert_eq!(p.children.len(), 1);
-                check!(&p.children[0], Node::Link(_), lookups => MdqElem::Inline(Inline::Link{text, link_definition}) = {
+                check!(&p.children[0], Node::Link(_), lookups => MdElem::Inline(Inline::Link{text, link_definition}) = {
                     assert_eq!(text, vec![mdq_inline!("https://example.com")]);
                     assert_eq!(link_definition, LinkDefinition{
                         url: "https://example.com".to_string(),
@@ -1290,7 +1290,7 @@ mod tests {
 
                     [1]: https://example.com/image.png"#});
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::ImageReference(_), lookups => MdqElem::Inline(img) = {
+                check!(&p.children[0], Node::ImageReference(_), lookups => MdElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "".to_string(),
                         link: LinkDefinition {
@@ -1308,7 +1308,7 @@ mod tests {
 
                     [1]: https://example.com/image.png "my title""#});
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::ImageReference(_), lookups => MdqElem::Inline(img) = {
+                check!(&p.children[0], Node::ImageReference(_), lookups => MdElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "".to_string(),
                         link: LinkDefinition {
@@ -1329,7 +1329,7 @@ mod tests {
                     [my alt]: https://example.com/image.png "my title""#},
                 );
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::ImageReference(_), lookups => MdqElem::Inline(img) = {
+                check!(&p.children[0], Node::ImageReference(_), lookups => MdElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "my alt".to_string(),
                         link: LinkDefinition {
@@ -1350,7 +1350,7 @@ mod tests {
                     [my alt]: https://example.com/image.png"#},
                 );
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::ImageReference(_), lookups => MdqElem::Inline(img) = {
+                check!(&p.children[0], Node::ImageReference(_), lookups => MdElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "my alt".to_string(),
                         link: LinkDefinition {
@@ -1373,7 +1373,7 @@ mod tests {
 
                     [1]: https://example.com/image.png"#});
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![],
                         link_definition: LinkDefinition {
@@ -1391,7 +1391,7 @@ mod tests {
 
                     [1]: https://example.com/image.png "my title""#});
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![],
                         link_definition: LinkDefinition {
@@ -1412,7 +1412,7 @@ mod tests {
                     [_my_ text]: https://example.com/image.png "my title""#},
                 );
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             Inline::Span{
@@ -1442,7 +1442,7 @@ mod tests {
                     [my text]: https://example.com/image.png"#},
                 );
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             Inline::Text {variant: TextVariant::Plain,value: "my text".to_string()},
@@ -1468,7 +1468,7 @@ mod tests {
                     plain code block
                     ```"#},
                 );
-                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
+                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                     assert_eq!(variant, CodeVariant::Code(None));
                     assert_eq!(value, "plain code block");
                 })
@@ -1481,7 +1481,7 @@ mod tests {
                     code block with language
                     ```"#},
                 );
-                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
+                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                     assert_eq!(variant, CodeVariant::Code(Some(CodeOpts{
                         language: "rust".to_string(),
                         metadata: None})));
@@ -1496,7 +1496,7 @@ mod tests {
                     code block with language and title
                     ```"#},
                 );
-                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
+                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                     assert_eq!(variant, CodeVariant::Code(Some(CodeOpts{
                         language: "rust".to_string(),
                         metadata: Some(r#"title="example.rs""#.to_string())})));
@@ -1511,7 +1511,7 @@ mod tests {
                     code block with only title
                     ```"#},
                 );
-                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
+                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                     // It's actually just a bogus language!
                     assert_eq!(variant, CodeVariant::Code(Some(CodeOpts{
                         language: r#"title="example.rs""#.to_string(),
@@ -1533,7 +1533,7 @@ mod tests {
                     x = {-b \pm \sqrt{b^2-4ac} \over 2a}
                     $$"#},
                 );
-                check!(&root.children[0], Node::Math(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
+                check!(&root.children[0], Node::Math(_), lookups => m_node!(MdElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                     assert_eq!(variant, CodeVariant::Math{metadata: None});
                     assert_eq!(value, r#"x = {-b \pm \sqrt{b^2-4ac} \over 2a}"#);
                 })
@@ -1546,7 +1546,7 @@ mod tests {
                     x = {-b \pm \sqrt{b^2-4ac} \over 2a}
                     $$"#},
                 );
-                check!(&root.children[0], Node::Math(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
+                check!(&root.children[0], Node::Math(_), lookups => m_node!(MdElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                     assert_eq!(variant, CodeVariant::Math{metadata: Some("my metadata".to_string())});
                     assert_eq!(value, r#"x = {-b \pm \sqrt{b^2-4ac} \over 2a}"#);
                 })
@@ -1564,7 +1564,7 @@ mod tests {
                 my: toml
                 +++"#},
             );
-            check!(&root.children[0], Node::Toml(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
+            check!(&root.children[0], Node::Toml(_), lookups => m_node!(MdElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                 assert_eq!(variant, CodeVariant::Toml);
                 assert_eq!(value, r#"my: toml"#);
             })
@@ -1581,7 +1581,7 @@ mod tests {
                 my: toml
                 ---"#},
             );
-            check!(&root.children[0], Node::Yaml(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
+            check!(&root.children[0], Node::Yaml(_), lookups => m_node!(MdElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                 assert_eq!(variant, CodeVariant::Yaml);
                 assert_eq!(value, r#"my: toml"#);
             })
@@ -1596,7 +1596,7 @@ mod tests {
                     And some text below it."#},
             );
 
-            let (header_depth, header_title) = check!(&root.children[0], Node::Heading(_), lookups => m_node!(MdqElem::Block::Container::Section{depth, title, body}) = {
+            let (header_depth, header_title) = check!(&root.children[0], Node::Heading(_), lookups => m_node!(MdElem::Block::Container::Section{depth, title, body}) = {
                 assert_eq!(depth, 2);
                 assert_eq!(title, vec![
                     Inline::Text { variant: TextVariant::Plain, value: "Header with ".to_string()},
@@ -1615,11 +1615,11 @@ mod tests {
 
             let mdast_root = Node::Root(root); // reconstruct it, since parse_with unwrapped it
             NODES_CHECKER.see(&mdast_root);
-            let mdqs = MdqElem::from_mdast_0(mdast_root, &lookups).unwrap();
+            let mdqs = MdElem::from_mdast_0(mdast_root, &lookups).unwrap();
 
             assert_eq!(
                 mdqs,
-                vec![m_node!(MdqElem::Block::Container::Section {
+                vec![m_node!(MdElem::Block::Container::Section {
                     depth: header_depth,
                     title: header_title,
                     body: md_elems!["And some text below it."],
@@ -1641,7 +1641,7 @@ mod tests {
             );
 
             assert_eq!(root.children.len(), 3);
-            check!(&root.children[1], Node::ThematicBreak(_), lookups => m_node!(MdqElem::Block::LeafBlock::ThematicBreak) = {
+            check!(&root.children[1], Node::ThematicBreak(_), lookups => m_node!(MdElem::Block::LeafBlock::ThematicBreak) = {
                 // nothing to check
             });
         }
@@ -1660,7 +1660,7 @@ mod tests {
                     "#},
             );
             assert_eq!(root.children.len(), 1);
-            check!(&root.children[0], Node::Table(table_node), lookups => m_node!(MdqElem::Block::LeafBlock::Table{alignments, rows}) = {
+            check!(&root.children[0], Node::Table(table_node), lookups => m_node!(MdElem::Block::LeafBlock::Table{alignments, rows}) = {
                 assert_eq!(alignments, vec![mdast::AlignKind::Left, mdast::AlignKind::Center, mdast::AlignKind::Right, mdast::AlignKind::None]);
                 assert_eq!(rows,
                     vec![ // rows
@@ -1909,31 +1909,31 @@ mod tests {
         #[test]
         fn h1_with_two_paragraphs() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("first")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                m_node!(MdElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("aaa")],
                 }),
-                m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                m_node!(MdElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("bbb")],
                 }),
             ];
-            let expect = vec![m_node!(MdqElem::Block::Container::Section {
+            let expect = vec![m_node!(MdElem::Block::Container::Section {
                 depth: 1,
                 title: vec![mdq_inline!("first")],
                 body: vec![
-                    m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                    m_node!(MdElem::Block::LeafBlock::Paragraph {
                         body: vec![mdq_inline!("aaa")],
                     }),
-                    m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                    m_node!(MdElem::Block::LeafBlock::Paragraph {
                         body: vec![mdq_inline!("bbb")],
                     }),
                 ],
             })];
-            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }
@@ -1941,32 +1941,32 @@ mod tests {
         #[test]
         fn simple_nesting() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("first")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("aaa")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                m_node!(MdElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("bbb")],
                 }),
             ];
-            let expect = vec![m_node!(MdqElem::Block::Container::Section {
+            let expect = vec![m_node!(MdElem::Block::Container::Section {
                 depth: 1,
                 title: vec![mdq_inline!("first")],
-                body: vec![m_node!(MdqElem::Block::Container::Section {
+                body: vec![m_node!(MdElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("aaa")],
-                    body: vec![m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                    body: vec![m_node!(MdElem::Block::LeafBlock::Paragraph {
                         body: vec![mdq_inline!("bbb")],
                     })],
                 })],
             })];
-            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }
@@ -1974,60 +1974,60 @@ mod tests {
         #[test]
         fn only_headers() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("first")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("second")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("third")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("fourth")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("fifth")],
                     body: vec![],
                 }),
             ];
-            let expect = vec![m_node!(MdqElem::Block::Container::Section {
+            let expect = vec![m_node!(MdElem::Block::Container::Section {
                 depth: 1,
                 title: vec![mdq_inline!("first")],
                 body: vec![
-                    m_node!(MdqElem::Block::Container::Section {
+                    m_node!(MdElem::Block::Container::Section {
                         depth: 2,
                         title: vec![mdq_inline!("second")],
                         body: vec![
-                            m_node!(MdqElem::Block::Container::Section {
+                            m_node!(MdElem::Block::Container::Section {
                                 depth: 3,
                                 title: vec![mdq_inline!("third")],
                                 body: vec![],
                             }),
-                            m_node!(MdqElem::Block::Container::Section {
+                            m_node!(MdElem::Block::Container::Section {
                                 depth: 3,
                                 title: vec![mdq_inline!("fourth")],
                                 body: vec![],
                             }),
                         ],
                     }),
-                    m_node!(MdqElem::Block::Container::Section {
+                    m_node!(MdElem::Block::Container::Section {
                         depth: 2,
                         title: vec![mdq_inline!("fifth")],
                         body: vec![],
                     }),
                 ],
             })];
-            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }
@@ -2035,22 +2035,22 @@ mod tests {
         #[test]
         fn no_headers() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                m_node!(MdElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("one")],
                 }),
-                m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                m_node!(MdElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("two")],
                 }),
             ];
             let expect = vec![
-                m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                m_node!(MdElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("one")],
                 }),
-                m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                m_node!(MdElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("two")],
                 }),
             ];
-            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }
@@ -2058,40 +2058,40 @@ mod tests {
         #[test]
         fn header_skips() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("one")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 5,
                     title: vec![mdq_inline!("five")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("two")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("three")],
                     body: vec![],
                 }),
             ];
-            let expect = vec![m_node!(MdqElem::Block::Container::Section {
+            let expect = vec![m_node!(MdElem::Block::Container::Section {
                 depth: 1,
                 title: vec![mdq_inline!("one")],
                 body: vec![
-                    m_node!(MdqElem::Block::Container::Section {
+                    m_node!(MdElem::Block::Container::Section {
                         depth: 5,
                         title: vec![mdq_inline!("five")],
                         body: vec![],
                     }),
-                    m_node!(MdqElem::Block::Container::Section {
+                    m_node!(MdElem::Block::Container::Section {
                         depth: 2,
                         title: vec![mdq_inline!("two")],
-                        body: vec![m_node!(MdqElem::Block::Container::Section {
+                        body: vec![m_node!(MdElem::Block::Container::Section {
                             depth: 3,
                             title: vec![mdq_inline!("three")],
                             body: vec![],
@@ -2099,7 +2099,7 @@ mod tests {
                     }),
                 ],
             })];
-            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }
@@ -2107,40 +2107,40 @@ mod tests {
         #[test]
         fn backwards_order() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("three")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("two")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("one")],
                     body: vec![],
                 }),
             ];
             let expect = vec![
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("three")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("two")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("one")],
                     body: vec![],
                 }),
             ];
-            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }
@@ -2148,31 +2148,31 @@ mod tests {
         #[test]
         fn paragraph_before_and_after_header() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                m_node!(MdElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("before")],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("the header")],
                     body: vec![],
                 }),
-                m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                m_node!(MdElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("after")],
                 }),
             ];
             let expect = vec![
-                m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                m_node!(MdElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("before")],
                 }),
-                m_node!(MdqElem::Block::Container::Section {
+                m_node!(MdElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("the header")],
-                    body: vec![m_node!(MdqElem::Block::LeafBlock::Paragraph {
+                    body: vec![m_node!(MdElem::Block::LeafBlock::Paragraph {
                         body: vec![mdq_inline!("after")],
                     })],
                 }),
             ];
-            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -7,7 +7,7 @@ use std::vec::IntoIter;
 use markdown::mdast;
 
 #[derive(Debug, PartialEq)]
-pub enum MdqNode {
+pub enum MdqElem {
     Block(Block),
     Inline(Inline),
 }
@@ -37,7 +37,7 @@ pub enum Container {
 pub struct Section {
     pub depth: u8,
     pub title: Vec<Inline>,
-    pub body: Vec<MdqNode>,
+    pub body: Vec<MdqElem>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -47,7 +47,7 @@ pub struct Paragraph {
 
 #[derive(Debug, PartialEq)]
 pub struct BlockQuote {
-    pub body: Vec<MdqNode>,
+    pub body: Vec<MdqElem>,
 }
 
 #[derive(Debug, PartialEq)]
@@ -144,7 +144,7 @@ pub enum Inline {
 #[derive(Debug)]
 pub struct Footnote {
     pub label: String,
-    pub text: Vec<MdqNode>,
+    pub text: Vec<MdqElem>,
 }
 
 /// Note that [Footnote]'s [Eq] and [Hash] only key off of its label, _not_ its text content.
@@ -176,7 +176,7 @@ pub struct LinkDefinition {
 #[derive(Debug, PartialEq)]
 pub struct ListItem {
     pub checked: Option<bool>,
-    pub item: Vec<MdqNode>,
+    pub item: Vec<MdqElem>,
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
@@ -255,7 +255,7 @@ macro_rules! m_node {
     };
 }
 
-impl MdqNode {
+impl MdqElem {
     pub fn read(node: mdast::Node, opts: &ReadOptions) -> Result<Vec<Self>, InvalidMd> {
         let lookups = Lookups::new(&node, opts)?;
         Self::from_mdast_0(node, &lookups)
@@ -263,9 +263,9 @@ impl MdqNode {
 
     fn from_mdast_0(node: mdast::Node, lookups: &Lookups) -> Result<Vec<Self>, InvalidMd> {
         let result = match node {
-            mdast::Node::Root(node) => return MdqNode::all(node.children, lookups),
-            mdast::Node::BlockQuote(node) => m_node!(MdqNode::Block::Container::BlockQuote {
-                body: MdqNode::all(node.children, lookups)?,
+            mdast::Node::Root(node) => return MdqElem::all(node.children, lookups),
+            mdast::Node::BlockQuote(node) => m_node!(MdqElem::Block::Container::BlockQuote {
+                body: MdqElem::all(node.children, lookups)?,
             }),
             mdast::Node::FootnoteDefinition(_) => return Ok(Vec::new()),
             mdast::Node::List(node) => {
@@ -276,36 +276,36 @@ impl MdqNode {
                     };
                     let li_mdq = ListItem {
                         checked: li_node.checked,
-                        item: MdqNode::all(li_node.children, lookups)?,
+                        item: MdqElem::all(li_node.children, lookups)?,
                     };
                     li_nodes.push(li_mdq);
                 }
-                m_node!(MdqNode::Block::Container::List {
+                m_node!(MdqElem::Block::Container::List {
                     starting_index: node.start,
                     items: li_nodes,
                 })
             }
-            mdast::Node::Break(_) => MdqNode::Inline(Inline::Text {
+            mdast::Node::Break(_) => MdqElem::Inline(Inline::Text {
                 variant: TextVariant::Plain,
                 value: "\n".to_string(),
             }),
-            mdast::Node::InlineCode(node) => MdqNode::Inline(Inline::Text {
+            mdast::Node::InlineCode(node) => MdqElem::Inline(Inline::Text {
                 variant: TextVariant::Code,
                 value: node.value,
             }),
-            mdast::Node::InlineMath(node) => MdqNode::Inline(Inline::Text {
+            mdast::Node::InlineMath(node) => MdqElem::Inline(Inline::Text {
                 variant: TextVariant::Math,
                 value: node.value,
             }),
-            mdast::Node::Delete(node) => MdqNode::Inline(Inline::Span {
+            mdast::Node::Delete(node) => MdqElem::Inline(Inline::Span {
                 variant: SpanVariant::Delete,
-                children: MdqNode::inlines(node.children, lookups)?,
+                children: MdqElem::inlines(node.children, lookups)?,
             }),
-            mdast::Node::Emphasis(node) => MdqNode::Inline(Inline::Span {
+            mdast::Node::Emphasis(node) => MdqElem::Inline(Inline::Span {
                 variant: SpanVariant::Emphasis,
-                children: MdqNode::inlines(node.children, lookups)?,
+                children: MdqElem::inlines(node.children, lookups)?,
             }),
-            mdast::Node::Image(node) => MdqNode::Inline(Inline::Image {
+            mdast::Node::Image(node) => MdqElem::Inline(Inline::Image {
                 alt: node.alt,
                 link: LinkDefinition {
                     url: node.url,
@@ -313,40 +313,40 @@ impl MdqNode {
                     reference: LinkReference::Inline,
                 },
             }),
-            mdast::Node::ImageReference(node) => MdqNode::Inline(Inline::Image {
+            mdast::Node::ImageReference(node) => MdqElem::Inline(Inline::Image {
                 alt: node.alt,
                 link: lookups.resolve_link(node.identifier, node.label, node.reference_kind)?,
             }),
-            mdast::Node::Link(node) => MdqNode::Inline(Inline::Link {
-                text: MdqNode::inlines(node.children, lookups)?,
+            mdast::Node::Link(node) => MdqElem::Inline(Inline::Link {
+                text: MdqElem::inlines(node.children, lookups)?,
                 link_definition: LinkDefinition {
                     url: node.url,
                     title: node.title,
                     reference: LinkReference::Inline,
                 },
             }),
-            mdast::Node::LinkReference(node) => MdqNode::Inline(Inline::Link {
-                text: MdqNode::inlines(node.children, lookups)?,
+            mdast::Node::LinkReference(node) => MdqElem::Inline(Inline::Link {
+                text: MdqElem::inlines(node.children, lookups)?,
                 link_definition: lookups.resolve_link(node.identifier, node.label, node.reference_kind)?,
             }),
             mdast::Node::FootnoteReference(node) => {
                 let definition = lookups.resolve_footnote(&node.identifier, &node.label)?;
-                MdqNode::Inline(Inline::Footnote(Footnote {
+                MdqElem::Inline(Inline::Footnote(Footnote {
                     label: node.label.unwrap_or(node.identifier),
-                    text: MdqNode::all(definition.children.clone(), lookups)?,
+                    text: MdqElem::all(definition.children.clone(), lookups)?,
                 }))
             }
-            mdast::Node::Strong(node) => MdqNode::Inline(Inline::Span {
+            mdast::Node::Strong(node) => MdqElem::Inline(Inline::Span {
                 variant: SpanVariant::Strong,
-                children: MdqNode::inlines(node.children, lookups)?,
+                children: MdqElem::inlines(node.children, lookups)?,
             }),
-            mdast::Node::Text(node) => MdqNode::Inline(Inline::Text {
+            mdast::Node::Text(node) => MdqElem::Inline(Inline::Text {
                 variant: TextVariant::Plain,
                 value: node.value,
             }),
             mdast::Node::Code(node) => {
                 let mdast::Code { value, lang, meta, .. } = node;
-                m_node!(MdqNode::Block::LeafBlock::CodeBlock {
+                m_node!(MdqElem::Block::LeafBlock::CodeBlock {
                     value,
                     variant: CodeVariant::Code(match lang {
                         None => None,
@@ -359,12 +359,12 @@ impl MdqNode {
             }
             mdast::Node::Math(node) => {
                 let mdast::Math { value, meta, .. } = node;
-                m_node!(MdqNode::Block::LeafBlock::CodeBlock {
+                m_node!(MdqElem::Block::LeafBlock::CodeBlock {
                     value,
                     variant: CodeVariant::Math { metadata: meta },
                 })
             }
-            mdast::Node::Heading(node) => m_node!(MdqNode::Block::Container::Section {
+            mdast::Node::Heading(node) => m_node!(MdqElem::Block::Container::Section {
                 depth: node.depth,
                 title: Self::inlines(node.children, lookups)?,
                 body: Vec::new(),
@@ -389,28 +389,28 @@ impl MdqNode {
                     }
                     rows.push(column);
                 }
-                m_node!(MdqNode::Block::LeafBlock::Table {
+                m_node!(MdqElem::Block::LeafBlock::Table {
                     alignments: align,
                     rows,
                 })
             }
-            mdast::Node::ThematicBreak(_) => m_node!(MdqNode::Block::LeafBlock::ThematicBreak),
+            mdast::Node::ThematicBreak(_) => m_node!(MdqElem::Block::LeafBlock::ThematicBreak),
             mdast::Node::TableRow(_) | mdast::Node::TableCell(_) | mdast::Node::ListItem(_) => {
                 return Err(InvalidMd::InternalError); // should have been handled by Node::Table
             }
             mdast::Node::Definition(_) => return Ok(Vec::new()),
-            mdast::Node::Paragraph(node) => m_node!(MdqNode::Block::LeafBlock::Paragraph {
+            mdast::Node::Paragraph(node) => m_node!(MdqElem::Block::LeafBlock::Paragraph {
                 body: Self::inlines(node.children, lookups)?,
             }),
-            mdast::Node::Toml(node) => m_node!(MdqNode::Block::LeafBlock::CodeBlock {
+            mdast::Node::Toml(node) => m_node!(MdqElem::Block::LeafBlock::CodeBlock {
                 variant: CodeVariant::Toml,
                 value: node.value,
             }),
-            mdast::Node::Yaml(node) => m_node!(MdqNode::Block::LeafBlock::CodeBlock {
+            mdast::Node::Yaml(node) => m_node!(MdqElem::Block::LeafBlock::CodeBlock {
                 variant: CodeVariant::Yaml,
                 value: node.value,
             }),
-            mdast::Node::Html(node) => MdqNode::Inline(Inline::Text {
+            mdast::Node::Html(node) => MdqElem::Inline(Inline::Text {
                 variant: TextVariant::Html,
                 value: node.value,
             }),
@@ -434,7 +434,7 @@ impl MdqNode {
 
     fn all_from_iter<I>(iter: I) -> Result<Vec<Self>, InvalidMd>
     where
-        I: Iterator<Item = Result<MdqNode, InvalidMd>>,
+        I: Iterator<Item = Result<MdqElem, InvalidMd>>,
     {
         // This is just a struct that reflects the struct-variant of MdqNode::Header. If that
         // enum variant used the tuple-style with an explicitly defined struct, we wouldn't need
@@ -442,14 +442,14 @@ impl MdqNode {
         struct HContainer {
             depth: u8,
             title: Vec<Inline>,
-            children: Vec<MdqNode>,
+            children: Vec<MdqElem>,
         }
 
         let mut result = Vec::with_capacity(16); // arbitrary capacity guess
         let mut headers: Vec<HContainer> = Vec::with_capacity(result.capacity());
         for child_mdq in iter {
             let child_mdq = child_mdq?;
-            if let m_node!(MdqNode::Block::Container::Section {
+            if let m_node!(MdqElem::Block::Container::Section {
                 depth,
                 title,
                 body: children,
@@ -473,7 +473,7 @@ impl MdqNode {
                         // to the new previous, or else to the top-level results if there is no new
                         // previous. Then, we'll just loop back around.
                         let HContainer { depth, title, children } = headers.pop().unwrap(); // "let Some(prev)" above guarantees that this works
-                        let prev = m_node!(MdqNode::Block::Container::Section {
+                        let prev = m_node!(MdqElem::Block::Container::Section {
                             depth,
                             title,
                             body: children,
@@ -499,7 +499,7 @@ impl MdqNode {
 
         // At this point, we still have our last tree branch of headers. Fold it up into the results.
         while let Some(HContainer { depth, title, children }) = headers.pop() {
-            let mdq_header = m_node!(MdqNode::Block::Container::Section {
+            let mdq_header = m_node!(MdqElem::Block::Container::Section {
                 depth,
                 title,
                 body: children,
@@ -514,7 +514,7 @@ impl MdqNode {
         headers
             .drain(..)
             .map(|HContainer { depth, title, children }| {
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth,
                     title,
                     body: children,
@@ -530,7 +530,7 @@ impl MdqNode {
         let mdq_children = Self::all(children, lookups)?;
         let mut result = Vec::with_capacity(mdq_children.len());
         for child in mdq_children {
-            let MdqNode::Inline(inline) = child else {
+            let MdqElem::Inline(inline) = child else {
                 return Err(InvalidMd::NonInlineWhereInlineExpected);
             };
             // If both this and the previous were plain text, then just combine the texts. This can happen if there was
@@ -560,7 +560,7 @@ where
     I: Iterator<Item = mdast::Node>,
 {
     children: I,
-    pending: IntoIter<MdqNode>,
+    pending: IntoIter<MdqElem>,
     lookups: &'a Lookups,
 }
 
@@ -568,7 +568,7 @@ impl<'a, I> Iterator for NodeToMdqIter<'a, I>
 where
     I: Iterator<Item = mdast::Node>,
 {
-    type Item = Result<MdqNode, InvalidMd>;
+    type Item = Result<MdqElem, InvalidMd>;
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
@@ -578,7 +578,7 @@ where
             let Some(next_node) = self.children.next() else {
                 return None;
             };
-            match MdqNode::from_mdast_0(next_node, self.lookups) {
+            match MdqElem::from_mdast_0(next_node, self.lookups) {
                 Ok(mdq_node) => {
                     self.pending = mdq_node.into_iter();
                 }
@@ -699,9 +699,9 @@ impl Lookups {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::md_elem;
+    use crate::md_elems;
     use crate::mdq_inline;
-    use crate::mdq_node;
-    use crate::mdq_nodes;
 
     ///  tests of each mdast node type
     ///
@@ -722,7 +722,7 @@ mod tests {
                 NODES_CHECKER.see(&node);
                 unwrap!(node, $enum_variant);
                 let node_clone = node.clone();
-                let mdq_err = MdqNode::from_mdast_0(node_clone, &$lookups).err().expect("expected no MdqNode");
+                let mdq_err = MdqElem::from_mdast_0(node_clone, &$lookups).err().expect("expected no MdqNode");
                 assert_eq!(mdq_err, $err);
                 $($body)?
             }};
@@ -732,7 +732,7 @@ mod tests {
                 NODES_CHECKER.see(&node);
                 unwrap!(node, $enum_variant);
                 let node_clone = node.clone();
-                let mdqs = MdqNode::from_mdast_0(node_clone, &$lookups).unwrap();
+                let mdqs = MdqElem::from_mdast_0(node_clone, &$lookups).unwrap();
                 assert_eq!(mdqs, Vec::new());
             }};
 
@@ -741,7 +741,7 @@ mod tests {
                 NODES_CHECKER.see(&node);
                 unwrap!(node, $enum_variant);
                 let node_clone = node.clone();
-                let mut mdqs = MdqNode::from_mdast_0(node_clone, &$lookups).unwrap();
+                let mut mdqs = MdqElem::from_mdast_0(node_clone, &$lookups).unwrap();
                 assert_eq!(mdqs.len(), 1, "expected exactly one element, but found: {:?}", mdqs);
                 let mdq = mdqs.pop().unwrap();
                 if let $mdq_pat = mdq $mdq_body else {
@@ -760,8 +760,8 @@ mod tests {
         fn block_quote() {
             let (root, lookups) = parse("> hello");
             let child = &root.children[0];
-            check!(child, Node::BlockQuote(_), lookups => m_node!(MdqNode::Block::Container::BlockQuote{body}) = {
-                assert_eq!(body, mdq_nodes!["hello"]);
+            check!(child, Node::BlockQuote(_), lookups => m_node!(MdqElem::Block::Container::BlockQuote{body}) = {
+                assert_eq!(body, md_elems!["hello"]);
             });
         }
 
@@ -777,10 +777,10 @@ mod tests {
                       with two lines."#},
                 );
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[1], Node::FootnoteReference(_), lookups => MdqNode::Inline(footnote) = {
+                check!(&p.children[1], Node::FootnoteReference(_), lookups => MdqElem::Inline(footnote) = {
                     assert_eq!(footnote, Inline::Footnote(Footnote{
                         label: "a".to_string(),
-                        text: mdq_nodes!["My footnote\nwith two lines."],
+                        text: md_elems!["My footnote\nwith two lines."],
                     }))
                 });
                 check!(no_node: &root.children[1], Node::FootnoteDefinition(_), lookups);
@@ -795,16 +795,16 @@ mod tests {
                 );
                 unwrap!(&root.children[0], Node::Paragraph(p));
 
-                check!(&p.children[1], Node::FootnoteReference(_), lookups => MdqNode::Inline(footnote) = {
+                check!(&p.children[1], Node::FootnoteReference(_), lookups => MdqElem::Inline(footnote) = {
                     assert_eq!(footnote, Inline::Footnote(Footnote{
                         label: "a".to_string(),
                         text: vec![
-                            m_node!(MdqNode::Block::Container::List{
+                            m_node!(MdqElem::Block::Container::List{
                                 starting_index: None,
                                 items: vec![
                                     ListItem{
                                         checked: None,
-                                        item: mdq_nodes!["footnote is a list"],
+                                        item: md_elems!["footnote is a list"],
                                     }
                                 ],
                             }),
@@ -833,7 +833,7 @@ mod tests {
             );
             assert_eq!(root.children.len(), 2); // unordered list, then ordered
 
-            check!(&root.children[0], Node::List(ul), lookups => m_node!(MdqNode::Block::Container::List{starting_index, items}) = {
+            check!(&root.children[0], Node::List(ul), lookups => m_node!(MdqElem::Block::Container::List{starting_index, items}) = {
                 for child in &ul.children {
                     check!(error: child, Node::ListItem(_), lookups => InvalidMd::InternalError);
                 }
@@ -841,19 +841,19 @@ mod tests {
                 assert_eq!(items, vec![
                     ListItem {
                         checked: None,
-                        item: mdq_nodes!["First"],
+                        item: md_elems!["First"],
                     },
                     ListItem {
                         checked: Some(false),
-                        item: mdq_nodes!["Second"],
+                        item: md_elems!["Second"],
                     },
                     ListItem {
                         checked: Some(true),
-                        item: mdq_nodes!["Third\nWith a line break"],
+                        item: md_elems!["Third\nWith a line break"],
                     },
                 ]);
             });
-            check!(&root.children[1], Node::List(ol), lookups => m_node!(MdqNode::Block::Container::List{starting_index, items}) = {
+            check!(&root.children[1], Node::List(ol), lookups => m_node!(MdqElem::Block::Container::List{starting_index, items}) = {
                 for child in &ol.children {
                     check!(error: child, Node::ListItem(_), lookups => InvalidMd::InternalError);
                 }
@@ -861,15 +861,15 @@ mod tests {
                 assert_eq!(items, vec![
                     ListItem {
                         checked: None,
-                        item: mdq_nodes!["Fourth"],
+                        item: md_elems!["Fourth"],
                     },
                     ListItem {
                         checked: Some(false),
-                        item: mdq_nodes!["Fifth"],
+                        item: md_elems!["Fifth"],
                     },
                     ListItem {
                         checked: Some(true),
-                        item: mdq_nodes![
+                        item: md_elems![
                             "Sixth",
                             "With a paragraph",
                         ],
@@ -888,15 +888,15 @@ mod tests {
                 "#},
             );
 
-            check!(&root.children[0], Node::Paragraph(p), lookups => m_node!(MdqNode::Block::LeafBlock::Paragraph{body}) = {
+            check!(&root.children[0], Node::Paragraph(p), lookups => m_node!(MdqElem::Block::LeafBlock::Paragraph{body}) = {
                 assert_eq!(p.children.len(), 3);
-                check!(&p.children[0], Node::Text(_), lookups => MdqNode::Inline(text) = {
+                check!(&p.children[0], Node::Text(_), lookups => MdqElem::Inline(text) = {
                     assert_eq!(text, Inline::Text {variant: TextVariant::Plain, value: "hello ".to_string()});
                 });
-                check!(&p.children[1], Node::Break(_), lookups => MdqNode::Inline(text) = {
+                check!(&p.children[1], Node::Break(_), lookups => MdqElem::Inline(text) = {
                     assert_eq!(text, Inline::Text {variant: TextVariant::Plain, value: "\n".to_string()});
                 });
-                check!(&p.children[2], Node::Text(_), lookups => MdqNode::Inline(text) = {
+                check!(&p.children[2], Node::Text(_), lookups => MdqElem::Inline(text) = {
                     assert_eq!(text, Inline::Text {variant: TextVariant::Plain, value: "world".to_string()});
                 });
                 assert_eq!(body, vec![
@@ -911,7 +911,7 @@ mod tests {
             let (root, lookups) = parse("`foo`");
 
             unwrap!(&root.children[0], Node::Paragraph(p));
-            check!(&p.children[0], Node::InlineCode(_), lookups => MdqNode::Inline(inline) = {
+            check!(&p.children[0], Node::InlineCode(_), lookups => MdqElem::Inline(inline) = {
                 assert_eq!(inline, Inline::Text { variant: TextVariant::Code, value: "foo".to_string() });
             });
         }
@@ -923,7 +923,7 @@ mod tests {
             let (root, lookups) = parse_with(&opts, r#"$ 0 \ne 1 $"#);
 
             unwrap!(&root.children[0], Node::Paragraph(p));
-            check!(&p.children[0], Node::InlineMath(_), lookups => MdqNode::Inline(inline) = {
+            check!(&p.children[0], Node::InlineMath(_), lookups => MdqElem::Inline(inline) = {
                 assert_eq!(inline, Inline::Text { variant: TextVariant::Math, value: r#" 0 \ne 1 "#.to_string() });
             });
         }
@@ -933,7 +933,7 @@ mod tests {
             let (root, lookups) = parse_with(&ParseOptions::gfm(), "~~86 me~~");
 
             unwrap!(&root.children[0], Node::Paragraph(p));
-            check!(&p.children[0], Node::Delete(_), lookups => MdqNode::Inline(inline) = {
+            check!(&p.children[0], Node::Delete(_), lookups => MdqElem::Inline(inline) = {
                 assert_eq!(inline, Inline::Span {
                     variant: SpanVariant::Delete,
                     children: vec![
@@ -948,7 +948,7 @@ mod tests {
             let (root, lookups) = parse("_86 me_");
 
             unwrap!(&root.children[0], Node::Paragraph(p));
-            check!(&p.children[0], Node::Emphasis(_), lookups => MdqNode::Inline(inline) = {
+            check!(&p.children[0], Node::Emphasis(_), lookups => MdqElem::Inline(inline) = {
                 assert_eq!(inline, Inline::Span {
                     variant: SpanVariant::Emphasis,
                     children: vec![
@@ -963,7 +963,7 @@ mod tests {
             let (root, lookups) = parse("**strongman**");
 
             unwrap!(&root.children[0], Node::Paragraph(p));
-            check!(&p.children[0], Node::Strong(_), lookups => MdqNode::Inline(inline) = {
+            check!(&p.children[0], Node::Strong(_), lookups => MdqElem::Inline(inline) = {
                 assert_eq!(inline, Inline::Span {
                     variant: SpanVariant::Strong,
                     children: vec![
@@ -978,7 +978,7 @@ mod tests {
             {
                 let (root, lookups) = parse("<a href>");
 
-                check!(&root.children[0], Node::Html(_), lookups => MdqNode::Inline(inline) = {
+                check!(&root.children[0], Node::Html(_), lookups => MdqElem::Inline(inline) = {
                     assert_eq!(inline, Inline::Text {
                         variant: TextVariant::Html,
                         value: "<a href>".to_string(),
@@ -990,7 +990,7 @@ mod tests {
                 let (root, lookups) = parse(indoc! {r#"
                 In <em>a paragraph.</em>
                 "#});
-                check!(&root.children[0], Node::Paragraph(_), lookups => m_node!(MdqNode::Block::LeafBlock::Paragraph{body}) = {
+                check!(&root.children[0], Node::Paragraph(_), lookups => m_node!(MdqElem::Block::LeafBlock::Paragraph{body}) = {
                     assert_eq!(body.len(), 4);
                     assert_eq!(body, vec![
                         mdq_inline!("In "),
@@ -1010,7 +1010,7 @@ mod tests {
                 In <em
                 newline  >a paragraph.</em>
                 "#});
-                check!(&root.children[0], Node::Paragraph(_), lookups => m_node!(MdqNode::Block::LeafBlock::Paragraph{body}) = {
+                check!(&root.children[0], Node::Paragraph(_), lookups => m_node!(MdqElem::Block::LeafBlock::Paragraph{body}) = {
                     assert_eq!(body.len(), 4);
                     assert_eq!(body, vec![
                         mdq_inline!("In "),
@@ -1031,7 +1031,7 @@ mod tests {
             {
                 let (root, lookups) = parse("![]()");
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::Image(_), lookups => MdqNode::Inline(img) = {
+                check!(&p.children[0], Node::Image(_), lookups => MdqElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "".to_string(),
                         link: LinkDefinition{
@@ -1045,7 +1045,7 @@ mod tests {
             {
                 let (root, lookups) = parse("![](https://example.com/foo.png)");
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::Image(_), lookups => MdqNode::Inline(img) = {
+                check!(&p.children[0], Node::Image(_), lookups => MdqElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "".to_string(),
                         link: LinkDefinition{
@@ -1059,7 +1059,7 @@ mod tests {
             {
                 let (root, lookups) = parse("![alt text]()");
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::Image(_), lookups => MdqNode::Inline(img) = {
+                check!(&p.children[0], Node::Image(_), lookups => MdqElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "alt text".to_string(),
                         link: LinkDefinition{
@@ -1073,7 +1073,7 @@ mod tests {
             {
                 let (root, lookups) = parse(r#"![](https://example.com/foo.png "my tooltip")"#);
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::Image(_), lookups => MdqNode::Inline(img) = {
+                check!(&p.children[0], Node::Image(_), lookups => MdqElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "".to_string(),
                         link: LinkDefinition{
@@ -1087,8 +1087,8 @@ mod tests {
             {
                 // This isn't an image, though it almost looks like one
                 let (root, lookups) = parse(r#"![]("only a tooltip")"#);
-                check!(&root.children[0], Node::Paragraph(_), lookups => p @ m_node!(MdqNode::Block::LeafBlock::Paragraph{ .. }) = {
-                    assert_eq!(p, mdq_node!(r#"![]("only a tooltip")"#));
+                check!(&root.children[0], Node::Paragraph(_), lookups => p @ m_node!(MdqElem::Block::LeafBlock::Paragraph{ .. }) = {
+                    assert_eq!(p, md_elem!(r#"![]("only a tooltip")"#));
                 });
             }
         }
@@ -1100,7 +1100,7 @@ mod tests {
                 let (root, lookups) = parse("[hello _world_](https://example.com)");
                 assert_eq!(root.children.len(), 1);
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::Link(_), lookups => MdqNode::Inline(link) = {
+                check!(&p.children[0], Node::Link(_), lookups => MdqElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
@@ -1122,7 +1122,7 @@ mod tests {
                 let (root, lookups) = parse(r#"[hello _world_](https://example.com "the title")"#);
                 assert_eq!(root.children.len(), 1);
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::Link(_), lookups => MdqNode::Inline(link) = {
+                check!(&p.children[0], Node::Link(_), lookups => MdqElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
@@ -1151,7 +1151,7 @@ mod tests {
                 );
                 assert_eq!(root.children.len(), 2);
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqNode::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
@@ -1181,7 +1181,7 @@ mod tests {
                 );
                 assert_eq!(root.children.len(), 2);
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqNode::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
@@ -1211,7 +1211,7 @@ mod tests {
                 );
                 assert_eq!(root.children.len(), 2);
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqNode::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
@@ -1237,7 +1237,7 @@ mod tests {
                 let (root, lookups) = parse("<https://example.com>");
                 unwrap!(&root.children[0], Node::Paragraph(p));
                 assert_eq!(p.children.len(), 1);
-                check!(&p.children[0], Node::Link(_), lookups => MdqNode::Inline(Inline::Link{text, link_definition}) = {
+                check!(&p.children[0], Node::Link(_), lookups => MdqElem::Inline(Inline::Link{text, link_definition}) = {
                     assert_eq!(text, vec![mdq_inline!("https://example.com")]);
                     assert_eq!(link_definition, LinkDefinition{
                         url: "https://example.com".to_string(),
@@ -1249,7 +1249,7 @@ mod tests {
                 let (root, lookups) = parse("<mailto:md@example.com>");
                 unwrap!(&root.children[0], Node::Paragraph(p));
                 assert_eq!(p.children.len(), 1);
-                check!(&p.children[0], Node::Link(_), lookups => MdqNode::Inline(Inline::Link{text, link_definition}) = {
+                check!(&p.children[0], Node::Link(_), lookups => MdqElem::Inline(Inline::Link{text, link_definition}) = {
                     assert_eq!(text, vec![mdq_inline!("mailto:md@example.com")]);
                     assert_eq!(link_definition, LinkDefinition{
                         url: "mailto:md@example.com".to_string(),
@@ -1262,7 +1262,7 @@ mod tests {
                 let (root, lookups) = parse_with(&ParseOptions::default(), "https://example.com");
                 unwrap!(&root.children[0], Node::Paragraph(p));
                 assert_eq!(p.children.len(), 1);
-                check!(&p.children[0], Node::Text(_), lookups => MdqNode::Inline(Inline::Text{variant: TextVariant::Plain, value}) = {
+                check!(&p.children[0], Node::Text(_), lookups => MdqElem::Inline(Inline::Text{variant: TextVariant::Plain, value}) = {
                     assert_eq!(value, "https://example.com".to_string());
                 });
             }
@@ -1271,7 +1271,7 @@ mod tests {
                 let (root, lookups) = parse_with(&ParseOptions::gfm(), "https://example.com");
                 unwrap!(&root.children[0], Node::Paragraph(p));
                 assert_eq!(p.children.len(), 1);
-                check!(&p.children[0], Node::Link(_), lookups => MdqNode::Inline(Inline::Link{text, link_definition}) = {
+                check!(&p.children[0], Node::Link(_), lookups => MdqElem::Inline(Inline::Link{text, link_definition}) = {
                     assert_eq!(text, vec![mdq_inline!("https://example.com")]);
                     assert_eq!(link_definition, LinkDefinition{
                         url: "https://example.com".to_string(),
@@ -1290,7 +1290,7 @@ mod tests {
 
                     [1]: https://example.com/image.png"#});
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::ImageReference(_), lookups => MdqNode::Inline(img) = {
+                check!(&p.children[0], Node::ImageReference(_), lookups => MdqElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "".to_string(),
                         link: LinkDefinition {
@@ -1308,7 +1308,7 @@ mod tests {
 
                     [1]: https://example.com/image.png "my title""#});
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::ImageReference(_), lookups => MdqNode::Inline(img) = {
+                check!(&p.children[0], Node::ImageReference(_), lookups => MdqElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "".to_string(),
                         link: LinkDefinition {
@@ -1329,7 +1329,7 @@ mod tests {
                     [my alt]: https://example.com/image.png "my title""#},
                 );
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::ImageReference(_), lookups => MdqNode::Inline(img) = {
+                check!(&p.children[0], Node::ImageReference(_), lookups => MdqElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "my alt".to_string(),
                         link: LinkDefinition {
@@ -1350,7 +1350,7 @@ mod tests {
                     [my alt]: https://example.com/image.png"#},
                 );
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::ImageReference(_), lookups => MdqNode::Inline(img) = {
+                check!(&p.children[0], Node::ImageReference(_), lookups => MdqElem::Inline(img) = {
                     assert_eq!(img, Inline::Image {
                         alt: "my alt".to_string(),
                         link: LinkDefinition {
@@ -1373,7 +1373,7 @@ mod tests {
 
                     [1]: https://example.com/image.png"#});
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqNode::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![],
                         link_definition: LinkDefinition {
@@ -1391,7 +1391,7 @@ mod tests {
 
                     [1]: https://example.com/image.png "my title""#});
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqNode::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![],
                         link_definition: LinkDefinition {
@@ -1412,7 +1412,7 @@ mod tests {
                     [_my_ text]: https://example.com/image.png "my title""#},
                 );
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqNode::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             Inline::Span{
@@ -1442,7 +1442,7 @@ mod tests {
                     [my text]: https://example.com/image.png"#},
                 );
                 unwrap!(&root.children[0], Node::Paragraph(p));
-                check!(&p.children[0], Node::LinkReference(_), lookups => MdqNode::Inline(link) = {
+                check!(&p.children[0], Node::LinkReference(_), lookups => MdqElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             Inline::Text {variant: TextVariant::Plain,value: "my text".to_string()},
@@ -1468,7 +1468,7 @@ mod tests {
                     plain code block
                     ```"#},
                 );
-                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdqNode::Block::LeafBlock::CodeBlock{variant, value}) = {
+                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                     assert_eq!(variant, CodeVariant::Code(None));
                     assert_eq!(value, "plain code block");
                 })
@@ -1481,7 +1481,7 @@ mod tests {
                     code block with language
                     ```"#},
                 );
-                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdqNode::Block::LeafBlock::CodeBlock{variant, value}) = {
+                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                     assert_eq!(variant, CodeVariant::Code(Some(CodeOpts{
                         language: "rust".to_string(),
                         metadata: None})));
@@ -1496,7 +1496,7 @@ mod tests {
                     code block with language and title
                     ```"#},
                 );
-                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdqNode::Block::LeafBlock::CodeBlock{variant, value}) = {
+                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                     assert_eq!(variant, CodeVariant::Code(Some(CodeOpts{
                         language: "rust".to_string(),
                         metadata: Some(r#"title="example.rs""#.to_string())})));
@@ -1511,7 +1511,7 @@ mod tests {
                     code block with only title
                     ```"#},
                 );
-                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdqNode::Block::LeafBlock::CodeBlock{variant, value}) = {
+                check!(&root.children[0], Node::Code(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                     // It's actually just a bogus language!
                     assert_eq!(variant, CodeVariant::Code(Some(CodeOpts{
                         language: r#"title="example.rs""#.to_string(),
@@ -1533,7 +1533,7 @@ mod tests {
                     x = {-b \pm \sqrt{b^2-4ac} \over 2a}
                     $$"#},
                 );
-                check!(&root.children[0], Node::Math(_), lookups => m_node!(MdqNode::Block::LeafBlock::CodeBlock{variant, value}) = {
+                check!(&root.children[0], Node::Math(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                     assert_eq!(variant, CodeVariant::Math{metadata: None});
                     assert_eq!(value, r#"x = {-b \pm \sqrt{b^2-4ac} \over 2a}"#);
                 })
@@ -1546,7 +1546,7 @@ mod tests {
                     x = {-b \pm \sqrt{b^2-4ac} \over 2a}
                     $$"#},
                 );
-                check!(&root.children[0], Node::Math(_), lookups => m_node!(MdqNode::Block::LeafBlock::CodeBlock{variant, value}) = {
+                check!(&root.children[0], Node::Math(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                     assert_eq!(variant, CodeVariant::Math{metadata: Some("my metadata".to_string())});
                     assert_eq!(value, r#"x = {-b \pm \sqrt{b^2-4ac} \over 2a}"#);
                 })
@@ -1564,7 +1564,7 @@ mod tests {
                 my: toml
                 +++"#},
             );
-            check!(&root.children[0], Node::Toml(_), lookups => m_node!(MdqNode::Block::LeafBlock::CodeBlock{variant, value}) = {
+            check!(&root.children[0], Node::Toml(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                 assert_eq!(variant, CodeVariant::Toml);
                 assert_eq!(value, r#"my: toml"#);
             })
@@ -1581,7 +1581,7 @@ mod tests {
                 my: toml
                 ---"#},
             );
-            check!(&root.children[0], Node::Yaml(_), lookups => m_node!(MdqNode::Block::LeafBlock::CodeBlock{variant, value}) = {
+            check!(&root.children[0], Node::Yaml(_), lookups => m_node!(MdqElem::Block::LeafBlock::CodeBlock{variant, value}) = {
                 assert_eq!(variant, CodeVariant::Yaml);
                 assert_eq!(value, r#"my: toml"#);
             })
@@ -1596,7 +1596,7 @@ mod tests {
                     And some text below it."#},
             );
 
-            let (header_depth, header_title) = check!(&root.children[0], Node::Heading(_), lookups => m_node!(MdqNode::Block::Container::Section{depth, title, body}) = {
+            let (header_depth, header_title) = check!(&root.children[0], Node::Heading(_), lookups => m_node!(MdqElem::Block::Container::Section{depth, title, body}) = {
                 assert_eq!(depth, 2);
                 assert_eq!(title, vec![
                     Inline::Text { variant: TextVariant::Plain, value: "Header with ".to_string()},
@@ -1615,14 +1615,14 @@ mod tests {
 
             let mdast_root = Node::Root(root); // reconstruct it, since parse_with unwrapped it
             NODES_CHECKER.see(&mdast_root);
-            let mdqs = MdqNode::from_mdast_0(mdast_root, &lookups).unwrap();
+            let mdqs = MdqElem::from_mdast_0(mdast_root, &lookups).unwrap();
 
             assert_eq!(
                 mdqs,
-                vec![m_node!(MdqNode::Block::Container::Section {
+                vec![m_node!(MdqElem::Block::Container::Section {
                     depth: header_depth,
                     title: header_title,
-                    body: mdq_nodes!["And some text below it."],
+                    body: md_elems!["And some text below it."],
                 }),]
             );
         }
@@ -1641,7 +1641,7 @@ mod tests {
             );
 
             assert_eq!(root.children.len(), 3);
-            check!(&root.children[1], Node::ThematicBreak(_), lookups => m_node!(MdqNode::Block::LeafBlock::ThematicBreak) = {
+            check!(&root.children[1], Node::ThematicBreak(_), lookups => m_node!(MdqElem::Block::LeafBlock::ThematicBreak) = {
                 // nothing to check
             });
         }
@@ -1660,7 +1660,7 @@ mod tests {
                     "#},
             );
             assert_eq!(root.children.len(), 1);
-            check!(&root.children[0], Node::Table(table_node), lookups => m_node!(MdqNode::Block::LeafBlock::Table{alignments, rows}) = {
+            check!(&root.children[0], Node::Table(table_node), lookups => m_node!(MdqElem::Block::LeafBlock::Table{alignments, rows}) = {
                 assert_eq!(alignments, vec![mdast::AlignKind::Left, mdast::AlignKind::Center, mdast::AlignKind::Right, mdast::AlignKind::None]);
                 assert_eq!(rows,
                     vec![ // rows
@@ -1909,31 +1909,31 @@ mod tests {
         #[test]
         fn h1_with_two_paragraphs() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("first")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                m_node!(MdqElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("aaa")],
                 }),
-                m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                m_node!(MdqElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("bbb")],
                 }),
             ];
-            let expect = vec![m_node!(MdqNode::Block::Container::Section {
+            let expect = vec![m_node!(MdqElem::Block::Container::Section {
                 depth: 1,
                 title: vec![mdq_inline!("first")],
                 body: vec![
-                    m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                    m_node!(MdqElem::Block::LeafBlock::Paragraph {
                         body: vec![mdq_inline!("aaa")],
                     }),
-                    m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                    m_node!(MdqElem::Block::LeafBlock::Paragraph {
                         body: vec![mdq_inline!("bbb")],
                     }),
                 ],
             })];
-            let actual = MdqNode::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }
@@ -1941,32 +1941,32 @@ mod tests {
         #[test]
         fn simple_nesting() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("first")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("aaa")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                m_node!(MdqElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("bbb")],
                 }),
             ];
-            let expect = vec![m_node!(MdqNode::Block::Container::Section {
+            let expect = vec![m_node!(MdqElem::Block::Container::Section {
                 depth: 1,
                 title: vec![mdq_inline!("first")],
-                body: vec![m_node!(MdqNode::Block::Container::Section {
+                body: vec![m_node!(MdqElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("aaa")],
-                    body: vec![m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                    body: vec![m_node!(MdqElem::Block::LeafBlock::Paragraph {
                         body: vec![mdq_inline!("bbb")],
                     })],
                 })],
             })];
-            let actual = MdqNode::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }
@@ -1974,60 +1974,60 @@ mod tests {
         #[test]
         fn only_headers() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("first")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("second")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("third")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("fourth")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("fifth")],
                     body: vec![],
                 }),
             ];
-            let expect = vec![m_node!(MdqNode::Block::Container::Section {
+            let expect = vec![m_node!(MdqElem::Block::Container::Section {
                 depth: 1,
                 title: vec![mdq_inline!("first")],
                 body: vec![
-                    m_node!(MdqNode::Block::Container::Section {
+                    m_node!(MdqElem::Block::Container::Section {
                         depth: 2,
                         title: vec![mdq_inline!("second")],
                         body: vec![
-                            m_node!(MdqNode::Block::Container::Section {
+                            m_node!(MdqElem::Block::Container::Section {
                                 depth: 3,
                                 title: vec![mdq_inline!("third")],
                                 body: vec![],
                             }),
-                            m_node!(MdqNode::Block::Container::Section {
+                            m_node!(MdqElem::Block::Container::Section {
                                 depth: 3,
                                 title: vec![mdq_inline!("fourth")],
                                 body: vec![],
                             }),
                         ],
                     }),
-                    m_node!(MdqNode::Block::Container::Section {
+                    m_node!(MdqElem::Block::Container::Section {
                         depth: 2,
                         title: vec![mdq_inline!("fifth")],
                         body: vec![],
                     }),
                 ],
             })];
-            let actual = MdqNode::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }
@@ -2035,22 +2035,22 @@ mod tests {
         #[test]
         fn no_headers() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                m_node!(MdqElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("one")],
                 }),
-                m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                m_node!(MdqElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("two")],
                 }),
             ];
             let expect = vec![
-                m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                m_node!(MdqElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("one")],
                 }),
-                m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                m_node!(MdqElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("two")],
                 }),
             ];
-            let actual = MdqNode::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }
@@ -2058,40 +2058,40 @@ mod tests {
         #[test]
         fn header_skips() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("one")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 5,
                     title: vec![mdq_inline!("five")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("two")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("three")],
                     body: vec![],
                 }),
             ];
-            let expect = vec![m_node!(MdqNode::Block::Container::Section {
+            let expect = vec![m_node!(MdqElem::Block::Container::Section {
                 depth: 1,
                 title: vec![mdq_inline!("one")],
                 body: vec![
-                    m_node!(MdqNode::Block::Container::Section {
+                    m_node!(MdqElem::Block::Container::Section {
                         depth: 5,
                         title: vec![mdq_inline!("five")],
                         body: vec![],
                     }),
-                    m_node!(MdqNode::Block::Container::Section {
+                    m_node!(MdqElem::Block::Container::Section {
                         depth: 2,
                         title: vec![mdq_inline!("two")],
-                        body: vec![m_node!(MdqNode::Block::Container::Section {
+                        body: vec![m_node!(MdqElem::Block::Container::Section {
                             depth: 3,
                             title: vec![mdq_inline!("three")],
                             body: vec![],
@@ -2099,7 +2099,7 @@ mod tests {
                     }),
                 ],
             })];
-            let actual = MdqNode::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }
@@ -2107,40 +2107,40 @@ mod tests {
         #[test]
         fn backwards_order() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("three")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("two")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("one")],
                     body: vec![],
                 }),
             ];
             let expect = vec![
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("three")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 2,
                     title: vec![mdq_inline!("two")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 1,
                     title: vec![mdq_inline!("one")],
                     body: vec![],
                 }),
             ];
-            let actual = MdqNode::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }
@@ -2148,31 +2148,31 @@ mod tests {
         #[test]
         fn paragraph_before_and_after_header() -> Result<(), InvalidMd> {
             let linear = vec![
-                m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                m_node!(MdqElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("before")],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("the header")],
                     body: vec![],
                 }),
-                m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                m_node!(MdqElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("after")],
                 }),
             ];
             let expect = vec![
-                m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                m_node!(MdqElem::Block::LeafBlock::Paragraph {
                     body: vec![mdq_inline!("before")],
                 }),
-                m_node!(MdqNode::Block::Container::Section {
+                m_node!(MdqElem::Block::Container::Section {
                     depth: 3,
                     title: vec![mdq_inline!("the header")],
-                    body: vec![m_node!(MdqNode::Block::LeafBlock::Paragraph {
+                    body: vec![m_node!(MdqElem::Block::LeafBlock::Paragraph {
                         body: vec![mdq_inline!("after")],
                     })],
                 }),
             ];
-            let actual = MdqNode::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
+            let actual = MdqElem::all_from_iter(linear.into_iter().map(|n| Ok(n)))?;
             assert_eq!(expect, actual);
             Ok(())
         }

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -1,11 +1,11 @@
 use crate::tree::{
-    Block, BlockQuote, CodeBlock, Container, Inline, LeafBlock, List, ListItem, MdqNode, Paragraph, Section, Table,
+    Block, BlockQuote, CodeBlock, Container, Inline, LeafBlock, List, ListItem, MdqElem, Paragraph, Section, Table,
 };
 
 /// An MdqNodeRef is a slice into an MdqNode tree, where each element can be outputted, and certain elements can be
 /// selected.
 #[derive(Debug, Clone)]
-pub enum MdqNodeRef<'a> {
+pub enum MdElemRef<'a> {
     Section(&'a Section),
     ListItem(ListItemRef<'a>),
     Inline(&'a Inline),
@@ -26,10 +26,10 @@ pub enum NonSelectable<'a> {
 #[derive(Debug, Clone, Copy)]
 pub struct ListItemRef<'a>(pub Option<u32>, pub &'a ListItem);
 
-impl<'a> From<&'a MdqNode> for MdqNodeRef<'a> {
-    fn from(value: &'a MdqNode) -> Self {
+impl<'a> From<&'a MdqElem> for MdElemRef<'a> {
+    fn from(value: &'a MdqElem) -> Self {
         match value {
-            MdqNode::Block(block) => match block {
+            MdqElem::Block(block) => match block {
                 Block::LeafBlock(leaf) => match leaf {
                     LeafBlock::ThematicBreak => Self::NonSelectable(NonSelectable::ThematicBreak),
                     LeafBlock::Paragraph(p) => Self::NonSelectable(NonSelectable::Paragraph(p)),
@@ -42,7 +42,7 @@ impl<'a> From<&'a MdqNode> for MdqNodeRef<'a> {
                     Container::Section(section) => Self::Section(section),
                 },
             },
-            MdqNode::Inline(v) => Self::Inline(v),
+            MdqElem::Inline(v) => Self::Inline(v),
         }
     }
 }
@@ -51,16 +51,16 @@ impl<'a> From<&'a MdqNode> for MdqNodeRef<'a> {
 macro_rules! wrap_mdq_refs {
     ($variant:ident: $source:expr) => {{
         let source = $source;
-        let mut result: Vec<MdqNodeRef> = Vec::with_capacity(source.len());
+        let mut result: Vec<MdElemRef> = Vec::with_capacity(source.len());
         for elem in source {
-            result.push(MdqNodeRef::$variant(elem));
+            result.push(MdElemRef::$variant(elem));
         }
         result
     }};
 }
 
-impl<'a> MdqNodeRef<'a> {
-    pub fn wrap_vec(source: &'a Vec<MdqNode>) -> Vec<Self> {
+impl<'a> MdElemRef<'a> {
+    pub fn wrap_vec(source: &'a Vec<MdqElem>) -> Vec<Self> {
         let mut result: Vec<Self> = Vec::with_capacity(source.len());
         for elem in source {
             result.push(elem.into());

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -1,5 +1,5 @@
 use crate::tree::{
-    Block, BlockQuote, CodeBlock, Container, Inline, LeafBlock, List, ListItem, MdqElem, Paragraph, Section, Table,
+    Block, BlockQuote, CodeBlock, Container, Inline, LeafBlock, List, ListItem, MdElem, Paragraph, Section, Table,
 };
 
 /// An MdqNodeRef is a slice into an MdqNode tree, where each element can be outputted, and certain elements can be
@@ -26,10 +26,10 @@ pub enum NonSelectable<'a> {
 #[derive(Debug, Clone, Copy)]
 pub struct ListItemRef<'a>(pub Option<u32>, pub &'a ListItem);
 
-impl<'a> From<&'a MdqElem> for MdElemRef<'a> {
-    fn from(value: &'a MdqElem) -> Self {
+impl<'a> From<&'a MdElem> for MdElemRef<'a> {
+    fn from(value: &'a MdElem) -> Self {
         match value {
-            MdqElem::Block(block) => match block {
+            MdElem::Block(block) => match block {
                 Block::LeafBlock(leaf) => match leaf {
                     LeafBlock::ThematicBreak => Self::NonSelectable(NonSelectable::ThematicBreak),
                     LeafBlock::Paragraph(p) => Self::NonSelectable(NonSelectable::Paragraph(p)),
@@ -42,7 +42,7 @@ impl<'a> From<&'a MdqElem> for MdElemRef<'a> {
                     Container::Section(section) => Self::Section(section),
                 },
             },
-            MdqElem::Inline(v) => Self::Inline(v),
+            MdElem::Inline(v) => Self::Inline(v),
         }
     }
 }
@@ -60,7 +60,7 @@ macro_rules! wrap_mdq_refs {
 }
 
 impl<'a> MdElemRef<'a> {
-    pub fn wrap_vec(source: &'a Vec<MdqElem>) -> Vec<Self> {
+    pub fn wrap_vec(source: &'a Vec<MdElem>) -> Vec<Self> {
         let mut result: Vec<Self> = Vec::with_capacity(source.len());
         for elem in source {
             result.push(elem.into());

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -2,29 +2,23 @@
 mod test_utils {
 
     #[macro_export]
-    macro_rules! mdq_node {
+    macro_rules! md_elem {
         ( $($node_names:ident)::* {$($attr:ident: $val:expr),*}) => {
-            crate::m_node!(MdqNode::$($node_names)::* {$($attr: $val),*})
+            crate::m_node!(MdqElem::$($node_names)::* {$($attr: $val),*})
         };
         ($paragraph_text:literal) => {
-            crate::m_node!(MdqNode::Block::LeafBlock::Paragraph{body: vec![crate::mdq_inline!($paragraph_text)]})
+            crate::m_node!(MdqElem::Block::LeafBlock::Paragraph{body: vec![crate::mdq_inline!($paragraph_text)]})
         };
     }
 
     #[macro_export]
-    macro_rules! mdq_nodes {
+    macro_rules! md_elems {
         [$($first:tt $( $(:: $($rest:ident)::* )? {$($attr:ident: $val:expr),*$(,)?})? ),*$(,)?] => {
             vec![$(
                 crate::mdq_node!($first$( $(:: $($rest)::*)? { $($attr: $val),* })?)
                 ),*
             ]
         };
-        // [$($paragraph_text:literal),*$(,)?] => {
-        //     vec![$(
-        //             crate::mdq_node!($paragraph_text)
-        //         ),*
-        //     ]
-        // } TODO rm if I don't need this
     }
 
     #[macro_export]

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -4,10 +4,10 @@ mod test_utils {
     #[macro_export]
     macro_rules! md_elem {
         ( $($node_names:ident)::* {$($attr:ident: $val:expr),*}) => {
-            crate::m_node!(MdqElem::$($node_names)::* {$($attr: $val),*})
+            crate::m_node!(MdElem::$($node_names)::* {$($attr: $val),*})
         };
         ($paragraph_text:literal) => {
-            crate::m_node!(MdqElem::Block::LeafBlock::Paragraph{body: vec![crate::mdq_inline!($paragraph_text)]})
+            crate::m_node!(MdElem::Block::LeafBlock::Paragraph{body: vec![crate::mdq_inline!($paragraph_text)]})
         };
     }
 
@@ -15,7 +15,7 @@ mod test_utils {
     macro_rules! md_elems {
         [$($first:tt $( $(:: $($rest:ident)::* )? {$($attr:ident: $val:expr),*$(,)?})? ),*$(,)?] => {
             vec![$(
-                crate::mdq_node!($first$( $(:: $($rest)::*)? { $($attr: $val),* })?)
+                crate::md_elem!($first$( $(:: $($rest)::*)? { $($attr: $val),* })?)
                 ),*
             ]
         };


### PR DESCRIPTION
- `MdNode` -> `MdElem`, with associated changes to the macros
- `MdqNodeRef` -> `MdElemRef`

This is during #53, but isn't really needed for that ticket. I just don't really like the "node" aspect, because it doesn't work as nicely in my head when we're dealing with a stream of them. In other words: yes it's a tree, but a lot of times the code is thinking less of its tree structure and more of it as a "thing that can be streamed".