### PR TITLE
factor out inline writes

### DIFF
--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -366,7 +366,7 @@ impl<'a> MdWriterState<'a> {
             DefinitionsToWrite::Both => {
                 self.inlines_writer.has_pending_links() || self.inlines_writer.has_pending_footnotes()
             }
-            DefinitionsToWrite::Neither => true,
+            DefinitionsToWrite::Neither => false,
         };
         if !any_pending {
             return;

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -74,7 +74,7 @@ where
         prev_was_thematic_break: false,
         inlines_writer: MdInlinesWriter::new(options.inline_options),
     };
-    writer_state.write_md(out, nodes, false);
+    writer_state.write_md(out, nodes, true);
 
     // Always write the pending definitions at the end of the doc. If there were no sections, then BottomOfSection
     // won't have been triggered, but we still want to write them

--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -176,7 +176,8 @@ impl<'a> MdInlinesWriter<'a> {
         }
         out.write_char(']');
 
-        let transformed = self.link_transformer.transform(self, &link.reference, &label);
+        let state = LinkTransformer::prepare_transformation(self.link_transformer.transform_variant(), self, link_like);
+        let transformed = self.link_transformer.transform(state, &link.reference);
         let link_ref_owned = transformed.into_owned();
 
         let reference_to_add = match link_ref_owned {

--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -1,0 +1,155 @@
+use crate::fmt_md::MdOptions;
+use crate::link_transform::{LinkLabel, LinkTransformer};
+use crate::output::{Output, SimpleWrite};
+use crate::tree::{
+    Footnote, Formatting, FormattingVariant, Inline, LinkDefinition, LinkReference, MdElem, Text, TextVariant,
+};
+use crate::tree_ref::MdElemRef;
+use std::borrow::{Borrow, Cow};
+use std::collections::{HashMap, HashSet};
+
+pub struct MdInlinesWriter<'a> {
+    seen_links: HashSet<LinkLabel<'a>>,
+    seen_footnotes: HashSet<&'a String>,
+    pending_references: PendingReferences<'a>,
+    link_transformer: LinkTransformer,
+}
+
+pub struct PendingReferences<'a> {
+    pub links: HashMap<LinkLabel<'a>, UrlAndTitle<'a>>,
+    pub footnotes: HashMap<&'a String, &'a Vec<MdElem>>,
+}
+
+#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
+pub struct UrlAndTitle<'a> {
+    pub url: &'a String,
+    pub title: &'a Option<String>,
+}
+
+impl<'a> MdInlinesWriter<'a> {
+    pub fn new(options: &MdOptions) -> Self {
+        let pending_refs_capacity = 8; // arbitrary guess
+        Self {
+            seen_links: HashSet::with_capacity(pending_refs_capacity),
+            seen_footnotes: HashSet::with_capacity(pending_refs_capacity),
+            pending_references: PendingReferences {
+                links: HashMap::with_capacity(pending_refs_capacity),
+                footnotes: HashMap::with_capacity(pending_refs_capacity),
+            },
+            link_transformer: LinkTransformer::from(options.link_canonicalization),
+        }
+    }
+
+    pub fn pending_references(&mut self) -> &mut PendingReferences<'a> {
+        &mut self.pending_references
+    }
+
+    pub fn write_line<E, W>(&mut self, out: &mut Output<W>, elems: &'a [E])
+    where
+        E: Borrow<Inline>,
+        W: SimpleWrite,
+    {
+        for elem in elems {
+            self.write_inline_element(out, elem.borrow());
+        }
+    }
+
+    pub fn write_inline_element<W>(&mut self, out: &mut Output<W>, elem: &'a Inline)
+    where
+        W: SimpleWrite,
+    {
+        match elem {
+            Inline::Formatting(Formatting { variant, children }) => {
+                let surround = match variant {
+                    FormattingVariant::Delete => "~~",
+                    FormattingVariant::Emphasis => "_",
+                    FormattingVariant::Strong => "**",
+                };
+                out.write_str(surround);
+                self.write_line(out, children);
+                out.write_str(surround);
+            }
+            Inline::Text(Text { variant, value }) => {
+                let surround = match variant {
+                    TextVariant::Plain => "",
+                    TextVariant::Code => "`",
+                    TextVariant::Math => "$",
+                    TextVariant::Html => "",
+                };
+                out.write_str(surround);
+                out.write_str(value);
+                out.write_str(surround);
+            }
+            Inline::Link(link) => self.write_one_md(out, MdElemRef::Link(link)),
+            Inline::Image(image) => self.write_one_md(out, MdElemRef::Image(image)),
+            Inline::Footnote(Footnote { label, text }) => {
+                out.write_str("[^");
+                out.write_str(label);
+                out.write_char(']');
+                if self.seen_footnotes.insert(label) {
+                    self.pending_references.footnotes.insert(label, text);
+                }
+            }
+        }
+    }
+
+    /// Writes the inline portion of the link, which may be the full link if it was originally inlined.
+    ///
+    /// Examples:
+    ///
+    /// ```
+    /// [an inline link](https://example.com)
+    /// [a referenced link][1]
+    /// ```
+    ///
+    /// The `contents` function is what writes e.g. `an inline link` above. It's a function because it may be a recursive
+    /// call into [write_line] (for links) or just simple text (for image alts).
+    pub fn write_link_inline_portion<W>(&mut self, out: &mut Output<W>, label: LinkLabel<'a>, link: &'a LinkDefinition)
+    where
+        W: SimpleWrite,
+    {
+        out.write_char('[');
+        match &label {
+            LinkLabel::Text(text) => out.write_str(text),
+            LinkLabel::Inline(text) => self.write_line(out, text),
+        }
+        out.write_char(']');
+
+        let transformed = self.link_transformer.transform(&link.reference, &label);
+        let link_ref_owned = transformed.into_owned();
+
+        let reference_to_add = match link_ref_owned {
+            LinkReference::Inline => {
+                out.write_char('(');
+                out.write_str(&link.url);
+                self.write_url_title(out, &link.title);
+                out.write_char(')');
+                None
+            }
+            LinkReference::Full(identifier) => {
+                out.write_char('[');
+                out.write_str(&identifier);
+                out.write_char(']');
+                Some(LinkLabel::Text(Cow::from(identifier)))
+            }
+            LinkReference::Collapsed => {
+                out.write_str("[]");
+                Some(label)
+            }
+            LinkReference::Shortcut => Some(label),
+        };
+
+        if let Some(reference_label) = reference_to_add {
+            if self.seen_links.insert(reference_label.clone()) {
+                self.pending_references.links.insert(
+                    reference_label,
+                    UrlAndTitle {
+                        url: &link.url,
+                        title: &link.title,
+                    },
+                );
+                // else warn?
+            }
+        }
+    }
+}

--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -1,4 +1,4 @@
-use crate::link_transform::{LinkLabel, LinkTransform, LinkTransformer, SingleTransformationState};
+use crate::link_transform::{LinkLabel, LinkTransform, LinkTransformation, LinkTransformer};
 use crate::output::{Output, SimpleWrite};
 use crate::tree::{
     Footnote, Formatting, FormattingVariant, Image, Inline, Link, LinkDefinition, LinkReference, MdElem, Text,
@@ -176,10 +176,9 @@ impl<'a> MdInlinesWriter<'a> {
         }
         out.write_char(']');
 
-        let state = SingleTransformationState::new(self.link_transformer.transform_variant(), self, link_like);
-        let link_ref_owned = state.apply(&mut self.link_transformer, &link.reference);
-
-        let reference_to_add = match link_ref_owned {
+        let link_ref = LinkTransformation::new(self.link_transformer.transform_variant(), self, link_like)
+            .apply(&mut self.link_transformer, &link.reference);
+        let reference_to_add = match link_ref {
             LinkReference::Inline => {
                 out.write_char('(');
                 out.write_str(&link.url);

--- a/src/link_transform.rs
+++ b/src/link_transform.rs
@@ -80,22 +80,11 @@ impl<'a> SingleTransformationState<'a> {
     fn with_link_text(text: Cow<'a, str>) -> Self {
         Self { link_text: Some(text) }
     }
-}
 
-impl LinkTransformer {
-    pub fn transform_variant(&self) -> LinkTransform {
-        match self.delegate {
-            LinkTransformState::Keep => LinkTransform::Keep,
-            LinkTransformState::Inline => LinkTransform::Inline,
-            LinkTransformState::Reference(_) => LinkTransform::Reference,
-        }
-    }
-
-    pub fn prepare_transformation<'a, L: LinkLike<'a>>(
-        transform: LinkTransform,
-        inline_writer: &mut MdInlinesWriter<'a>,
-        item: L,
-    ) -> SingleTransformationState<'a> {
+    pub fn new<L>(transform: LinkTransform, inline_writer: &mut MdInlinesWriter<'a>, item: L) -> Self
+    where
+        L: LinkLike<'a> + Copy,
+    {
         match transform {
             LinkTransform::Keep | LinkTransform::Inline => SingleTransformationState::empty(),
             LinkTransform::Reference => {
@@ -111,6 +100,20 @@ impl LinkTransformer {
                     }
                 }
             }
+        }
+    }
+
+    pub fn apply(self, transformer: &mut LinkTransformer, link: &'a LinkReference) -> LinkReference {
+        transformer.transform(self, link).into_owned()
+    }
+}
+
+impl LinkTransformer {
+    pub fn transform_variant(&self) -> LinkTransform {
+        match self.delegate {
+            LinkTransformState::Keep => LinkTransform::Keep,
+            LinkTransformState::Inline => LinkTransform::Inline,
+            LinkTransformState::Reference(_) => LinkTransform::Reference,
         }
     }
 

--- a/src/link_transform.rs
+++ b/src/link_transform.rs
@@ -68,11 +68,11 @@ enum LinkTransformState {
     Reference(ReferenceAssigner),
 }
 
-pub struct SingleTransformationState<'a> {
+pub struct LinkTransformation<'a> {
     link_text: Option<Cow<'a, str>>,
 }
 
-impl<'a> SingleTransformationState<'a> {
+impl<'a> LinkTransformation<'a> {
     pub fn new<L>(transform: LinkTransform, inline_writer: &mut MdInlinesWriter<'a>, item: L) -> Self
     where
         L: LinkLike<'a> + Copy,
@@ -110,11 +110,7 @@ impl LinkTransformer {
         }
     }
 
-    pub fn transform<'a>(
-        &mut self,
-        state: SingleTransformationState<'a>,
-        link: &'a LinkReference,
-    ) -> Cow<'a, LinkReference> {
+    pub fn transform<'a>(&mut self, state: LinkTransformation<'a>, link: &'a LinkReference) -> Cow<'a, LinkReference> {
         match &mut self.delegate {
             LinkTransformState::Keep => Cow::Borrowed(&link),
             LinkTransformState::Inline => Cow::Owned(LinkReference::Inline),
@@ -141,7 +137,7 @@ impl ReferenceAssigner {
         }
     }
 
-    fn assign<'a>(&mut self, state: SingleTransformationState<'a>, link: &'a LinkReference) -> Cow<'a, LinkReference> {
+    fn assign<'a>(&mut self, state: LinkTransformation<'a>, link: &'a LinkReference) -> Cow<'a, LinkReference> {
         match &link {
             LinkReference::Inline => self.assign_new(),
             LinkReference::Full(prev) => self.assign_if_numeric(prev).unwrap_or_else(|| Cow::Borrowed(link)),
@@ -189,7 +185,8 @@ fn inlines_to_string<'a>(inline_writer: &mut MdInlinesWriter<'a>, inlines: &'a V
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::utils_for_test::*;
+    use crate::mdq_inline;
+    use crate::tree::{Link, LinkDefinition, Text, TextVariant};
     use crate::variants_checker;
 
     enum Combo {
@@ -218,31 +215,31 @@ mod tests {
 
         #[test]
         fn inline() {
-            check_keep(&LinkReference::Inline);
+            check_keep(LinkReference::Inline);
         }
 
         #[test]
         fn collapsed() {
-            check_keep(&LinkReference::Collapsed);
+            check_keep(LinkReference::Collapsed);
         }
 
         #[test]
         fn full() {
-            check_keep(&LinkReference::Full("5".to_string()));
+            check_keep(LinkReference::Full("5".to_string()));
         }
 
         #[test]
         fn shortcut() {
-            check_keep(&LinkReference::Shortcut);
+            check_keep(LinkReference::Shortcut);
         }
 
-        fn check_keep(link_ref: &LinkReference) {
-            check_one(
-                LinkTransform::Keep,
-                link_ref,
-                &LinkLabel::Text(Cow::Borrowed("text label")),
-                &Cow::Borrowed(link_ref),
-            );
+        fn check_keep(link_ref: LinkReference) {
+            Given {
+                transform: LinkTransform::Keep,
+                label: mdq_inline!("doesn't matter"),
+                orig_reference: link_ref.clone(),
+            }
+            .expect(link_ref);
         }
     }
 
@@ -254,120 +251,117 @@ mod tests {
             // We could in principle have this return a Borrowed Cow, since the input and output are both Inline.
             // But it's not really worth it, given that Inline is just a stateless enum variant and thus as cheap
             // (or potentially even cheaper!) than a pointer.
-            check_inline(&LinkReference::Inline);
+            check_inline(LinkReference::Inline);
         }
 
         #[test]
         fn collapsed() {
-            check_inline(&LinkReference::Collapsed);
+            check_inline(LinkReference::Collapsed);
         }
 
         #[test]
         fn full() {
-            check_inline(&LinkReference::Full("5".to_string()));
+            check_inline(LinkReference::Full("5".to_string()));
         }
 
         #[test]
         fn shortcut() {
-            check_inline(&LinkReference::Shortcut);
+            check_inline(LinkReference::Shortcut);
         }
 
-        fn check_inline(link_ref: &LinkReference) {
-            check_one(
-                LinkTransform::Inline,
-                link_ref,
-                &LinkLabel::Text(Cow::Borrowed("text label")),
-                &Cow::Owned(LinkReference::Inline),
-            );
+        fn check_inline(link_ref: LinkReference) {
+            Given {
+                transform: LinkTransform::Inline,
+                label: mdq_inline!("doesn't matter"),
+                orig_reference: link_ref,
+            }
+            .expect(LinkReference::Inline);
         }
     }
 
     mod reference {
         use super::*;
-        use crate::tree::{Formatting, FormattingVariant, Text, TextVariant};
+        use crate::tree::{Formatting, FormattingVariant};
 
         #[test]
         fn inline() {
-            check_one(
-                LinkTransform::Reference,
-                &LinkReference::Inline,
-                &LinkLabel::Text(Cow::Borrowed("doesn't matter")),
-                &Cow::Owned(LinkReference::Full("1".to_string())),
-            )
+            Given {
+                transform: LinkTransform::Reference,
+                label: mdq_inline!("doesn't matter"),
+                orig_reference: LinkReference::Inline,
+            }
+            .expect(LinkReference::Full("1".to_string()));
         }
 
         #[test]
         fn collapsed_label_not_number() {
-            check_one(
-                LinkTransform::Reference,
-                &LinkReference::Collapsed,
-                &LinkLabel::Text(Cow::Borrowed("not a number")),
-                &Cow::Owned(LinkReference::Full("not a number".to_string())),
-            )
+            Given {
+                transform: LinkTransform::Reference,
+                label: mdq_inline!("not a number"),
+                orig_reference: LinkReference::Collapsed,
+            }
+            .expect(LinkReference::Full("not a number".to_string()));
         }
 
         #[test]
         fn collapsed_label_is_number() {
-            check_one(
-                LinkTransform::Reference,
-                &LinkReference::Collapsed,
-                &LinkLabel::Text(Cow::Borrowed("5")),
-                &Cow::Owned(LinkReference::Full("1".to_string())), // always count from 1
-            )
+            Given {
+                transform: LinkTransform::Reference,
+                label: mdq_inline!("321"),
+                orig_reference: LinkReference::Collapsed,
+            }
+            .expect(LinkReference::Full("1".to_string()));
         }
 
         #[test]
         fn full_ref_id_not_number() {
-            let reference = LinkReference::Full("non-number".to_string());
-            let reference_cow: Cow<LinkReference> = Cow::Borrowed(&reference);
-
-            check_one(
-                LinkTransform::Reference,
-                &reference,
-                &LinkLabel::Text(Cow::Borrowed("doesn't matter")),
-                &reference_cow,
-            )
+            Given {
+                transform: LinkTransform::Reference,
+                label: mdq_inline!("doesn't matter"),
+                orig_reference: LinkReference::Full("non-number".to_string()),
+            }
+            .expect(LinkReference::Full("non-number".to_string()));
         }
 
         #[test]
         fn full_ref_id_is_number() {
-            check_one(
-                LinkTransform::Reference,
-                &LinkReference::Full("321".to_string()), // what number it is doesn't matter
-                &LinkLabel::Text(Cow::Borrowed("doesn't matter")),
-                &Cow::Owned(LinkReference::Full("1".to_string())),
-            )
+            Given {
+                transform: LinkTransform::Reference,
+                label: mdq_inline!("doesn't matter"),
+                orig_reference: LinkReference::Full("non-number".to_string()),
+            }
+            .expect(LinkReference::Full("non-number".to_string()));
         }
 
         #[test]
         fn full_ref_id_is_huge_number() {
             let huge_num_str = format!("{}00000", u128::MAX);
-            check_one(
-                LinkTransform::Reference,
-                &LinkReference::Full(huge_num_str), // what number it is doesn't matter
-                &LinkLabel::Text(Cow::Borrowed("doesn't matter")),
-                &Cow::Owned(LinkReference::Full("1".to_string())), // always count from 1
-            )
+            Given {
+                transform: LinkTransform::Reference,
+                label: mdq_inline!("doesn't matter"),
+                orig_reference: LinkReference::Full(huge_num_str),
+            }
+            .expect(LinkReference::Full("1".to_string()));
         }
 
         #[test]
         fn shortcut_label_not_number() {
-            check_one(
-                LinkTransform::Reference,
-                &LinkReference::Shortcut,
-                &LinkLabel::Text(Cow::Borrowed("not a number")),
-                &Cow::Owned(LinkReference::Full("not a number".to_string())),
-            )
+            Given {
+                transform: LinkTransform::Reference,
+                label: mdq_inline!("not a number"),
+                orig_reference: LinkReference::Shortcut,
+            }
+            .expect(LinkReference::Full("not a number".to_string()));
         }
 
         #[test]
         fn shortcut_label_is_number() {
-            check_one(
-                LinkTransform::Reference,
-                &LinkReference::Shortcut,
-                &LinkLabel::Text(Cow::Borrowed("5")),
-                &Cow::Owned(LinkReference::Full("1".to_string())), // always count from 1
-            )
+            Given {
+                transform: LinkTransform::Reference,
+                label: mdq_inline!("321"),
+                orig_reference: LinkReference::Shortcut,
+            }
+            .expect(LinkReference::Full("1".to_string()));
         }
 
         /// The label isn't even close to a number.
@@ -375,15 +369,12 @@ mod tests {
         /// _c.f._ [shortcut_label_inlines_are_emphasized_number]
         #[test]
         fn shortcut_label_inlines_not_number_like() {
-            check_one(
-                LinkTransform::Reference,
-                &LinkReference::Shortcut,
-                &LinkLabel::Inline(&vec![Inline::Text(Text {
-                    variant: TextVariant::Plain,
-                    value: "hello world".to_string(),
-                })]),
-                &Cow::Owned(LinkReference::Full("hello world".to_string())),
-            )
+            Given {
+                transform: LinkTransform::Reference,
+                label: mdq_inline!("hello world"),
+                orig_reference: LinkReference::Shortcut,
+            }
+            .expect(LinkReference::Full("hello world".to_string()));
         }
 
         /// The label is kind of like a number, except that it's emphasized: `_123_`. This makes it not a number.
@@ -391,31 +382,18 @@ mod tests {
         /// _c.f._ [shortcut_label_inlines_not_number_like]
         #[test]
         fn shortcut_label_inlines_are_emphasized_number() {
-            check_one(
-                LinkTransform::Reference,
-                &LinkReference::Shortcut,
-                &LinkLabel::Inline(&vec![Inline::Formatting(Formatting {
+            Given {
+                transform: LinkTransform::Reference,
+                label: Inline::Formatting(Formatting {
                     variant: FormattingVariant::Emphasis,
                     children: vec![Inline::Text(Text {
                         variant: TextVariant::Plain,
                         value: "123".to_string(),
                     })],
-                })]),
-                &Cow::Owned(LinkReference::Full("_123_".to_string())), // note: the emphasis makes it not a number!
-            )
-        }
-
-        #[test]
-        fn shortcut_label_inlines_are_number() {
-            check_one(
-                LinkTransform::Reference,
-                &LinkReference::Shortcut,
-                &LinkLabel::Inline(&vec![Inline::Text(Text {
-                    variant: TextVariant::Plain,
-                    value: "123".to_string(),
-                })]),
-                &Cow::Owned(LinkReference::Full("1".to_string())),
-            )
+                }),
+                orig_reference: LinkReference::Shortcut,
+            }
+            .expect(LinkReference::Full("_123_".to_string()));
         }
     }
 
@@ -424,46 +402,109 @@ mod tests {
     #[test]
     fn smoke_test_multi() {
         let mut transformer = LinkTransformer::from(LinkTransform::Reference);
+        let mut iw = MdInlinesWriter::new(MdInlinesWriterOptions {
+            link_canonicalization: LinkTransform::Keep,
+        });
 
         // [alpha](https://example.com) ==> [alpha][1]
-        assert_eq_cow(
-            &transformer.transform(&LinkReference::Inline, &LinkLabel::Text(Cow::Borrowed("alpha"))),
-            &Cow::Owned(LinkReference::Full("1".to_string())),
+        let alpha = make_link("alpha", LinkReference::Inline);
+        assert_eq!(
+            transform(&mut transformer, &mut iw, &alpha),
+            LinkReference::Full("1".to_string())
         );
 
         // [bravo][1] ==> [bravo][2]
-        assert_eq_cow(
-            &transformer.transform(
-                &LinkReference::Full("1".to_string()),
-                &LinkLabel::Text(Cow::Borrowed("bravo")),
-            ),
-            &Cow::Owned(LinkReference::Full("2".to_string())),
+        let bravo = make_link("bravo", LinkReference::Full("1".to_string()));
+        assert_eq!(
+            transform(&mut transformer, &mut iw, &bravo),
+            LinkReference::Full("2".to_string())
         );
 
-        // [charlie][3] ==> [charlie][3]
-        // Note that in this case, we could return a Borrowed cow, but we return a new Owned one anyway for simplicity
-        assert_eq_cow(
-            &transformer.transform(
-                &LinkReference::Full("3".to_string()),
-                &LinkLabel::Text(Cow::Borrowed("charlie")),
-            ),
-            &Cow::Owned(LinkReference::Full("3".to_string())),
+        // [charlie][] ==> [charlie][charlie]
+        let charlie = make_link("charlie", LinkReference::Shortcut);
+        assert_eq!(
+            transform(&mut transformer, &mut iw, &charlie),
+            LinkReference::Full("charlie".to_string())
         );
 
-        // [delta][] ==> [delta][delta]
-        // Note that in this case, we could return a Borrowed cow, but we return a new Owned one anyway for simplicity
-        assert_eq_cow(
-            &transformer.transform(&LinkReference::Collapsed, &LinkLabel::Text(Cow::Borrowed("delta"))),
-            &Cow::Owned(LinkReference::Full("delta".to_string())),
+        // [delta][delta] ==> [delta][delta]
+        let delta = make_link("delta", LinkReference::Full("delta".to_string()));
+        assert_eq!(
+            transform(&mut transformer, &mut iw, &delta),
+            LinkReference::Full("delta".to_string())
+        );
+
+        // [789] ==> [789][3]
+        let echo = make_link("789", LinkReference::Collapsed);
+        assert_eq!(
+            transform(&mut transformer, &mut iw, &echo),
+            LinkReference::Full("3".to_string())
+        );
+
+        // [echo] ==> [echo][echo]
+        let echo = make_link("echo", LinkReference::Collapsed);
+        assert_eq!(
+            transform(&mut transformer, &mut iw, &echo),
+            LinkReference::Full("echo".to_string())
         );
     }
 
-    fn check_one(transform: LinkTransform, link_ref: &LinkReference, label: &LinkLabel, expected: &Cow<LinkReference>) {
-        let mut transformer = LinkTransformer::from(transform);
-        let actual = transformer.transform(&link_ref, &label);
+    fn transform<'a>(
+        mut transformer: &mut LinkTransformer,
+        mut iw: &mut MdInlinesWriter<'a>,
+        link: &'a Link,
+    ) -> LinkReference {
+        let actual = LinkTransformation::new(transformer.transform_variant(), &mut iw, link)
+            .apply(&mut transformer, &link.link_definition.reference);
+        actual
+    }
 
-        VARIANTS_CHECKER.see(&Combo::Of(transform, link_ref.clone()));
+    fn make_link(label: &str, link_ref: LinkReference) -> Link {
+        let link = Link {
+            text: vec![Inline::Text(Text {
+                variant: TextVariant::Plain,
+                value: label.to_string(),
+            })],
+            link_definition: LinkDefinition {
+                url: "https://example.com".to_string(),
+                title: None,
+                reference: link_ref,
+            },
+        };
+        link
+    }
 
-        assert_eq_cow(&actual, &expected);
+    struct Given {
+        transform: LinkTransform,
+        label: Inline,
+        orig_reference: LinkReference,
+    }
+
+    impl Given {
+        fn expect(self, expected: LinkReference) {
+            let Given {
+                transform,
+                label,
+                orig_reference: reference,
+            } = self;
+            let mut transformer = LinkTransformer::from(transform);
+            let mut iw = MdInlinesWriter::new(MdInlinesWriterOptions {
+                link_canonicalization: LinkTransform::Keep,
+            });
+            let link = Link {
+                text: vec![label],
+                link_definition: LinkDefinition {
+                    url: "https://example.com".to_string(),
+                    title: None,
+                    reference: reference.clone(),
+                },
+            };
+
+            let actual = self::transform(&mut transformer, &mut iw, &link);
+
+            VARIANTS_CHECKER.see(&Combo::Of(transform, reference.clone()));
+
+            assert_eq!(actual, expected);
+        }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ use std::io::{stdin, Read};
 use std::process::ExitCode;
 
 use crate::fmt_md::{MdOptions, ReferencePlacement};
+use crate::fmt_md_inlines::MdInlinesWriterOptions;
 use crate::link_transform::LinkTransform;
 use crate::output::Stream;
 use crate::select::ParseError;
@@ -74,8 +75,9 @@ fn main() -> ExitCode {
     let md_options = MdOptions {
         link_reference_placement: cli.link_pos,
         footnote_reference_placement: cli.footnote_pos.unwrap_or(cli.link_pos),
-        link_canonicalization: cli.link_canonicalization,
-        add_thematic_breaks: true,
+        inline_options: MdInlinesWriterOptions {
+            link_canonicalization: cli.link_canonicalization,
+        },
     };
 
     fmt_md::write_md(&md_options, &mut out, pipeline_nodes.into_iter());

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ use crate::tree_ref::MdElemRef;
 use select::MdqRefSelector;
 
 mod fmt_md;
+mod fmt_md_inlines;
 mod fmt_str;
 mod link_transform;
 mod matcher;

--- a/src/utils_for_test.rs
+++ b/src/utils_for_test.rs
@@ -1,12 +1,7 @@
-#[cfg(test)]
-pub use test_utils::*;
-
 // We this file's contents from prod by putting them in a submodule guarded by cfg(test), but then "pub use" it to
 // export its contents.
 #[cfg(test)]
 mod test_utils {
-    use std::borrow::Cow;
-    use std::fmt::Debug;
     /// Turn a pattern match into an `if let ... { else panic! }`.
     #[macro_export]
     macro_rules! unwrap {
@@ -105,17 +100,5 @@ mod test_utils {
                 }
             }
         };
-    }
-
-    pub fn assert_eq_cow<T>(actual: &Cow<T>, expected: &Cow<T>)
-    where
-        T: Clone + PartialEq + Debug,
-    {
-        assert_eq!(actual, expected);
-        match (actual, expected) {
-            (Cow::Borrowed(_), Cow::Owned(_)) => panic!("expected Cow::Owned({:?}) but saw Borrowed", expected),
-            (Cow::Owned(_), Cow::Borrowed(_)) => panic!("expected Cow::Borrowed({:?}) but saw Owned", expected),
-            (Cow::Borrowed(_), Cow::Borrowed(_)) | (Cow::Owned(_), Cow::Owned(_)) => {}
-        }
     }
 }


### PR DESCRIPTION
Move the handling of inlines from `fmt_md.rs` to a separate struct.

This makes it easier to do json output (#74), since I want to render inlines via just the markdown text (not a JSON breakdown of the various spans).

Resolves #87. That was originally written as a performance improvement, but I'm doing it now for the JSON (not performance).