### PR TITLE
make Inline variants into structs

### DIFF
--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -163,9 +163,6 @@ impl<'a> MdWriterState<'a> {
             MdElemRef::ListItem(ListItemRef(idx, item)) => {
                 self.write_list_item(out, &idx, item);
             }
-            MdElemRef::Inline(inline) => {
-                self.write_inline_element(out, inline);
-            }
             MdElemRef::NonSelectable(node) => match node {
                 NonSelectable::ThematicBreak => {
                     out.with_block(Block::Plain, |out| out.write_str("***"));
@@ -177,6 +174,9 @@ impl<'a> MdWriterState<'a> {
                 NonSelectable::BlockQuote(block) => self.write_block_quote(out, block),
                 NonSelectable::List(list) => self.write_list(out, list),
                 NonSelectable::Table(table) => self.write_table(out, table),
+                NonSelectable::Inline(inline) => {
+                    self.write_inline_element(out, inline);
+                }
             },
         }
     }
@@ -614,34 +614,34 @@ pub mod tests {
         Section(_),
         ListItem(..),
 
-        Inline(Inline::Formatting(Formatting{variant: FormattingVariant::Delete, ..})),
-        Inline(Inline::Formatting(Formatting{variant: FormattingVariant::Emphasis, ..})),
-        Inline(Inline::Formatting(Formatting{variant: FormattingVariant::Strong, ..})),
+        NonSelectable(NonSelectable::Inline(Inline::Formatting(Formatting{variant: FormattingVariant::Delete, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Formatting(Formatting{variant: FormattingVariant::Emphasis, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Formatting(Formatting{variant: FormattingVariant::Strong, ..}))),
 
-        Inline(Inline::Text(Text{variant: TextVariant::Plain, ..})),
-        Inline(Inline::Text(Text{variant: TextVariant::Code, ..})),
-        Inline(Inline::Text(Text{variant: TextVariant::Math, ..})),
-        Inline(Inline::Text(Text{variant: TextVariant::Html, ..})),
+        NonSelectable(NonSelectable::Inline(Inline::Text(Text{variant: TextVariant::Plain, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Text(Text{variant: TextVariant::Code, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Text(Text{variant: TextVariant::Math, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Text(Text{variant: TextVariant::Html, ..}))),
 
-        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..})),
-        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..})),
-        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Collapsed, ..}, ..})),
-        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Shortcut, ..}, ..})),
-        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Inline, ..}, ..})),
-        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Full(_), ..}, ..})),
-        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Collapsed, ..}, ..})),
-        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Shortcut, ..}, ..})),
+        NonSelectable(NonSelectable::Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Collapsed, ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Shortcut, ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Link(Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Inline, ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Link(Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Full(_), ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Link(Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Collapsed, ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Link(Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Shortcut, ..}, ..}))),
 
-        Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..})),
-        Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..})),
-        Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Collapsed, ..}, ..})),
-        Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Shortcut, ..}, ..})),
-        Inline(Inline::Image(Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Inline, ..}, ..})),
-        Inline(Inline::Image(Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Full(_), ..}, ..})),
-        Inline(Inline::Image(Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Collapsed, ..}, ..})),
-        Inline(Inline::Image(Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Shortcut, ..}, ..})),
+        NonSelectable(NonSelectable::Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Collapsed, ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Shortcut, ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Image(Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Inline, ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Image(Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Full(_), ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Image(Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Collapsed, ..}, ..}))),
+        NonSelectable(NonSelectable::Inline(Inline::Image(Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Shortcut, ..}, ..}))),
 
-        Inline(Inline::Footnote{..}),
+        NonSelectable(NonSelectable::Inline(Inline::Footnote{..})),
 
         NonSelectable(NonSelectable::ThematicBreak),
         NonSelectable(NonSelectable::CodeBlock(CodeBlock{variant: CodeVariant::Code(None), ..})),

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -405,7 +405,7 @@ impl<'a> MdWriterState<'a> {
                 self.write_line(out, children);
                 out.write_str(surround);
             }
