### PR TITLE
simplify the `MdElemRef` variants

### DIFF
--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -6,52 +6,37 @@ use crate::tree::{
 /// selected.
 #[derive(Debug, Clone)]
 pub enum MdElemRef<'a> {
-    Section(&'a Section),
-    ListItem(ListItemRef<'a>),
-
-    NonSelectable(NonSelectable<'a>),
-}
-
-#[derive(Debug, Clone)]
-pub enum NonSelectable<'a> {
-    ThematicBreak,
-    CodeBlock(&'a CodeBlock),
-    Paragraph(&'a Paragraph),
     BlockQuote(&'a BlockQuote),
-    List(&'a List),
-    Table(&'a Table),
+    CodeBlock(&'a CodeBlock),
     Inline(&'a Inline),
+    List(&'a List),
+    ListItem(ListItemRef<'a>),
+    Paragraph(&'a Paragraph),
+    Section(&'a Section),
+    Table(&'a Table),
+    ThematicBreak,
 }
 
 #[derive(Debug, Clone, Copy)]
 pub struct ListItemRef<'a>(pub Option<u32>, pub &'a ListItem);
-
-/// We implement this one specifically because it's non-trivial: some Inlines are selectable, and some aren't.
-impl<'a> From<&'a Inline> for MdElemRef<'a> {
-    fn from(value: &'a Inline) -> Self {
-        // TODO actually make this be non-trivial, as the doc says it will be. :-) Specifically, make Link and Image
-        // selectable.
-        MdElemRef::NonSelectable(NonSelectable::Inline(value))
-    }
-}
 
 impl<'a> From<&'a MdElem> for MdElemRef<'a> {
     fn from(value: &'a MdElem) -> Self {
         match value {
             MdElem::Block(block) => match block {
                 Block::LeafBlock(leaf) => match leaf {
-                    LeafBlock::ThematicBreak => Self::NonSelectable(NonSelectable::ThematicBreak),
-                    LeafBlock::Paragraph(p) => Self::NonSelectable(NonSelectable::Paragraph(p)),
-                    LeafBlock::CodeBlock(c) => Self::NonSelectable(NonSelectable::CodeBlock(c)),
-                    LeafBlock::Table(t) => Self::NonSelectable(NonSelectable::Table(t)),
+                    LeafBlock::ThematicBreak => Self::ThematicBreak,
+                    LeafBlock::Paragraph(p) => Self::Paragraph(p),
+                    LeafBlock::CodeBlock(c) => Self::CodeBlock(c),
+                    LeafBlock::Table(t) => Self::Table(t),
                 },
                 Block::Container(container) => match container {
-                    Container::List(list) => Self::NonSelectable(NonSelectable::List(list)),
-                    Container::BlockQuote(block) => Self::NonSelectable(NonSelectable::BlockQuote(block)),
+                    Container::List(list) => Self::List(list),
+                    Container::BlockQuote(block) => Self::BlockQuote(block),
                     Container::Section(section) => Self::Section(section),
                 },
             },
-            MdElem::Inline(v) => v.into(),
+            MdElem::Inline(child) => MdElemRef::Inline(child),
         }
     }
 }


### PR DESCRIPTION
I don't actually need them separated into selectable or not, and doing so is actually pretty ugly, because it means `fmt_md` is beholden to select's whims.