### PR TITLE
quoted strings

### DIFF
--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -26,6 +26,7 @@ pub enum ParseErrorReason {
     UnexpectedCharacter(char),
     UnexpectedEndOfInput,
     InvalidSyntax(String),
+    InvalidEscape,
 }
 
 impl Display for ParseErrorReason {
@@ -35,6 +36,7 @@ impl Display for ParseErrorReason {
             ParseErrorReason::UnexpectedCharacter(ch) => write!(f, "unexpected character \"{}\"", ch),
             ParseErrorReason::UnexpectedEndOfInput => write!(f, "unexpected end of input"),
             ParseErrorReason::InvalidSyntax(s) => write!(f, "{}", s),
+            ParseErrorReason::InvalidEscape => write!(f, "invalid escape sequence"),
         }
     }
 }


### PR DESCRIPTION
Add quoted string matchers:

- can start with either a single or double quote
- escape sequences for quotes (single or double, regardless of the quote char used to start the string), tabs, newlines, and unicode escape
- case sensitive

This resolves #77. See discussion at #56.