### PR TITLE
add a new MdElemRef::Doc

### DIFF
--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -792,6 +792,17 @@ pub mod tests {
                 Second"#},
             )
         }
+
+        #[test]
+        fn two_paragraphs_in_one_doc() {
+            check_render_refs(
+                vec![MdElemRef::Doc(&md_elems!["First", "Second"])],
+                indoc! {r#"
+                First
+
+                Second"#},
+            )
+        }
     }
 
     mod header {

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -156,6 +156,7 @@ impl<'a> MdWriterState<'a> {
         self.prev_was_thematic_break = false;
 
         match node_ref {
+            MdElemRef::Doc(items) => self.write_md(out, items.iter().map(|elem| elem.into()), false),
             MdElemRef::Section(Section { depth, title, body }) => {
                 out.with_block(Block::Plain, |out| {
                     for _ in 0..*depth {
@@ -166,7 +167,7 @@ impl<'a> MdWriterState<'a> {
                         self.write_line(out, title);
                     }
                 });
-                self.write_md(out, MdElemRef::wrap_vec(body).into_iter(), false);
+                self.write_md(out, Self::doc_iter(body), false);
                 let which_defs_to_write = match (
                     &self.opts.link_reference_placement,
                     &self.opts.footnote_reference_placement,
@@ -215,7 +216,7 @@ impl<'a> MdWriterState<'a> {
 
     fn write_block_quote<W: SimpleWrite>(&mut self, out: &mut Output<W>, block: &'a BlockQuote) {
         out.with_block(Block::Quote, |out| {
-            self.write_md(out, MdElemRef::wrap_vec(&block.body).into_iter(), false);
+            self.write_md(out, Self::doc_iter(&block.body), false);
         });
     }
 
@@ -402,7 +403,7 @@ impl<'a> MdWriterState<'a> {
         }
         let count = counting_writer.count();
         out.with_block(Block::Inlined(count), |out| {
-            self.write_md(out, MdElemRef::wrap_vec(&item.item).into_iter(), false);
+            self.write_md(out, Self::doc_iter(&item.item), false);
         });
     }
 
@@ -569,7 +570,7 @@ impl<'a> MdWriterState<'a> {
                     out.write_str(link_ref);
                     out.write_str("]: ");
                     out.with_block(Block::Inlined(2), |out| {
-                        self.write_md(out, MdElemRef::wrap_vec(text).into_iter(), false);
+                        self.write_md(out, Self::doc_iter(text), false);
                     });
                 }
             }
@@ -592,6 +593,10 @@ impl<'a> MdWriterState<'a> {
         let mut out = Output::new(String::with_capacity(line.len() * 10)); // rough guess
         self.write_line(&mut out, line);
         out.take_underlying().unwrap()
+    }
+
+    fn doc_iter(body: &'a Vec<MdElem>) -> impl Iterator<Item = MdElemRef<'a>> {
+        [MdElemRef::Doc(body)].into_iter()
     }
 }
 
@@ -666,6 +671,7 @@ pub mod tests {
     use super::write_md;
 
     crate::variants_checker!(VARIANTS_CHECKER = MdElemRef {
+        Doc(..),
         Section(_),
         ListItem(..),
         Link(..),
@@ -2195,7 +2201,11 @@ pub mod tests {
     }
 
     fn check_render_with(options: &MdOptions, nodes: Vec<MdElem>, expect: &str) {
-        check_render_refs_with(options, MdElemRef::wrap_vec(&nodes), expect)
+        let mut wrapped = Vec::with_capacity(nodes.len());
+        for node in &nodes {
+            wrapped.push(node.into());
+        }
+        check_render_refs_with(options, wrapped, expect)
     }
 
     fn check_render_refs(nodes: Vec<MdElemRef>, expect: &str) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> ExitCode {
         }
     };
 
-    let mut pipeline_nodes = vec![MdElemRef::wrap_vec(&mdqs)];
+    let mut pipeline_nodes = vec![MdElemRef::Doc(&mdqs)];
     for selector in selectors {
         let new_pipeline = selector.find_nodes(pipeline_nodes);
         pipeline_nodes = new_pipeline;

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ fn main() -> ExitCode {
         }
     };
 
-    let mut pipeline_nodes = MdElemRef::wrap_vec(&mdqs);
+    let mut pipeline_nodes = vec![MdElemRef::wrap_vec(&mdqs)];
     for selector in selectors {
         let new_pipeline = selector.find_nodes(pipeline_nodes);
         pipeline_nodes = new_pipeline;

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -200,10 +200,10 @@ impl MdqRefSelector {
                 }
                 wrapped
             }
-            MdElemRef::Section(s) => vec![MdElemRef::wrap_vec(&s.body)],
-            MdElemRef::ListItem(ListItemRef(_, item)) => vec![MdElemRef::wrap_vec(&item.item)],
+            MdElemRef::Section(s) => vec![MdElemRef::Doc(&s.body)],
+            MdElemRef::ListItem(ListItemRef(_, item)) => vec![MdElemRef::Doc(&item.item)],
             MdElemRef::Paragraph(p) => p.body.iter().map(|child| MdElemRef::Inline(child)).collect(),
-            MdElemRef::BlockQuote(b) => vec![MdElemRef::wrap_vec(&b.body)],
+            MdElemRef::BlockQuote(b) => vec![MdElemRef::Doc(&b.body)],
             MdElemRef::List(list) => {
                 let mut idx = list.starting_index;
                 let mut result = Vec::with_capacity(list.items.len());
@@ -232,7 +232,7 @@ impl MdqRefSelector {
                 Inline::Formatting(Formatting { children, .. }) => {
                     children.iter().map(|child| MdElemRef::Inline(child)).collect()
                 }
-                Inline::Footnote(footnote) => vec![MdElemRef::wrap_vec(&footnote.text)],
+                Inline::Footnote(footnote) => vec![MdElemRef::Doc(&footnote.text)],
                 Inline::Link(link) => vec![MdElemRef::Link(link)], // TODO find a test case that hits this to make sure it doesn't infinite-loop!
                 Inline::Image(image) => vec![MdElemRef::Image(image)],
                 Inline::Text(Text { .. }) => Vec::new(),

--- a/src/select/base.rs
+++ b/src/select/base.rs
@@ -1,10 +1,10 @@
-use crate::select::SelectResult;
+use crate::tree_ref::MdElemRef;
 
 pub trait Selector<'a, I: Copy> {
     fn matches(&self, item: I) -> bool;
-    fn pick(&self, item: I) -> SelectResult<'a>;
+    fn pick(&self, item: I) -> MdElemRef<'a>;
 
-    fn try_select(&self, item: I) -> Option<SelectResult<'a>> {
+    fn try_select(&self, item: I) -> Option<MdElemRef<'a>> {
         if self.matches(item) {
             Some(self.pick(item))
         } else {

--- a/src/select/sel_image.rs
+++ b/src/select/sel_image.rs
@@ -1,7 +1,7 @@
 use crate::parsing_iter::ParsingIterator;
 use crate::select::base::Selector;
 use crate::select::sel_link::LinkMatchers;
-use crate::select::{ParseResult, SelectResult};
+use crate::select::ParseResult;
 use crate::tree::Image;
 use crate::tree_ref::MdElemRef;
 
@@ -22,7 +22,7 @@ impl<'a> Selector<'a, &'a Image> for ImageSelector {
         self.matchers.display_matcher.matches(&item.alt) && self.matchers.url_matcher.matches(&item.link.url)
     }
 
-    fn pick(&self, item: &'a Image) -> SelectResult<'a> {
-        SelectResult::One(MdElemRef::Image(item))
+    fn pick(&self, item: &'a Image) -> MdElemRef<'a> {
+        MdElemRef::Image(item)
     }
 }

--- a/src/select/sel_link.rs
+++ b/src/select/sel_link.rs
@@ -1,7 +1,7 @@
 use crate::matcher::StringMatcher;
 use crate::parsing_iter::ParsingIterator;
 use crate::select::base::Selector;
-use crate::select::{ParseResult, SelectResult};
+use crate::select::ParseResult;
 use crate::tree::Link;
 use crate::tree_ref::MdElemRef;
 
@@ -23,8 +23,8 @@ impl<'a> Selector<'a, &'a Link> for LinkSelector {
             && self.matchers.url_matcher.matches(&item.link_definition.url)
     }
 
-    fn pick(&self, item: &'a Link) -> SelectResult<'a> {
-        SelectResult::One(MdElemRef::Link(item))
+    fn pick(&self, item: &'a Link) -> MdElemRef<'a> {
+        MdElemRef::Link(item)
     }
 }
 

--- a/src/select/sel_list_item.rs
+++ b/src/select/sel_list_item.rs
@@ -1,7 +1,7 @@
 use crate::matcher::StringMatcher;
 use crate::parsing_iter::ParsingIterator;
 use crate::select::base::Selector;
-use crate::select::{ParseErrorReason, ParseResult, SelectResult, SELECTOR_SEPARATOR};
+use crate::select::{ParseErrorReason, ParseResult, SELECTOR_SEPARATOR};
 use crate::tree_ref::{ListItemRef, MdElemRef};
 
 #[derive(Debug, PartialEq)]
@@ -87,8 +87,8 @@ impl<'a> Selector<'a, ListItemRef<'a>> for ListItemSelector {
         self.li_type.matches(&idx) && self.checkbox.matches(&li.checked) && self.string_matcher.matches_any(&li.item)
     }
 
-    fn pick(&self, item: ListItemRef<'a>) -> SelectResult<'a> {
-        SelectResult::One(MdElemRef::ListItem(item))
+    fn pick(&self, item: ListItemRef<'a>) -> MdElemRef<'a> {
+        MdElemRef::ListItem(item)
     }
 }
 

--- a/src/select/sel_section.rs
+++ b/src/select/sel_section.rs
@@ -23,6 +23,6 @@ impl<'a> Selector<'a, &'a Section> for SectionSelector {
     }
 
     fn pick(&self, item: &'a Section) -> MdElemRef<'a> {
-        MdElemRef::wrap_vec(&item.body)
+        MdElemRef::Doc(&item.body)
     }
 }

--- a/src/select/sel_section.rs
+++ b/src/select/sel_section.rs
@@ -1,8 +1,9 @@
 use crate::matcher::StringMatcher;
 use crate::parsing_iter::ParsingIterator;
 use crate::select::base::Selector;
-use crate::select::{ParseResult, SelectResult, SELECTOR_SEPARATOR};
+use crate::select::{ParseResult, SELECTOR_SEPARATOR};
 use crate::tree::Section;
+use crate::tree_ref::MdElemRef;
 
 #[derive(Debug, PartialEq)]
 pub struct SectionSelector {
@@ -21,7 +22,7 @@ impl<'a> Selector<'a, &'a Section> for SectionSelector {
         self.matcher.matches_inlines(&section.title)
     }
 
-    fn pick(&self, item: &'a Section) -> SelectResult<'a> {
-        SelectResult::Multi(&item.body)
+    fn pick(&self, item: &'a Section) -> MdElemRef<'a> {
+        MdElemRef::wrap_vec(&item.body)
     }
 }

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -61,10 +61,3 @@ macro_rules! wrap_mdq_refs {
         result
     }};
 }
-
-impl<'a> MdElemRef<'a> {
-    pub fn wrap_vec(source: &'a Vec<MdElem>) -> Self {
-        // TODO inline this func
-        Self::Doc(source)
-    }
-}

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -7,6 +7,9 @@ use crate::tree::{
 /// selected.
 #[derive(Debug, Clone, Copy)]
 pub enum MdElemRef<'a> {
+    // Multiple elements that form a single area
+    Doc(&'a Vec<MdElem>),
+
     // main elements
     BlockQuote(&'a BlockQuote),
     CodeBlock(&'a CodeBlock),
@@ -60,11 +63,8 @@ macro_rules! wrap_mdq_refs {
 }
 
 impl<'a> MdElemRef<'a> {
-    pub fn wrap_vec(source: &'a Vec<MdElem>) -> Vec<Self> {
-        let mut result: Vec<Self> = Vec::with_capacity(source.len());
-        for elem in source {
-            result.push(elem.into());
-        }
-        result
+    pub fn wrap_vec(source: &'a Vec<MdElem>) -> Self {
+        // TODO inline this func
+        Self::Doc(source)
     }
 }


### PR DESCRIPTION
This lets us encapsulate a `Vec<MdElem>` that represents a single area of
the doc, as opposed to a stream of disparate areas.

Note that we don't need a new `MdElem` variant, just a new `MdElemRef` variant. This is consistent with the code's existing pattern that `MdElem` is just the structure, and `MdElemRef` is various slices into that structure.

This also lets us simplify the `SelectResult`, since each selector now
returns exactly one element (previously, there was a `Multi` case for
`SectionSelector`, but now that's just a single Doc).

This resolves #79.