### PR TITLE
selector parsing fixes

### DIFF
--- a/examples/hello.md
+++ b/examples/hello.md
@@ -1,5 +1,7 @@
 # Greetings
 
+![welcome mat image](https://example.com/welcome.png)
+
 How are you!
 
 *I'm* doing well.

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -104,7 +104,7 @@ impl MdqRefSelector {
 
     fn build_output<'a>(&self, out: &mut Vec<MdElemRef<'a>>, node: MdElemRef<'a>) {
         let result = match (self, node.clone()) {
-            (MdqRefSelector::Section(selector), MdElemRef::Section(header)) => selector.try_select(&header),
+            (MdqRefSelector::Section(selector), MdElemRef::Section(header)) => selector.try_select(header),
             (MdqRefSelector::ListItem(selector), MdElemRef::ListItem(item)) => selector.try_select(item),
             (MdqRefSelector::Link(selector), MdElemRef::Link(item)) => selector.try_select(item),
             _ => None,


### PR DESCRIPTION
`# foo | #bar` was broken due to my previous change, in which the separator was no longer consumed by the bareword parser. So, fix that.

Also some minor cleanup.