### PR TITLE
lock stdout

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -112,10 +112,10 @@ fn main() -> ExitCode {
         },
     };
 
+    let mut stdout = io::stdout().lock();
     if cli.json {
-        serde_json::to_writer(io::stdout(), &SerdeDoc::new(&pipeline_nodes, md_options.inline_options)).unwrap();
+        serde_json::to_writer(&mut stdout, &SerdeDoc::new(&pipeline_nodes, md_options.inline_options)).unwrap();
     } else {
-        let mut stdout = io::stdout().lock();
         let mut out = output::Output::new(Stream(&mut stdout));
         fmt_md::write_md(&md_options, &mut out, pipeline_nodes.into_iter());
         out.write_str("\n");

--- a/src/main.rs
+++ b/src/main.rs
@@ -115,7 +115,8 @@ fn main() -> ExitCode {
     if cli.json {
         serde_json::to_writer(io::stdout(), &SerdeDoc::new(&pipeline_nodes, md_options.inline_options)).unwrap();
     } else {
-        let mut out = output::Output::new(Stream(io::stdout()));
+        let mut stdout = io::stdout().lock();
+        let mut out = output::Output::new(Stream(&mut stdout));
         fmt_md::write_md(&md_options, &mut out, pipeline_nodes.into_iter());
         out.write_str("\n");
     }


### PR DESCRIPTION
I did some very rough benchmarking on a file that's just 1000x of `examples/hello.md`, and this doesn't seem to have any effect.

But hey, why not.

resolves #95 