-            Inline::Text { variant, value } => {
+            Inline::Text(Text { variant, value }) => {
                 let surround = match variant {
                     TextVariant::Plain => "",
                     TextVariant::Code => "`",
@@ -618,10 +618,10 @@ pub mod tests {
         Inline(Inline::Formatting(Formatting{variant: FormattingVariant::Emphasis, ..})),
         Inline(Inline::Formatting(Formatting{variant: FormattingVariant::Strong, ..})),
 
-        Inline(Inline::Text{variant: TextVariant::Plain, ..}),
-        Inline(Inline::Text{variant: TextVariant::Code, ..}),
-        Inline(Inline::Text{variant: TextVariant::Math, ..}),
-        Inline(Inline::Text{variant: TextVariant::Html, ..}),
+        Inline(Inline::Text(Text{variant: TextVariant::Plain, ..})),
+        Inline(Inline::Text(Text{variant: TextVariant::Code, ..})),
+        Inline(Inline::Text(Text{variant: TextVariant::Math, ..})),
+        Inline(Inline::Text(Text{variant: TextVariant::Html, ..})),
 
         Inline(Inline::Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..}),
         Inline(Inline::Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..}),
@@ -1313,10 +1313,10 @@ pub mod tests {
             #[test]
             fn text() {
                 check_render(
-                    vec![MdElem::Inline(Inline::Text {
+                    vec![MdElem::Inline(Inline::Text(Text {
                         variant: TextVariant::Plain,
                         value: "hello world".to_string(),
-                    })],
+                    }))],
                     indoc! {"hello world"},
                 );
             }
@@ -1324,10 +1324,10 @@ pub mod tests {
             #[test]
             fn code() {
                 check_render(
-                    vec![MdElem::Inline(Inline::Text {
+                    vec![MdElem::Inline(Inline::Text(Text {
                         variant: TextVariant::Code,
                         value: "hello world".to_string(),
-                    })],
+                    }))],
                     indoc! {"`hello world`"},
                 );
             }
@@ -1335,10 +1335,10 @@ pub mod tests {
             #[test]
             fn math() {
                 check_render(
-                    vec![MdElem::Inline(Inline::Text {
+                    vec![MdElem::Inline(Inline::Text(Text {
                         variant: TextVariant::Math,
                         value: "hello world".to_string(),
-                    })],
+                    }))],
                     indoc! {"$hello world$"},
                 );
             }
@@ -1346,10 +1346,10 @@ pub mod tests {
             #[test]
             fn html() {
                 check_render(
-                    vec![MdElem::Inline(Inline::Text {
+                    vec![MdElem::Inline(Inline::Text(Text {
                         variant: TextVariant::Html,
                         value: "<a hello />".to_string(),
-                    })],
+                    }))],
                     indoc! {"<a hello />"},
                 );
             }

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -416,12 +416,12 @@ impl<'a> MdWriterState<'a> {
                 out.write_str(value);
                 out.write_str(surround);
             }
-            Inline::Link { text, link_definition } => {
+            Inline::Link(Link { text, link_definition }) => {
                 self.write_link_inline(out, ReifiedLabel::Inline(text), link_definition, |me, out| {
                     me.write_line(out, text)
                 });
             }
-            Inline::Image { alt, link } => {
+            Inline::Image(Image { alt, link }) => {
                 out.write_char('!');
                 self.write_link_inline(out, ReifiedLabel::Identifier(alt), link, |_, out| out.write_str(alt));
             }
@@ -623,23 +623,23 @@ pub mod tests {
         Inline(Inline::Text(Text{variant: TextVariant::Math, ..})),
         Inline(Inline::Text(Text{variant: TextVariant::Html, ..})),
 
-        Inline(Inline::Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..}),
-        Inline(Inline::Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..}),
-        Inline(Inline::Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Collapsed, ..}, ..}),
-        Inline(Inline::Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Shortcut, ..}, ..}),
-        Inline(Inline::Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Inline, ..}, ..}),
-        Inline(Inline::Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Full(_), ..}, ..}),
-        Inline(Inline::Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Collapsed, ..}, ..}),
-        Inline(Inline::Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Shortcut, ..}, ..}),
+        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..})),
+        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..})),
+        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Collapsed, ..}, ..})),
+        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Shortcut, ..}, ..})),
+        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Inline, ..}, ..})),
+        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Full(_), ..}, ..})),
+        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Collapsed, ..}, ..})),
+        Inline(Inline::Link(Link{link_definition: LinkDefinition{title: Some(_), reference: LinkReference::Shortcut, ..}, ..})),
 
-        Inline(Inline::Image{link: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..}),
-        Inline(Inline::Image{link: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..}),
-        Inline(Inline::Image{link: LinkDefinition{title: None, reference: LinkReference::Collapsed, ..}, ..}),
-        Inline(Inline::Image{link: LinkDefinition{title: None, reference: LinkReference::Shortcut, ..}, ..}),
-        Inline(Inline::Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Inline, ..}, ..}),
-        Inline(Inline::Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Full(_), ..}, ..}),
-        Inline(Inline::Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Collapsed, ..}, ..}),
-        Inline(Inline::Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Shortcut, ..}, ..}),
+        Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..})),
+        Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..})),
+        Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Collapsed, ..}, ..})),
+        Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Shortcut, ..}, ..})),
+        Inline(Inline::Image(Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Inline, ..}, ..})),
+        Inline(Inline::Image(Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Full(_), ..}, ..})),
+        Inline(Inline::Image(Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Collapsed, ..}, ..})),
+        Inline(Inline::Image(Image{link: LinkDefinition{title: Some(_), reference: LinkReference::Shortcut, ..}, ..})),
 
         Inline(Inline::Footnote{..}),
 
