### PR TITLE
json output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8478577c03552c21db0e2724ffb8986a5ce7af88107e6be5d2ee6e158c12800"
 
 [[package]]
+name = "itoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49f1f14873335454500d59611f1cf4a4b0f786f9ac11f4312a78e4cf2566695b"
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +155,8 @@ dependencies = [
  "markdown",
  "paste",
  "regex",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -209,6 +217,43 @@ name = "regex-syntax"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a66a03ae7c801facd77a29370b4faec201768915ac14a721ba36f20bc9c209b"
+
+[[package]]
+name = "ryu"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+
+[[package]]
+name = "serde"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7253ab4de971e72fb7be983802300c30b5a7f0c2e56fab8abfc6a214307c0094"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "500cbc0ebeb6f46627f50f3f5811ccf6bf00643be300b4c3eabc0ef55dc5b5ba"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.119"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8eddb61f0697cc3989c5d64b452f5488e2b8a60fd7d5076a3045076ffef8cb0"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ clap = { version = "4.5.7", features = ["derive"] }
 markdown = "1.0.0-alpha.16"
 paste = "1.0"
 regex = "1.10.4"
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ clap = { version = "4.5.7", features = ["derive"] }
 markdown = "1.0.0-alpha.16"
 paste = "1.0"
 regex = "1.10.4"
+serde = "1"
+serde_json = "1.0"
 
 [dev-dependencies]
 indoc = "2"

--- a/examples/hello.md
+++ b/examples/hello.md
@@ -39,8 +39,10 @@ This is [a collapsed link][], and this is [a shortcut link].
 
 ## Hello lists
 
-1. List two
-2. List two
+1. List one
+2. List two with...
+
+   ...two paragraphs
 
 - Item a[^1]
 

--- a/examples/hello.md
+++ b/examples/hello.md
@@ -1,6 +1,6 @@
 # Greetings
 
-![welcome mat image](https://example.com/welcome.png)
+![welcome image](https://example.com/welcome.png)
 
 How are you!
 
@@ -18,6 +18,8 @@ This is [my referenced link][a1].
 
 [a1]: https://example.com/reference
 
+# Details
+
 ### Here's a *cool* table
 
 | Column Left | Column Middle | Column Right |
@@ -29,6 +31,11 @@ This is [my inline link](https://example.com/inline).
 This is [my inline link with title](https://example.com/inline "its title").
 
 This is [my referenced link with title][a2].
+
+This is [a collapsed link][], and this is [a shortcut link].
+
+[a collapsed link]: https://example.com/collapsed
+[a shortcut link]: https://example.com/shortcut "and it has a title"
 
 ## Hello lists
 

--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -4,6 +4,7 @@ use crate::tree::{
     Footnote, Formatting, FormattingVariant, Image, Inline, Link, LinkDefinition, LinkReference, MdElem, Text,
     TextVariant,
 };
+use serde::Serialize;
 use std::borrow::{Borrow, Cow};
 use std::collections::{HashMap, HashSet};
 
@@ -33,9 +34,10 @@ impl<'a> PendingReferences<'a> {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Copy, Clone, Hash)]
+#[derive(Serialize, Debug, PartialEq, Eq, Copy, Clone, Hash)]
 pub struct UrlAndTitle<'a> {
     pub url: &'a String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub title: &'a Option<String>,
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,7 @@ use crate::output::Stream;
 use crate::select::ParseError;
 use crate::tree::{MdElem, ReadOptions};
 use crate::tree_ref::MdElemRef;
-use crate::tree_ref_serde::MdElemsStream;
+use crate::tree_ref_serde::SerdeDoc;
 use select::MdqRefSelector;
 
 mod fmt_md;
@@ -85,7 +85,7 @@ fn main() -> ExitCode {
     };
 
     if cli.json {
-        serde_json::to_writer(io::stdout(), &MdElemsStream::from(&pipeline_nodes)).unwrap();
+        serde_json::to_writer(io::stdout(), &SerdeDoc::new(&pipeline_nodes, md_options.inline_options)).unwrap();
     } else {
         let mut out = output::Output::new(Stream(io::stdout()));
         fmt_md::write_md(&md_options, &mut out, pipeline_nodes.into_iter());

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use crate::output::Stream;
 use crate::select::ParseError;
 use crate::tree::{MdElem, ReadOptions};
 use crate::tree_ref::MdElemRef;
+use crate::tree_ref_serde::MdElemsStream;
 use select::MdqRefSelector;
 
 mod fmt_md;
@@ -81,7 +82,7 @@ fn main() -> ExitCode {
     };
 
     if cli.json {
-        serde_json::to_writer(io::stdout(), &pipeline_nodes).unwrap();
+        serde_json::to_writer(io::stdout(), &MdElemsStream::from(&pipeline_nodes)).unwrap();
     } else {
         let mut out = output::Output::new(Stream(io::stdout()));
         fmt_md::write_md(&md_options, &mut out, pipeline_nodes.into_iter());

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -1,65 +1,100 @@
 use crate::fmt_md_inlines::{MdInlinesWriter, MdInlinesWriterOptions, UrlAndTitle};
 use crate::link_transform::LinkLabel;
 use crate::output::Output;
-use crate::tree::Inline;
+use crate::tree::{CodeBlock, CodeVariant, Inline, LinkDefinition, LinkReference, MdElem, Section};
 use crate::tree_ref::MdElemRef;
-use serde::ser::SerializeSeq;
-use serde::{Serialize, Serializer};
-use std::borrow::Cow;
+use crate::{fmt_md, tree};
+use serde::Serialize;
+use std::borrow::{Borrow, Cow};
 use std::collections::HashMap;
+use tree::Link;
 
 #[derive(Serialize)]
-pub enum ElemType {
-    Document,
-    Section,
+#[serde(rename_all = "snake_case")]
+pub enum SerdeElem<'a> {
+    Document(Vec<SerdeElem<'a>>),
+    BlockQuote(Vec<SerdeElem<'a>>),
+    CodeBlock {
+        code: &'a String,
+        #[serde(rename = "type")]
+        code_type: CodeBlockType,
+        metadata: Option<&'a String>,
+        language: Option<&'a String>,
+    },
+    Paragraph(String),
+    Link {
+        display: String,
+        url: &'a String,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        title: &'a Option<String>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reference: Option<Cow<'a, String>>,
+
+        #[serde(skip_serializing_if = "Option::is_none")]
+        reference_style: Option<LinkCollapseStyle>,
+    },
+    List(Vec<LiSerde<'a>>),
+    Section {
+        depth: u8,
+        title: String,
+        body: Vec<SerdeElem<'a>>,
+    },
 }
 
 #[derive(Serialize)]
-#[serde(untagged)]
-pub enum SerdeElem<'a> {
-    Node {
-        #[serde(rename = "type")]
-        elem_type: ElemType,
-        contents: &'a SerdeElem<'a>,
-    },
-    Inline(String),
+pub struct LiSerde<'a> {
+    item: Vec<SerdeElem<'a>>,
+    #[serde(rename = "type")]
+    li_type: ListItemType,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    checked: &'a Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    index: Option<u32>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LinkCollapseStyle {
+    Collapsed,
+    Shortcut,
+}
+
+#[derive(Serialize)]
+pub enum ListItemType {
+    Ordered,
+    Unordered,
+}
+
+#[derive(Serialize)]
+pub enum CodeBlockType {
+    Code,
+    Math,
+    Toml,
+    Yaml,
 }
 
 #[derive(Serialize)]
 pub struct SerdeDoc<'a> {
     items: Vec<SerdeElem<'a>>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
     links: HashMap<Cow<'a, str>, UrlAndTitle<'a>>,
+    #[serde(skip_serializing_if = "HashMap::is_empty")]
     footnotes: HashMap<&'a String, SerdeElem<'a>>,
-
-    #[serde(skip_serializing)]
-    stored_items: Holder<SerdeElem<'a>>,
-}
-
-struct Holder<E>(Vec<E>);
-
-impl<E> Holder<E> {
-    fn with_capacity(size: usize) -> Self {
-        Self(Vec::with_capacity(size))
-    }
-
-    fn store(&mut self, item: E) -> &E {
-        self.0.push(item);
-        &self.0[&self.0.len() - 1]
-    }
 }
 
 impl<'a> SerdeDoc<'a> {
-    pub fn new(elems: &Vec<MdElemRef>, opts: MdInlinesWriterOptions) -> Self {
+    pub fn new(elems: &Vec<MdElemRef<'a>>, opts: MdInlinesWriterOptions) -> Self {
         let mut inlines_writer = MdInlinesWriter::new(opts);
         const DEFAULT_CAPACITY: usize = 16; // todo we can actually compute these if we want
         let mut result = Self {
             items: Vec::with_capacity(DEFAULT_CAPACITY),
             links: HashMap::with_capacity(DEFAULT_CAPACITY),
             footnotes: HashMap::with_capacity(DEFAULT_CAPACITY),
-            stored_items: Holder::with_capacity(DEFAULT_CAPACITY),
         };
         for elem in elems {
-            let top = SerdeDoc::build(*elem, &mut result.stored_items, &mut inlines_writer);
+            let top = SerdeElem::build(*elem, &mut inlines_writer);
             result.items.push(top);
         }
         for (link_label, url) in inlines_writer.drain_pending_links() {
@@ -77,34 +112,118 @@ impl<'a> SerdeDoc<'a> {
 }
 
 impl<'a> SerdeElem<'a> {
-    fn build(elem: MdElemRef<'a>, storage: &mut Holder<Self>, inlines_writer: &mut MdInlinesWriter<'a>) {
+    fn build_multi<M>(elems: &'a [M], inlines_writer: &mut MdInlinesWriter<'a>) -> Vec<Self>
+    where
+        M: Borrow<MdElem>,
+    {
+        let mut result = Vec::with_capacity(elems.len());
+        for elem in elems {
+            result.push(Self::build(elem.borrow().into(), inlines_writer));
+        }
+        result
+    }
+
+    fn build(elem: MdElemRef<'a>, inlines_writer: &mut MdInlinesWriter<'a>) -> Self {
         match elem {
-            MdElemRef::Doc(doc) => {
-                for elem in doc {
-                    let elem_serde = Self::build(elem.into(), storage, inlines_writer);
+            MdElemRef::Doc(doc) => Self::Document(Self::build_multi(doc, inlines_writer)),
+            MdElemRef::BlockQuote(bq) => Self::BlockQuote(Self::build_multi(&bq.body, inlines_writer)),
+            MdElemRef::CodeBlock(cb) => {
+                let CodeBlock { variant, value } = cb;
+                let (code_type, metadata, language) = match variant {
+                    CodeVariant::Code(None) => (CodeBlockType::Code, None, None),
+                    CodeVariant::Code(Some(code_opts)) => (
+                        CodeBlockType::Code,
+                        code_opts.metadata.as_ref(),
+                        Some(&code_opts.language),
+                    ),
+                    CodeVariant::Math { metadata } => (CodeBlockType::Math, metadata.as_ref(), None),
+                    CodeVariant::Toml => (CodeBlockType::Toml, None, None),
+                    CodeVariant::Yaml => (CodeBlockType::Yaml, None, None),
+                };
+                Self::CodeBlock {
+                    code: value,
+                    code_type,
+                    metadata,
+                    language,
                 }
             }
-            MdElemRef::BlockQuote(_) => {}
-            MdElemRef::CodeBlock(_) => {}
-            MdElemRef::Inline(_) => {}
-            MdElemRef::List(_) => {}
-            MdElemRef::Paragraph(_) => {}
-            MdElemRef::Section(_) => {}
-            MdElemRef::Table(_) => {}
-            MdElemRef::ThematicBreak => {}
-            MdElemRef::ListItem(_) => {}
-            MdElemRef::Link(_) => {}
-            MdElemRef::Image(_) => {}
+            MdElemRef::Inline(inline) => {
+                let as_string = inlines_to_string([inline], inlines_writer);
+                Self::Paragraph(as_string)
+            }
+            MdElemRef::List(list) => {
+                let mut starting = list.starting_index;
+                let mut li_refs = Vec::with_capacity(list.items.len());
+                for li in &list.items {
+                    let (li_type, index) = match starting.as_mut() {
+                        None => (ListItemType::Unordered, None),
+                        Some(value) => {
+                            let old = *value;
+                            *value += 1;
+                            (ListItemType::Ordered, Some(old))
+                        }
+                    };
+                    li_refs.push(LiSerde {
+                        item: Self::build_multi(&li.item, inlines_writer),
+                        checked: &li.checked,
+                        li_type,
+                        index,
+                    })
+                }
+                Self::List(li_refs)
+            }
+            MdElemRef::Paragraph(p) => {
+                let as_string = inlines_to_string(&p.body, inlines_writer);
+                Self::Paragraph(as_string)
+            }
+            MdElemRef::Section(section) => {
+                let Section { depth, title, body } = section;
+                let depth = *depth;
+                let title = inlines_to_string(title, inlines_writer);
+                let body = Self::build_multi(body, inlines_writer);
+                Self::Section { depth, title, body }
+            }
+            // MdElemRef::Table(_) => {}
+            // MdElemRef::ThematicBreak => {}
+            // MdElemRef::ListItem(li) => {}
+            MdElemRef::Link(link) => {
+                let Link { text, link_definition } = link;
+                let LinkDefinition { url, title, reference } = link_definition;
+
+                let display = inlines_to_string(text, inlines_writer);
+                let (reference, reference_style) = match reference {
+                    LinkReference::Inline => (None, None),
+                    LinkReference::Full(reference) => (Some(Cow::Borrowed(reference)), None),
+                    LinkReference::Collapsed => (None, Some(LinkCollapseStyle::Collapsed)),
+                    LinkReference::Shortcut => (None, Some(LinkCollapseStyle::Shortcut)),
+                };
+                Self::Link {
+                    display,
+                    url,
+                    title,
+                    reference,
+                    reference_style,
+                }
+            }
+            // MdElemRef::Image(_) => {}
+            _ => todo!(),
         }
     }
 }
 
-fn inlines_to_string(inlines: &Vec<Inline>, writer: &mut MdInlinesWriter) -> String {
-    md_to_string(inlines.iter().map(|inline| MdElemRef::Inline(inline)).collect())
+fn inlines_to_string<'a, I>(inlines: I, writer: &mut MdInlinesWriter<'a>) -> String
+where
+    I: IntoIterator<Item = &'a Inline>,
+{
+    md_to_string(
+        &inlines.into_iter().map(|inline| MdElemRef::Inline(inline)).collect(),
+        writer,
+    )
 }
 
-fn md_to_string(md: &Vec<MdElemRef>, writer: &mut MdInlinesWriter) -> String {
+fn md_to_string<'a>(md: &Vec<MdElemRef<'a>>, writer: &mut MdInlinesWriter<'a>) -> String {
     let mut output = Output::new(String::with_capacity(16)); // guess
+    fmt_md::write_md_inlines(&mut output, md.iter().map(|e| *e), writer);
 
     output.take_underlying().unwrap()
 }

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -285,15 +285,8 @@ fn inlines_to_string<'a, I>(inlines: I, writer: &mut MdInlinesWriter<'a>) -> Str
 where
     I: IntoIterator<Item = &'a Inline>,
 {
-    md_to_string(
-        &inlines.into_iter().map(|inline| MdElemRef::Inline(inline)).collect(),
-        writer,
-    )
-}
-
-fn md_to_string<'a>(md: &Vec<MdElemRef<'a>>, writer: &mut MdInlinesWriter<'a>) -> String {
+    let md: Vec<_> = inlines.into_iter().map(|inline| MdElemRef::Inline(inline)).collect();
     let mut output = Output::new(String::with_capacity(16)); // guess
-    fmt_md::write_md_inlines(&mut output, md.iter().map(|e| *e), writer);
-
+    fmt_md::write_md_inlines(&mut output, md.into_iter().map(|e| e), writer);
     output.take_underlying().unwrap()
 }

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -6,7 +6,7 @@ pub struct MdElemsStream<'md, 's> {
     elems: &'s Vec<MdElemRef<'md>>,
 }
 
-impl<'md, 's> From<&'s Vec<MdElemRef<'md>>> for MdElemsStream {
+impl<'md, 's> From<&'s Vec<MdElemRef<'md>>> for MdElemsStream<'md, 's> {
     fn from(elems: &'s Vec<MdElemRef<'md>>) -> Self {
         Self { elems }
     }
@@ -17,39 +17,20 @@ impl<'md, 's> Serialize for MdElemsStream<'md, 's> {
     where
         S: Serializer,
     {
+        todo
         // TODO: create Inlines holder, use it to serialize something of form:
-        {
-            items: <vec>,
-            references: <vec>
-        }
-        // or maybe:
-        {
-            items: []items
-        }
-        where:
-            item: {
-                item: <contents>
-                references: []refs
-            }
-    }
-}
-
-impl<'md, 's> MdElemsStream<'md, 's> {
-    fn serialize_elem<S: Serializer>(&mut self, elem: MdElemRef<'md>, out: S) {
-        todo!();
-        match elem {
-            MdElemRef::Doc(doc) => {}
-            MdElemRef::BlockQuote(block) => {}
-            MdElemRef::CodeBlock(block) => {}
-            MdElemRef::Inline(inline) => {}
-            MdElemRef::List(list) => {}
-            MdElemRef::Paragraph(paragraph) => {}
-            MdElemRef::Section(section) => {}
-            MdElemRef::Table(table) => {}
-            MdElemRef::ThematicBreak => {}
-            MdElemRef::ListItem(list_item) => {}
-            MdElemRef::Link(link) => {}
-            MdElemRef::Image(image) => {}
-        }
+        // {
+        //     items: <vec>,
+        //     references: <vec>
+        // }
+        // // or maybe:
+        // {
+        //     items: []items
+        // }
+        // where:
+        //     item: {
+        //         item: <contents>
+        //         references: []refs
+        //     }
     }
 }

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -1,36 +1,133 @@
+use crate::fmt_md_inlines::{MdInlinesWriter, MdInlinesWriterOptions, UrlAndTitle};
+use crate::link_transform::LinkLabel;
+use crate::output::Output;
+use crate::tree::Inline;
 use crate::tree_ref::MdElemRef;
 use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
+use std::borrow::Cow;
+use std::collections::HashMap;
 
-pub struct MdElemsStream<'md, 's> {
-    elems: &'s Vec<MdElemRef<'md>>,
+#[derive(Serialize)]
+pub enum ElemType {
+    Document,
+    Section,
 }
 
-impl<'md, 's> From<&'s Vec<MdElemRef<'md>>> for MdElemsStream<'md, 's> {
-    fn from(elems: &'s Vec<MdElemRef<'md>>) -> Self {
-        Self { elems }
+#[derive(Serialize)]
+#[serde(untagged)]
+pub enum SerdeElem<'a> {
+    Node {
+        #[serde(rename = "type")]
+        elem_type: ElemType,
+        contents: &'a SerdeElem<'a>,
+    },
+    Inline(String),
+}
+
+#[derive(Serialize)]
+pub struct SerdeDoc<'a> {
+    items: Vec<SerdeElem<'a>>,
+    links: HashMap<Cow<'a, str>, UrlAndTitle<'a>>,
+    footnotes: HashMap<&'a String, SerdeElem<'a>>,
+
+    #[serde(skip_serializing)]
+    stored_items: Holder<SerdeElem<'a>>,
+}
+
+struct Holder<E>(Vec<E>);
+
+impl<E> Holder<E> {
+    fn with_capacity(size: usize) -> Self {
+        Self(Vec::with_capacity(size))
+    }
+
+    fn store(&mut self, item: E) -> &E {
+        self.0.push(item);
+        &self.0[&self.0.len() - 1]
     }
 }
 
-impl<'md, 's> Serialize for MdElemsStream<'md, 's> {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: Serializer,
-    {
-        todo
-        // TODO: create Inlines holder, use it to serialize something of form:
-        // {
-        //     items: <vec>,
-        //     references: <vec>
-        // }
-        // // or maybe:
-        // {
-        //     items: []items
-        // }
-        // where:
-        //     item: {
-        //         item: <contents>
-        //         references: []refs
-        //     }
+impl<'a> SerdeDoc<'a> {
+    pub fn new(elems: &Vec<MdElemRef>, opts: MdInlinesWriterOptions) -> Self {
+        let mut inlines_writer = MdInlinesWriter::new(opts);
+        const DEFAULT_CAPACITY: usize = 16; // todo we can actually compute these if we want
+        let mut result = Self {
+            items: Vec::with_capacity(DEFAULT_CAPACITY),
+            links: HashMap::with_capacity(DEFAULT_CAPACITY),
+            footnotes: HashMap::with_capacity(DEFAULT_CAPACITY),
+            stored_items: Holder::with_capacity(DEFAULT_CAPACITY),
+        };
+        for elem in elems {
+            let top = SerdeDoc::build(*elem, &mut result.stored_items, &mut inlines_writer);
+            result.items.push(top);
+        }
+        for (link_label, url) in inlines_writer.drain_pending_links() {
+            let link_to_str = match link_label {
+                LinkLabel::Text(text) => text,
+                LinkLabel::Inline(inlines) => Cow::Owned(inlines_to_string(inlines, &mut inlines_writer)),
+            };
+            result.links.insert(link_to_str, url);
+        }
+        for (footnote_name, footnote_contents) in inlines_writer.drain_pending_footnotes() {
+            // TODO
+        }
+        result
     }
 }
+
+impl<'a> SerdeElem<'a> {
+    fn build(elem: MdElemRef<'a>, storage: &mut Holder<Self>, inlines_writer: &mut MdInlinesWriter<'a>) {
+        match elem {
+            MdElemRef::Doc(doc) => {
+                for elem in doc {
+                    let elem_serde = Self::build(elem.into(), storage, inlines_writer);
+                }
+            }
+            MdElemRef::BlockQuote(_) => {}
+            MdElemRef::CodeBlock(_) => {}
+            MdElemRef::Inline(_) => {}
+            MdElemRef::List(_) => {}
+            MdElemRef::Paragraph(_) => {}
+            MdElemRef::Section(_) => {}
+            MdElemRef::Table(_) => {}
+            MdElemRef::ThematicBreak => {}
+            MdElemRef::ListItem(_) => {}
+            MdElemRef::Link(_) => {}
+            MdElemRef::Image(_) => {}
+        }
+    }
+}
+
+fn inlines_to_string(inlines: &Vec<Inline>, writer: &mut MdInlinesWriter) -> String {
+    md_to_string(inlines.iter().map(|inline| MdElemRef::Inline(inline)).collect())
+}
+
+fn md_to_string(md: &Vec<MdElemRef>, writer: &mut MdInlinesWriter) -> String {
+    let mut output = Output::new(String::with_capacity(16)); // guess
+
+    output.take_underlying().unwrap()
+}
+
+// impl<'md, 's> Serialize for MdElemsStream<'md, 's> {
+//     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+//     where
+//         S: Serializer,
+//     {
+//         todo
+//         // TODO: create Inlines holder, use it to serialize something of form:
+//         // {
+//         //     items: <vec>,
+//         //     references: <vec>
+//         // }
+//         // // or maybe:
+//         // {
+//         //     items: []items
+//         // }
+//         // where:
+//         //     item: {
+//         //         item: <contents>
+//         //         references: []refs
+//         //     }
+//     }
+// }

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -1,11 +1,55 @@
 use crate::tree_ref::MdElemRef;
+use serde::ser::SerializeSeq;
 use serde::{Serialize, Serializer};
 
-impl<'a> Serialize for MdElemRef<'a> {
+pub struct MdElemsStream<'md, 's> {
+    elems: &'s Vec<MdElemRef<'md>>,
+}
+
+impl<'md, 's> From<&'s Vec<MdElemRef<'md>>> for MdElemsStream {
+    fn from(elems: &'s Vec<MdElemRef<'md>>) -> Self {
+        Self { elems }
+    }
+}
+
+impl<'md, 's> Serialize for MdElemsStream<'md, 's> {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
         S: Serializer,
     {
-        serializer.serialize_str("testing")
+        // TODO: create Inlines holder, use it to serialize something of form:
+        {
+            items: <vec>,
+            references: <vec>
+        }
+        // or maybe:
+        {
+            items: []items
+        }
+        where:
+            item: {
+                item: <contents>
+                references: []refs
+            }
+    }
+}
+
+impl<'md, 's> MdElemsStream<'md, 's> {
+    fn serialize_elem<S: Serializer>(&mut self, elem: MdElemRef<'md>, out: S) {
+        todo!();
+        match elem {
+            MdElemRef::Doc(doc) => {}
+            MdElemRef::BlockQuote(block) => {}
+            MdElemRef::CodeBlock(block) => {}
+            MdElemRef::Inline(inline) => {}
+            MdElemRef::List(list) => {}
+            MdElemRef::Paragraph(paragraph) => {}
+            MdElemRef::Section(section) => {}
+            MdElemRef::Table(table) => {}
+            MdElemRef::ThematicBreak => {}
+            MdElemRef::ListItem(list_item) => {}
+            MdElemRef::Link(link) => {}
+            MdElemRef::Image(image) => {}
+        }
     }
 }

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -1,0 +1,11 @@
+use crate::tree_ref::MdElemRef;
+use serde::{Serialize, Serializer};
+
+impl<'a> Serialize for MdElemRef<'a> {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str("testing")
+    }
+}

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -627,6 +627,30 @@ mod tests {
         );
     }
 
+    #[test]
+    fn table() {
+        check(
+            md_elem!(Table {
+                alignments: vec![AlignKind::Left, AlignKind::None],
+                rows: vec![
+                    vec![vec![mdq_inline!("R1C1")], vec![mdq_inline!("R1C2")]],
+                    vec![vec![mdq_inline!("R2C1")], vec![mdq_inline!("R2C2")]],
+                ]
+            }),
+            json_str!(
+                {"items":[
+                    {"table":{
+                        "alignments": ["left", "none"],
+                        "rows": [
+                            [ "R1C1", "R1C2" ],
+                            [ "R2C1", "R2C2" ]
+                        ]
+                    }}
+                ]}
+            ),
+        );
+    }
+
     fn check(given: MdElem, expect: &str) {
         let opts = MdInlinesWriterOptions {
             link_canonicalization: LinkTransform::Keep,


### PR DESCRIPTION
Provide `--json` output option.

This introduces now a _third_ version of the md-nodes enum, but I think it's probably  acceptable. There may be a consolidation opportunity in the future (especially with `MdElemRef`, which is already denormalized w.r.t. `MdElem`), but this is okay for now.

Resolves #74.