### PR TITLE
bareword improvements

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -29,7 +29,11 @@ impl StringMatcher {
     pub fn matches(&self, haystack: &str) -> bool {
         match self {
             StringMatcher::Any => true,
-            StringMatcher::Substring(look_for) => haystack.contains(look_for),
+            StringMatcher::Substring(look_for) => {
+                let pattern = format!("(?i){}", regex::escape(look_for));
+                let re = Regex::new(&pattern).expect("internal error");
+                re.is_match(haystack)
+            }
             StringMatcher::Regex(re) => re.is_match(haystack),
         }
     }

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -118,7 +118,11 @@ impl StringMatcher {
             let Some(ch) = chars.peek() else {
                 break;
             };
-            if ch == Self::BAREWORD_ANCHOR_END || ch == bareword_end {
+            if ch == Self::BAREWORD_ANCHOR_END {
+                let _ = chars.next();
+                break;
+            }
+            if ch == bareword_end {
                 break;
             }
             let _ = chars.next();
@@ -212,7 +216,7 @@ mod test {
             '@',
             "hello$world",
             StringMatcher::Substring("hello".to_string()),
-            "$world",
+            "world", // note: the dollar sign got consumed!
         );
     }
 

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -24,6 +24,8 @@ impl PartialEq for StringMatcher {
 }
 
 impl StringMatcher {
+    const BAREWORD_ANCHOR_END: char = '$';
+
     pub fn matches(&self, haystack: &str) -> bool {
         match self {
             StringMatcher::Any => true,
@@ -112,7 +114,7 @@ impl StringMatcher {
             let Some(ch) = chars.peek() else {
                 break;
             };
-            if ch == bareword_end {
+            if ch == Self::BAREWORD_ANCHOR_END || ch == bareword_end {
                 break;
             }
             let _ = chars.next();


### PR DESCRIPTION
- make them case-insensitive; this resolves #67 
- make `$` always an ending delimiter that gets consumed; this is in preparation for #56 
- add tests