### PR TITLE
let selector strings start with list selectors

### DIFF
--- a/examples/hello.md
+++ b/examples/hello.md
@@ -47,7 +47,7 @@ This is [a collapsed link][], and this is [a shortcut link].
 - Item a[^1]
 
 - [x] checked
-- [ ] unchecked
+- [ ] unchecked and contains a [link within a task](https://example.com/task)
 
 [a2]: https://example.com/reference "from the previous section"
 [^1]: interesting footnote

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,6 @@ use clap::Parser;
 use std::borrow::Cow;
 use std::io;
 use std::io::{stdin, Read};
-use std::ops::Deref;
 use std::process::ExitCode;
 
 use crate::fmt_md::{MdOptions, ReferencePlacement};
@@ -48,28 +47,36 @@ struct Cli {
     #[arg(long, short, value_enum, default_value_t=LinkTransform::Reference)]
     link_canonicalization: LinkTransform,
 
+    /// Output the results as a JSON object, instead of as markdown.
     #[arg(long, short, default_value_t = false)]
-    json: bool,
+    json: bool, // TODO this should really be output=<json|md>
 
-    #[arg(short = ' ', hide = true)]
-    list_switch: Option<String>,
+    #[arg(
+        short = ' ',
+        hide = true,
+        group = "selectors_group",
+        value_name = "selectors starting with list"
+    )]
+    list_selector: Option<String>,
 
-    /// The selector string
+    /// The selectors string
+    #[arg(group = "selectors_group", value_name = "selectors")]
     selectors: Option<String>,
 }
 
 impl Cli {
-    fn selector_string(&self) -> Result<Cow<String>, &str> {
-        match (&self.selectors, &self.list_switch) {
-            (Some(selectors), None) => Ok(Cow::Borrowed(selectors)),
-            (None, Some(list_selectors)) => {
-                let mut reconstructed = String::with_capacity(list_selectors.len() + 2);
-                reconstructed.push_str("- ");
-                reconstructed.push_str(list_selectors);
-                Ok(Cow::Owned(reconstructed))
-            }
-            (None, None) => Ok(Cow::Owned(String::new())),
-            (Some(_), Some(_)) => Err("cannot list multiple selectors"),
+    fn selector_string(&self) -> Cow<String> {
+        match &self.selectors {
+            Some(s) => Cow::Borrowed(s),
+            None => match &self.list_selector {
+                Some(list_selectors) => {
+                    let mut reconstructed = String::with_capacity(list_selectors.len() + 2);
+                    reconstructed.push_str("- ");
+                    reconstructed.push_str(list_selectors);
+                    Cow::Owned(reconstructed)
+                }
+                None => Cow::Owned(String::new()),
+            },
         }
     }
 }
@@ -82,17 +89,11 @@ fn main() -> ExitCode {
     let ast = markdown::to_mdast(&mut contents, &markdown::ParseOptions::gfm()).unwrap();
     let mdqs = MdElem::read(ast, &ReadOptions::default()).unwrap();
 
-    let selectors_str = match cli.selector_string() {
-        Ok(s) => s,
-        Err(err) => {
-            eprintln!("{err}");
-            return ExitCode::FAILURE;
-        }
-    };
-    let selectors = match MdqRefSelector::parse(selectors_str.deref()) {
+    let selectors_str = cli.selector_string();
+    let selectors = match MdqRefSelector::parse(&selectors_str) {
         Ok(selectors) => selectors,
         Err(err) => {
-            print_select_parse_error(selectors_str.deref(), err);
+            print_select_parse_error(&selectors_str, err);
             return ExitCode::FAILURE;
         }
     };


### PR DESCRIPTION
Allow something like:

```
cat example.md | mdq '- foo'
```

We do this by creating a hidden flag named ` ` (just a space), so that `- foo` is really the `-{space}` flag followed by an argument `foo`. We then use that to recreate the `- foo` selector string.

clap arg groups let us validate that the user doesn't specify both this list-starting selector and a normal selector:

```
$ mdq '# hello' ✅
$ mdq '- world' ✅

$ mdq '# hello' '- world' ❌
error: the argument '[selectors]' cannot be used with '-  <selectors starting with list>'
```

The error message isn't perfect, but this is good enough.

Resolves #102 