@@ -1494,14 +1494,14 @@ pub mod tests {
 
             fn check_link(link: LinkDefinition, expect: &str) {
                 let nodes = vec![
-                    MdElem::Inline(Inline::Link {
+                    MdElem::Inline(Inline::Link(Link {
                         text: vec![
                             mdq_inline!("hello "),
                             mdq_inline!(span Emphasis [mdq_inline!("world")]),
                             mdq_inline!("!"),
                         ],
                         link_definition: link,
-                    }),
+                    })),
                     m_node!(MdElem::Block::LeafBlock::ThematicBreak),
                 ];
                 check_render(nodes, expect);
@@ -1647,10 +1647,10 @@ pub mod tests {
 
             fn check_image(link: LinkDefinition, expect: &str) {
                 let nodes = vec![
-                    MdElem::Inline(Inline::Image {
+                    MdElem::Inline(Inline::Image(Image {
                         alt: "hello _world_!".to_string(),
                         link,
-                    }),
+                    })),
                     m_node!(MdElem::Block::LeafBlock::ThematicBreak),
                 ];
                 check_render(nodes, expect);
@@ -1711,14 +1711,14 @@ pub mod tests {
                 md_elems![Block::LeafBlock::Paragraph {
                     body: vec![
                         mdq_inline!("Hello, "),
-                        Inline::Link {
+                        m_node!(Inline::Link {
                             text: vec![mdq_inline!("world"),],
                             link_definition: LinkDefinition {
                                 url: "https://example.com".to_string(),
                                 title: None,
                                 reference: LinkReference::Full("1".to_string()),
                             }
-                        },
+                        }),
                         mdq_inline!("! This is interesting"),
                         Inline::Footnote(Footnote {
                             label: "a".to_string(),
@@ -1843,22 +1843,22 @@ pub mod tests {
                             label: "c".to_string(),
                             text: md_elems!["footnote 2"]
                         }),
-                        Inline::Link {
+                        m_node!(Inline::Link {
                             text: vec![mdq_inline!("b-text")],
                             link_definition: LinkDefinition {
                                 url: "https://example.com/b".to_string(),
                                 title: None,
                                 reference: LinkReference::Full("b".to_string()),
                             },
-                        },
-                        Inline::Link {
+                        }),
+                        m_node!(Inline::Link {
                             text: vec![mdq_inline!("a-text")],
                             link_definition: LinkDefinition {
                                 url: "https://example.com/a".to_string(),
                                 title: None,
                                 reference: LinkReference::Full("a".to_string()),
                             },
-                        },
+                        }),
                     ]
                 }],
                 indoc! {r#"
@@ -1878,14 +1878,14 @@ pub mod tests {
                     title: vec![mdq_inline!("First section")],
                     body: md_elems![Block::LeafBlock::Paragraph {
                         body: vec![
-                            Inline::Link {
+                            m_node!(Inline::Link {
                                 text: vec![mdq_inline!("link description")],
                                 link_definition: LinkDefinition {
                                     url: "https://exampl.com".to_string(),
                                     title: None,
                                     reference: LinkReference::Full("1".to_string()),
                                 },
-                            },
+                            }),
                             mdq_inline!(" and then a thought"),
                             Inline::Footnote(Footnote {
                                 label: "a".to_string(),

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -395,7 +395,7 @@ impl<'a> MdWriterState<'a> {
         W: SimpleWrite,
     {
         match elem {
-            Inline::Formatting { variant, children } => {
+            Inline::Formatting(Formatting { variant, children }) => {
                 let surround = match variant {
                     FormattingVariant::Delete => "~~",
                     FormattingVariant::Emphasis => "_",
@@ -614,9 +614,9 @@ pub mod tests {
         Section(_),
         ListItem(..),
 
-        Inline(Inline::Formatting{variant: FormattingVariant::Delete, ..}),
-        Inline(Inline::Formatting{variant: FormattingVariant::Emphasis, ..}),
-        Inline(Inline::Formatting{variant: FormattingVariant::Strong, ..}),
+        Inline(Inline::Formatting(Formatting{variant: FormattingVariant::Delete, ..})),
+        Inline(Inline::Formatting(Formatting{variant: FormattingVariant::Emphasis, ..})),
+        Inline(Inline::Formatting(Formatting{variant: FormattingVariant::Strong, ..})),
 
         Inline(Inline::Text{variant: TextVariant::Plain, ..}),
         Inline(Inline::Text{variant: TextVariant::Code, ..}),

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -395,11 +395,11 @@ impl<'a> MdWriterState<'a> {
         W: SimpleWrite,
     {
         match elem {
-            Inline::Span { variant, children } => {
+            Inline::Formatting { variant, children } => {
                 let surround = match variant {
-                    SpanVariant::Delete => "~~",
-                    SpanVariant::Emphasis => "_",
-                    SpanVariant::Strong => "**",
+                    FormattingVariant::Delete => "~~",
+                    FormattingVariant::Emphasis => "_",
+                    FormattingVariant::Strong => "**",
                 };
                 out.write_str(surround);
                 self.write_line(out, children);
@@ -614,9 +614,9 @@ pub mod tests {
         Section(_),
         ListItem(..),
 
-        Inline(Inline::Span{variant: SpanVariant::Delete, ..}),
-        Inline(Inline::Span{variant: SpanVariant::Emphasis, ..}),
-        Inline(Inline::Span{variant: SpanVariant::Strong, ..}),
+        Inline(Inline::Formatting{variant: FormattingVariant::Delete, ..}),
+        Inline(Inline::Formatting{variant: FormattingVariant::Emphasis, ..}),
+        Inline(Inline::Formatting{variant: FormattingVariant::Strong, ..}),
 
         Inline(Inline::Text{variant: TextVariant::Plain, ..}),
         Inline(Inline::Text{variant: TextVariant::Code, ..}),

--- a/src/fmt_str.rs
+++ b/src/fmt_str.rs
@@ -1,4 +1,4 @@
-use crate::tree::{Formatting, Inline, Text, TextVariant};
+use crate::tree::{Formatting, Image, Inline, Link, Text, TextVariant};
 use std::borrow::Borrow;
 
 pub fn inlines_to_plain_string<N: Borrow<Inline>>(inlines: &[N]) -> String {
@@ -21,8 +21,8 @@ fn build_inline(out: &mut String, elem: &Inline) {
                 out.push_str(value)
             }
         }
-        Inline::Link { text, .. } => build_inlines(out, text),
-        Inline::Image { alt, .. } => out.push_str(alt),
+        Inline::Link(Link { text, .. }) => build_inlines(out, text),
+        Inline::Image(Image { alt, .. }) => out.push_str(alt),
         Inline::Footnote(footnote) => {
             out.push_str("[^");
             out.push_str(&footnote.label);

--- a/src/fmt_str.rs
+++ b/src/fmt_str.rs
@@ -1,4 +1,4 @@
-use crate::tree::{Inline, TextVariant};
+use crate::tree::{Formatting, Inline, TextVariant};
 use std::borrow::Borrow;
 
 pub fn inlines_to_plain_string<N: Borrow<Inline>>(inlines: &[N]) -> String {
@@ -15,7 +15,7 @@ fn build_inlines<N: Borrow<Inline>>(out: &mut String, inlines: &[N]) {
 
 fn build_inline(out: &mut String, elem: &Inline) {
     match elem {
-        Inline::Formatting { children, .. } => build_inlines(out, children),
+        Inline::Formatting(Formatting { children, .. }) => build_inlines(out, children),
         Inline::Text { variant, value, .. } => {
             if !matches!(variant, TextVariant::Html) {
                 out.push_str(value)
@@ -41,9 +41,9 @@ mod tests {
     use markdown::ParseOptions;
 
     crate::variants_checker!(VARIANTS_CHECKER = Inline {
-        Formatting { variant: FormattingVariant::Delete, .. },
-        Formatting { variant: FormattingVariant::Emphasis, .. },
-        Formatting { variant: FormattingVariant::Strong, .. },
+        Formatting(Formatting{ variant: FormattingVariant::Delete, .. }),
+        Formatting(Formatting{ variant: FormattingVariant::Emphasis, .. }),
+        Formatting(Formatting{ variant: FormattingVariant::Strong, .. }),
         Text { variant: TextVariant::Plain, .. },
         Text { variant: TextVariant::Code, .. },
         Text { variant: TextVariant::Math, .. },

--- a/src/fmt_str.rs
+++ b/src/fmt_str.rs
@@ -1,4 +1,4 @@
-use crate::tree::{Formatting, Inline, TextVariant};
+use crate::tree::{Formatting, Inline, Text, TextVariant};
 use std::borrow::Borrow;
 
 pub fn inlines_to_plain_string<N: Borrow<Inline>>(inlines: &[N]) -> String {
@@ -16,7 +16,7 @@ fn build_inlines<N: Borrow<Inline>>(out: &mut String, inlines: &[N]) {
 fn build_inline(out: &mut String, elem: &Inline) {
     match elem {
         Inline::Formatting(Formatting { children, .. }) => build_inlines(out, children),
-        Inline::Text { variant, value, .. } => {
+        Inline::Text(Text { variant, value, .. }) => {
             if !matches!(variant, TextVariant::Html) {
                 out.push_str(value)
             }
@@ -44,10 +44,10 @@ mod tests {
         Formatting(Formatting{ variant: FormattingVariant::Delete, .. }),
         Formatting(Formatting{ variant: FormattingVariant::Emphasis, .. }),
         Formatting(Formatting{ variant: FormattingVariant::Strong, .. }),
-        Text { variant: TextVariant::Plain, .. },
-        Text { variant: TextVariant::Code, .. },
-        Text { variant: TextVariant::Math, .. },
-        Text { variant: TextVariant::Html, .. },
+        Text(Text { variant: TextVariant::Plain, .. }),
+        Text(Text { variant: TextVariant::Code, .. }),
+        Text(Text { variant: TextVariant::Math, .. }),
+        Text(Text { variant: TextVariant::Html, .. }),
         Link { .. },
         Image { .. },
         Footnote(_),

--- a/src/fmt_str.rs
+++ b/src/fmt_str.rs
@@ -15,7 +15,7 @@ fn build_inlines<N: Borrow<Inline>>(out: &mut String, inlines: &[N]) {
 
 fn build_inline(out: &mut String, elem: &Inline) {
     match elem {
-        Inline::Span { children, .. } => build_inlines(out, children),
+        Inline::Formatting { children, .. } => build_inlines(out, children),
         Inline::Text { variant, value, .. } => {
             if !matches!(variant, TextVariant::Html) {
                 out.push_str(value)
@@ -36,14 +36,14 @@ mod tests {
     use super::*;
     use indoc::indoc;
 
-    use crate::tree::{Block, Inline, LeafBlock, MdElem, ReadOptions, SpanVariant, TextVariant};
+    use crate::tree::{Block, FormattingVariant, Inline, LeafBlock, MdElem, ReadOptions, TextVariant};
     use crate::unwrap;
     use markdown::ParseOptions;
 
     crate::variants_checker!(VARIANTS_CHECKER = Inline {
-        Span { variant: SpanVariant::Delete, .. },
-        Span { variant: SpanVariant::Emphasis, .. },
-        Span { variant: SpanVariant::Strong, .. },
+        Formatting { variant: FormattingVariant::Delete, .. },
+        Formatting { variant: FormattingVariant::Emphasis, .. },
+        Formatting { variant: FormattingVariant::Strong, .. },
         Text { variant: TextVariant::Plain, .. },
         Text { variant: TextVariant::Code, .. },
         Text { variant: TextVariant::Math, .. },

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -3,7 +3,7 @@ use crate::select::base::Selector;
 use crate::select::interface::{ParseError, ParseErrorReason, ParseResult, SelectResult};
 use crate::select::list_item::{ListItemSelector, ListItemType};
 use crate::select::section::SectionSelector;
-use crate::tree::{Formatting, Inline, Text};
+use crate::tree::{Formatting, Image, Inline, Link, Text};
 use crate::tree_ref::{ListItemRef, MdElemRef, NonSelectable};
 use crate::wrap_mdq_refs;
 
@@ -96,11 +96,11 @@ impl MdqRefSelector {
                     children.iter().map(|child| MdElemRef::Inline(child)).collect()
                 }
                 Inline::Footnote(footnote) => MdElemRef::wrap_vec(&footnote.text),
-                Inline::Link { .. } => {
+                Inline::Link(Link { .. }) => {
                     // TODO need to return an MdqNodeRef::Link
                     Vec::new()
                 }
-                Inline::Text(Text { .. }) | Inline::Image { .. } => Vec::new(),
+                Inline::Text(Text { .. }) | Inline::Image(Image { .. }) => Vec::new(),
             },
             MdElemRef::NonSelectable(elem) => match elem {
                 NonSelectable::Paragraph(p) => wrap_mdq_refs!(Inline: &p.body),

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -92,7 +92,7 @@ impl MdqRefSelector {
             MdElemRef::Section(s) => MdElemRef::wrap_vec(&s.body),
             MdElemRef::ListItem(ListItemRef(_, item)) => MdElemRef::wrap_vec(&item.item),
             MdElemRef::Inline(inline) => match inline {
-                Inline::Span { children, .. } => children.iter().map(|child| MdElemRef::Inline(child)).collect(),
+                Inline::Formatting { children, .. } => children.iter().map(|child| MdElemRef::Inline(child)).collect(),
                 Inline::Footnote(footnote) => MdElemRef::wrap_vec(&footnote.text),
                 Inline::Link { .. } => {
                     // TODO need to return an MdqNodeRef::Link

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -5,7 +5,6 @@ use crate::select::list_item::{ListItemSelector, ListItemType};
 use crate::select::section::SectionSelector;
 use crate::tree::{Formatting, Image, Inline, Link, Text};
 use crate::tree_ref::{ListItemRef, MdElemRef, NonSelectable};
-use crate::wrap_mdq_refs;
 
 #[derive(Debug, PartialEq)]
 pub enum MdqRefSelector {
@@ -91,19 +90,8 @@ impl MdqRefSelector {
         match node {
             MdElemRef::Section(s) => MdElemRef::wrap_vec(&s.body),
             MdElemRef::ListItem(ListItemRef(_, item)) => MdElemRef::wrap_vec(&item.item),
-            MdElemRef::Inline(inline) => match inline {
-                Inline::Formatting(Formatting { children, .. }) => {
-                    children.iter().map(|child| MdElemRef::Inline(child)).collect()
-                }
-                Inline::Footnote(footnote) => MdElemRef::wrap_vec(&footnote.text),
-                Inline::Link(Link { .. }) => {
-                    // TODO need to return an MdqNodeRef::Link
-                    Vec::new()
-                }
-                Inline::Text(Text { .. }) | Inline::Image(Image { .. }) => Vec::new(),
-            },
             MdElemRef::NonSelectable(elem) => match elem {
-                NonSelectable::Paragraph(p) => wrap_mdq_refs!(Inline: &p.body),
+                NonSelectable::Paragraph(p) => p.body.iter().map(|child| child.into()).collect(),
                 NonSelectable::BlockQuote(b) => MdElemRef::wrap_vec(&b.body),
                 NonSelectable::List(list) => {
                     let mut idx = list.starting_index;
@@ -122,13 +110,24 @@ impl MdqRefSelector {
                     for row in &table.rows {
                         for col in row {
                             for cell in col {
-                                result.push(MdElemRef::Inline(cell));
+                                result.push(MdElemRef::NonSelectable(NonSelectable::Inline(cell)));
                             }
                         }
                     }
                     result
                 }
                 NonSelectable::ThematicBreak | NonSelectable::CodeBlock(_) => Vec::new(),
+                NonSelectable::Inline(inline) => match inline {
+                    Inline::Formatting(Formatting { children, .. }) => {
+                        children.iter().map(|child| child.into()).collect()
+                    }
+                    Inline::Footnote(footnote) => MdElemRef::wrap_vec(&footnote.text),
+                    Inline::Link(Link { .. }) => {
+                        // TODO need to return an MdqNodeRef::Link
+                        Vec::new()
+                    }
+                    Inline::Text(Text { .. }) | Inline::Image(Image { .. }) => Vec::new(),
+                },
             },
         }
     }

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -3,7 +3,7 @@ use crate::select::base::Selector;
 use crate::select::interface::{ParseError, ParseErrorReason, ParseResult, SelectResult};
 use crate::select::list_item::{ListItemSelector, ListItemType};
 use crate::select::section::SectionSelector;
-use crate::tree::Inline;
+use crate::tree::{Formatting, Inline};
 use crate::tree_ref::{ListItemRef, MdElemRef, NonSelectable};
 use crate::wrap_mdq_refs;
 
@@ -92,7 +92,9 @@ impl MdqRefSelector {
             MdElemRef::Section(s) => MdElemRef::wrap_vec(&s.body),
             MdElemRef::ListItem(ListItemRef(_, item)) => MdElemRef::wrap_vec(&item.item),
             MdElemRef::Inline(inline) => match inline {
-                Inline::Formatting { children, .. } => children.iter().map(|child| MdElemRef::Inline(child)).collect(),
+                Inline::Formatting(Formatting { children, .. }) => {
+                    children.iter().map(|child| MdElemRef::Inline(child)).collect()
+                }
                 Inline::Footnote(footnote) => MdElemRef::wrap_vec(&footnote.text),
                 Inline::Link { .. } => {
                     // TODO need to return an MdqNodeRef::Link

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -3,7 +3,7 @@ use crate::select::base::Selector;
 use crate::select::interface::{ParseError, ParseErrorReason, ParseResult, SelectResult};
 use crate::select::list_item::{ListItemSelector, ListItemType};
 use crate::select::section::SectionSelector;
-use crate::tree::{Formatting, Inline};
+use crate::tree::{Formatting, Inline, Text};
 use crate::tree_ref::{ListItemRef, MdElemRef, NonSelectable};
 use crate::wrap_mdq_refs;
 
@@ -100,7 +100,7 @@ impl MdqRefSelector {
                     // TODO need to return an MdqNodeRef::Link
                     Vec::new()
                 }
-                Inline::Text { .. } | Inline::Image { .. } => Vec::new(),
+                Inline::Text(Text { .. }) | Inline::Image { .. } => Vec::new(),
             },
             MdElemRef::NonSelectable(elem) => match elem {
                 NonSelectable::Paragraph(p) => wrap_mdq_refs!(Inline: &p.body),

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -122,11 +122,11 @@ pub enum CodeVariant {
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum Inline {
-    Formatting(Formatting),
-    Text(Text),
-    Link(Link),
-    Image(Image),
     Footnote(Footnote),
+    Formatting(Formatting),
+    Image(Image),
+    Link(Link),
+    Text(Text),
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -122,8 +122,8 @@ pub enum CodeVariant {
 
 #[derive(Debug, PartialEq, Eq, Hash)]
 pub enum Inline {
-    Span {
-        variant: SpanVariant,
+    Formatting {
+        variant: FormattingVariant,
         children: Vec<Inline>,
     },
     Text {
@@ -180,7 +180,7 @@ pub struct ListItem {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash)]
-pub enum SpanVariant {
+pub enum FormattingVariant {
     Delete,
     Emphasis,
     Strong,
@@ -297,12 +297,12 @@ impl MdElem {
                 variant: TextVariant::Math,
                 value: node.value,
             }),
-            mdast::Node::Delete(node) => MdElem::Inline(Inline::Span {
-                variant: SpanVariant::Delete,
+            mdast::Node::Delete(node) => MdElem::Inline(Inline::Formatting {
+                variant: FormattingVariant::Delete,
                 children: MdElem::inlines(node.children, lookups)?,
             }),
-            mdast::Node::Emphasis(node) => MdElem::Inline(Inline::Span {
-                variant: SpanVariant::Emphasis,
+            mdast::Node::Emphasis(node) => MdElem::Inline(Inline::Formatting {
+                variant: FormattingVariant::Emphasis,
                 children: MdElem::inlines(node.children, lookups)?,
             }),
             mdast::Node::Image(node) => MdElem::Inline(Inline::Image {
@@ -336,8 +336,8 @@ impl MdElem {
                     text: MdElem::all(definition.children.clone(), lookups)?,
                 }))
             }
-            mdast::Node::Strong(node) => MdElem::Inline(Inline::Span {
-                variant: SpanVariant::Strong,
+            mdast::Node::Strong(node) => MdElem::Inline(Inline::Formatting {
+                variant: FormattingVariant::Strong,
                 children: MdElem::inlines(node.children, lookups)?,
             }),
             mdast::Node::Text(node) => MdElem::Inline(Inline::Text {
@@ -934,8 +934,8 @@ mod tests {
 
             unwrap!(&root.children[0], Node::Paragraph(p));
             check!(&p.children[0], Node::Delete(_), lookups => MdElem::Inline(inline) = {
-                assert_eq!(inline, Inline::Span {
-                    variant: SpanVariant::Delete,
+                assert_eq!(inline, Inline::Formatting {
+                    variant: FormattingVariant::Delete,
                     children: vec![
                         Inline::Text { variant: TextVariant::Plain, value: "86 me".to_string()},
                     ]
@@ -949,8 +949,8 @@ mod tests {
 
             unwrap!(&root.children[0], Node::Paragraph(p));
             check!(&p.children[0], Node::Emphasis(_), lookups => MdElem::Inline(inline) = {
-                assert_eq!(inline, Inline::Span {
-                    variant: SpanVariant::Emphasis,
+                assert_eq!(inline, Inline::Formatting {
+                    variant: FormattingVariant::Emphasis,
                     children: vec![
                         Inline::Text { variant: TextVariant::Plain, value: "86 me".to_string()},
                     ]
@@ -964,8 +964,8 @@ mod tests {
 
             unwrap!(&root.children[0], Node::Paragraph(p));
             check!(&p.children[0], Node::Strong(_), lookups => MdElem::Inline(inline) = {
-                assert_eq!(inline, Inline::Span {
-                    variant: SpanVariant::Strong,
+                assert_eq!(inline, Inline::Formatting {
+                    variant: FormattingVariant::Strong,
                     children: vec![
                         Inline::Text { variant: TextVariant::Plain, value: "strongman".to_string()},
                     ]
@@ -1104,8 +1104,8 @@ mod tests {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
-                            Inline::Span {
-                                variant: SpanVariant::Emphasis,
+                            Inline::Formatting {
+                                variant: FormattingVariant::Emphasis,
                                 children: vec![mdq_inline!("world")],
                             }
                         ],
@@ -1126,8 +1126,8 @@ mod tests {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
-                            Inline::Span {
-                                variant: SpanVariant::Emphasis,
+                            Inline::Formatting {
+                                variant: FormattingVariant::Emphasis,
                                 children: vec![mdq_inline!("world")],
                             }
                         ],
@@ -1155,8 +1155,8 @@ mod tests {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
-                            Inline::Span {
-                                variant: SpanVariant::Emphasis,
+                            Inline::Formatting {
+                                variant: FormattingVariant::Emphasis,
                                 children: vec![mdq_inline!("world")],
                             },
                         ],
@@ -1185,8 +1185,8 @@ mod tests {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
-                            Inline::Span {
-                                variant: SpanVariant::Emphasis,
+                            Inline::Formatting {
+                                variant: FormattingVariant::Emphasis,
                                 children: vec![mdq_inline!("world")],
                             },
                         ],
@@ -1215,8 +1215,8 @@ mod tests {
                     assert_eq!(link, Inline::Link {
                         text: vec![
                             mdq_inline!("hello "),
-                            Inline::Span {
-                                variant: SpanVariant::Emphasis,
+                            Inline::Formatting {
+                                variant: FormattingVariant::Emphasis,
                                 children: vec![mdq_inline!("world")],
                             },
                         ],
@@ -1415,8 +1415,8 @@ mod tests {
                 check!(&p.children[0], Node::LinkReference(_), lookups => MdElem::Inline(link) = {
                     assert_eq!(link, Inline::Link {
                         text: vec![
-                            Inline::Span{
-                                variant: SpanVariant::Emphasis,
+                            Inline::Formatting{
+                                variant: FormattingVariant::Emphasis,
                                 children: vec![
                                     Inline::Text {variant: TextVariant::Plain,value: "my".to_string()}
                                 ],
@@ -1600,8 +1600,8 @@ mod tests {
                 assert_eq!(depth, 2);
                 assert_eq!(title, vec![
                     Inline::Text { variant: TextVariant::Plain, value: "Header with ".to_string()},
-                    Inline::Span {
-                        variant: SpanVariant::Emphasis,
+                    Inline::Formatting {
+                        variant: FormattingVariant::Emphasis,
                         children: vec![
                             Inline::Text { variant: TextVariant::Plain, value: "emphasis".to_string()},
                         ]

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -8,7 +8,6 @@ use crate::tree::{
 pub enum MdElemRef<'a> {
     Section(&'a Section),
     ListItem(ListItemRef<'a>),
-    Inline(&'a Inline),
 
     NonSelectable(NonSelectable<'a>),
 }
@@ -21,10 +20,20 @@ pub enum NonSelectable<'a> {
     BlockQuote(&'a BlockQuote),
     List(&'a List),
     Table(&'a Table),
+    Inline(&'a Inline),
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct ListItemRef<'a>(pub Option<u32>, pub &'a ListItem);
+
+/// We implement this one specifically because it's non-trivial: some Inlines are selectable, and some aren't.
+impl<'a> From<&'a Inline> for MdElemRef<'a> {
+    fn from(value: &'a Inline) -> Self {
+        // TODO actually make this be non-trivial, as the doc says it will be. :-) Specifically, make Link and Image
+        // selectable.
+        MdElemRef::NonSelectable(NonSelectable::Inline(value))
+    }
+}
 
 impl<'a> From<&'a MdElem> for MdElemRef<'a> {
     fn from(value: &'a MdElem) -> Self {
@@ -42,7 +51,7 @@ impl<'a> From<&'a MdElem> for MdElemRef<'a> {
                     Container::Section(section) => Self::Section(section),
                 },
             },
-            MdElem::Inline(v) => Self::Inline(v),
+            MdElem::Inline(v) => v.into(),
         }
     }
 }

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -29,10 +29,10 @@ mod test_utils {
             })
         };
         ($text:literal) => {
-            crate::tree::Inline::Text {
+            crate::tree::Inline::Text(Text {
                 variant: crate::tree::TextVariant::Plain,
                 value: $text.to_string(),
-            }
+            })
         };
     }
 }

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -24,8 +24,8 @@ mod test_utils {
     #[macro_export]
     macro_rules! mdq_inline {
         (span $which:ident [$($contents:expr),*$(,)?]) => {
-            crate::tree::Inline::Span {
-                variant: crate::tree::SpanVariant::$which,
+            crate::tree::Inline::Formatting {
+                variant: crate::tree::FormattingVariant::$which,
                 children: vec![$($contents),*],
             }
         };

--- a/src/tree_test_utils.rs
+++ b/src/tree_test_utils.rs
@@ -1,6 +1,5 @@
 #[cfg(test)]
 mod test_utils {
-
     #[macro_export]
     macro_rules! md_elem {
         ( $($node_names:ident)::* {$($attr:ident: $val:expr),*}) => {
@@ -24,10 +23,10 @@ mod test_utils {
     #[macro_export]
     macro_rules! mdq_inline {
         (span $which:ident [$($contents:expr),*$(,)?]) => {
-            crate::tree::Inline::Formatting {
+            crate::tree::Inline::Formatting(Formatting {
                 variant: crate::tree::FormattingVariant::$which,
                 children: vec![$($contents),*],
-            }
+            })
         };
         ($text:literal) => {
             crate::tree::Inline::Text {


### PR DESCRIPTION
- extract the inlined struct variants into actual structs
- make `Inline` be non-selectable

With this change, everything is now officially nice and tidy. Everything that's selectable is a top-level variant in `MdElemRef`, and everything that's not selectable is within the `NonSelectable` variant.

This (finally!) resolves #53 