### PR TITLE
macro-ify selector registration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,8 +7,8 @@ edition = "2021"
 
 [dependencies]
 markdown = "1.0.0-alpha.16"
-regex = "1.10.4"
 paste = "1.0"
+regex = "1.10.4"
 
 [dev-dependencies]
 indoc = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,8 +8,8 @@ edition = "2021"
 [dependencies]
 markdown = "1.0.0-alpha.16"
 regex = "1.10.4"
+paste = "1.0"
 
 [dev-dependencies]
 indoc = "2"
 lazy_static = "1.4.0"
-paste = "1.0"

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -46,7 +46,7 @@ impl Display for ParseErrorReason {
 
 macro_rules! selectors {
     // TODO can I replace $bang:literal with literally just a "!"?
-    [$($(#[$meta:meta])* {$($char:literal $(::$($read_variant:ident)::+)? ),+} $name:ident),* $(,)?] => {
+    [$($(#[$meta:meta])* $(!)? {$($char:literal $(::$($read_variant:ident)::+)? ),+} $name:ident),* $(,)?] => {
         #[derive(Debug, PartialEq)]
         pub enum MdqRefSelector {
             $(
@@ -71,11 +71,7 @@ macro_rules! selectors {
                     None => Err(ParseErrorReason::UnexpectedEndOfInput),
                     $(
                         $(
-                            Some($char) => paste::paste!{ {
-                                let read = [<$name Selector>]::read($( $($read_variant)::+ ,)?chars)?;
-                                let variant = Self::$name(read);
-                                Ok(variant)
-                            } },
+                            Some($char) => paste::paste!{ Ok(Self::$name([<$name Selector>]::read($( $($read_variant)::+ ,)?chars)?))},
                         )+
                     )*
                     Some(other) => Err(ParseErrorReason::UnexpectedCharacter(other)), // TODO should be Any w/ bareword if first char is a letter
@@ -112,8 +108,7 @@ selectors![
     {'1'::ListItemType::Ordered,'-'::ListItemType::Unordered} ListItem,
 
     {'['} Link,
-    // TODO fix this so it's qualified
-    {'!'} Image,
+    ! {'!'} Image,
 ];
 
 impl MdqRefSelector {

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -105,29 +105,28 @@ macro_rules! selectors {
 }
 
 selectors![
-    // TODO rust-doc-ify these; I'm just commenting them out for now to remove noise while debugging a macro
-    // Selects the content of a section identified by its heading.
-    //
-    // Format: `# <string_matcher>`
-    //
-    // In bareword form, the string matcher terminates with the
-    // [selector delimiter character](parse_common::SELECTOR_SEPARATOR).
+    /// Selects the content of a section identified by its heading.
+    ///
+    /// Format: `# <string_matcher>`
+    ///
+    /// In bareword form, the string matcher terminates with the
+    /// [selector delimiter character](parse_common::SELECTOR_SEPARATOR).
     {'#'} Section,
 
-    // Selects a list item.
-    //
-    // Format: `<type> [checkbox] <string_matcher>` where:
-    // - _type_ is either `-` for unordered lists or `1.` for ordered lists. Note that ordered lists are _only_
-    //   identified by `1.`. Other digits are invalid.
-    // - _checkbox_, if provided, must be one of:
-    //   - `[ ]` for an unchecked box
-    //   - `[x]` for a checked box
-    //   - `[?]` for a box that may be checked or unchecked
-    //
-    // If the checkbox specifier is provided, the selector will only select list items with a checkbox. If the
-    // checkbox specifier is omitted, the selector will only select list items without a checkbox.
-    //
-    // In bareword form, the string matcher terminates with the [selector delimiter character](SELECTOR_SEPARATOR).
+    /// Selects a list item.
+    ///
+    /// Format: `<type> [checkbox] <string_matcher>` where:
+    /// - _type_ is either `-` for unordered lists or `1.` for ordered lists. Note that ordered lists are _only_
+    ///   identified by `1.`. Other digits are invalid.
+    /// - _checkbox_, if provided, must be one of:
+    ///   - `[ ]` for an unchecked box
+    ///   - `[x]` for a checked box
+    ///   - `[?]` for a box that may be checked or unchecked
+    ///
+    /// If the checkbox specifier is provided, the selector will only select list items with a checkbox. If the
+    /// checkbox specifier is omitted, the selector will only select list items without a checkbox.
+    ///
+    /// In bareword form, the string matcher terminates with the [selector delimiter character](SELECTOR_SEPARATOR).
     {'1'::ListItemType::Ordered,'-'::ListItemType::Unordered} ListItem,
 
     {'['} Link,

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -51,7 +51,7 @@ macro_rules! selectors {
         pub enum MdqRefSelector {
             $(
                 $(#[$meta])*
-                 $name ( paste::paste!{[<$name Selector >]}),
+                $name ( paste::paste!{[<$name Selector >]}),
             )*
         }
 

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -86,7 +86,10 @@ macro_rules! selectors {
                             $(
                                 $(
                                     $(
-                                        Some($bang_char) => paste::paste!{ Ok(Self::$name([<$name Selector>]::read($( $($bang_read_variant)::+ ,)?chars)?))},
+                                        Some($bang_char) => {
+                                            let _ = chars.next(); // drop the peeked char
+                                            paste::paste!{ Ok(Self::$name([<$name Selector>]::read($( $($bang_read_variant)::+ ,)?chars)?))}
+                                        }
                                     )+
                                 )?
                             )*

--- a/src/select/sel_list_item.rs
+++ b/src/select/sel_list_item.rs
@@ -75,6 +75,12 @@ impl CheckboxSpecifier {
     }
 }
 
+impl ListItemSelector {
+    pub fn read(variant: ListItemType, chars: &mut ParsingIterator) -> ParseResult<Self> {
+        variant.read(chars)
+    }
+}
+
 impl<'a> Selector<'a, ListItemRef<'a>> for ListItemSelector {
     fn matches(&self, item: ListItemRef<'a>) -> bool {
         let ListItemRef(idx, li) = item;

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -5,7 +5,7 @@ use crate::tree::{
 
 /// An MdqNodeRef is a slice into an MdqNode tree, where each element can be outputted, and certain elements can be
 /// selected.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum MdElemRef<'a> {
     // main elements
     BlockQuote(&'a BlockQuote),


### PR DESCRIPTION
Create a somewhat ugly macro that:

- creates the `MdqRefSelector` and its variants (one for each selector type)
- creates the `fn try_select_node`, which is the
  `match ... (selector, node) -> selector.try_select(node)` dispatch
- creates the `fn parse_selector`, which dispatches to the various
  `read(ParsingIterator)` functions

This actually results in more code (whoops!), but it means it's closer to foolproof to register a selector. You just add it to the `selectors!` list, and it handles parsing and dispatch for you.

I'm going to go ahead and say this resolves #62. It's far from perfect, but it's also plenty good enough for now. Maybe even over-engineered.