### PR TITLE
section selector selects the whole section

### DIFF
--- a/src/select/base.rs
+++ b/src/select/base.rs
@@ -1,12 +1,11 @@
 use crate::tree_ref::MdElemRef;
 
-pub trait Selector<'a, I: Copy> {
+pub trait Selector<'a, I: Copy + Into<MdElemRef<'a>>> {
     fn matches(&self, item: I) -> bool;
-    fn pick(&self, item: I) -> MdElemRef<'a>;
 
     fn try_select(&self, item: I) -> Option<MdElemRef<'a>> {
         if self.matches(item) {
-            Some(self.pick(item))
+            Some(item.into())
         } else {
             None
         }

--- a/src/select/sel_image.rs
+++ b/src/select/sel_image.rs
@@ -3,7 +3,6 @@ use crate::select::base::Selector;
 use crate::select::sel_link::LinkMatchers;
 use crate::select::ParseResult;
 use crate::tree::Image;
-use crate::tree_ref::MdElemRef;
 
 #[derive(Debug, PartialEq)]
 pub struct ImageSelector {
@@ -20,9 +19,5 @@ impl ImageSelector {
 impl<'a> Selector<'a, &'a Image> for ImageSelector {
     fn matches(&self, item: &'a Image) -> bool {
         self.matchers.display_matcher.matches(&item.alt) && self.matchers.url_matcher.matches(&item.link.url)
-    }
-
-    fn pick(&self, item: &'a Image) -> MdElemRef<'a> {
-        item.into()
     }
 }

--- a/src/select/sel_image.rs
+++ b/src/select/sel_image.rs
@@ -23,6 +23,6 @@ impl<'a> Selector<'a, &'a Image> for ImageSelector {
     }
 
     fn pick(&self, item: &'a Image) -> MdElemRef<'a> {
-        MdElemRef::Image(item)
+        item.into()
     }
 }

--- a/src/select/sel_link.rs
+++ b/src/select/sel_link.rs
@@ -3,7 +3,6 @@ use crate::parsing_iter::ParsingIterator;
 use crate::select::base::Selector;
 use crate::select::ParseResult;
 use crate::tree::Link;
-use crate::tree_ref::MdElemRef;
 
 #[derive(Debug, PartialEq)]
 pub struct LinkSelector {
@@ -21,10 +20,6 @@ impl<'a> Selector<'a, &'a Link> for LinkSelector {
     fn matches(&self, item: &'a Link) -> bool {
         self.matchers.display_matcher.matches_inlines(&item.text)
             && self.matchers.url_matcher.matches(&item.link_definition.url)
-    }
-
-    fn pick(&self, item: &'a Link) -> MdElemRef<'a> {
-        item.into()
     }
 }
 

--- a/src/select/sel_link.rs
+++ b/src/select/sel_link.rs
@@ -24,7 +24,7 @@ impl<'a> Selector<'a, &'a Link> for LinkSelector {
     }
 
     fn pick(&self, item: &'a Link) -> MdElemRef<'a> {
-        MdElemRef::Link(item)
+        item.into()
     }
 }
 

--- a/src/select/sel_list_item.rs
+++ b/src/select/sel_list_item.rs
@@ -88,7 +88,7 @@ impl<'a> Selector<'a, ListItemRef<'a>> for ListItemSelector {
     }
 
     fn pick(&self, item: ListItemRef<'a>) -> MdElemRef<'a> {
-        MdElemRef::ListItem(item)
+        item.into()
     }
 }
 

--- a/src/select/sel_list_item.rs
+++ b/src/select/sel_list_item.rs
@@ -2,7 +2,7 @@ use crate::matcher::StringMatcher;
 use crate::parsing_iter::ParsingIterator;
 use crate::select::base::Selector;
 use crate::select::{ParseErrorReason, ParseResult, SELECTOR_SEPARATOR};
-use crate::tree_ref::{ListItemRef, MdElemRef};
+use crate::tree_ref::ListItemRef;
 
 #[derive(Debug, PartialEq)]
 pub struct ListItemSelector {
@@ -85,10 +85,6 @@ impl<'a> Selector<'a, ListItemRef<'a>> for ListItemSelector {
     fn matches(&self, item: ListItemRef<'a>) -> bool {
         let ListItemRef(idx, li) = item;
         self.li_type.matches(&idx) && self.checkbox.matches(&li.checked) && self.string_matcher.matches_any(&li.item)
-    }
-
-    fn pick(&self, item: ListItemRef<'a>) -> MdElemRef<'a> {
-        item.into()
     }
 }
 

--- a/src/select/sel_section.rs
+++ b/src/select/sel_section.rs
@@ -3,7 +3,6 @@ use crate::parsing_iter::ParsingIterator;
 use crate::select::base::Selector;
 use crate::select::{ParseResult, SELECTOR_SEPARATOR};
 use crate::tree::Section;
-use crate::tree_ref::MdElemRef;
 
 #[derive(Debug, PartialEq)]
 pub struct SectionSelector {
@@ -20,9 +19,5 @@ impl SectionSelector {
 impl<'a> Selector<'a, &'a Section> for SectionSelector {
     fn matches(&self, section: &'a Section) -> bool {
         self.matcher.matches_inlines(&section.title)
-    }
-
-    fn pick(&self, item: &'a Section) -> MdElemRef<'a> {
-        item.into()
     }
 }

--- a/src/select/sel_section.rs
+++ b/src/select/sel_section.rs
@@ -23,6 +23,6 @@ impl<'a> Selector<'a, &'a Section> for SectionSelector {
     }
 
     fn pick(&self, item: &'a Section) -> MdElemRef<'a> {
-        MdElemRef::Doc(&item.body)
+        item.into()
     }
 }

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -41,6 +41,12 @@ impl<'a> From<&'a MdElem> for MdElemRef<'a> {
     }
 }
 
+impl<'a> From<&'a Section> for MdElemRef<'a> {
+    fn from(value: &'a Section) -> Self {
+        MdElemRef::Section(value)
+    }
+}
+
 #[macro_export]
 macro_rules! wrap_mdq_refs {
     ($variant:ident: $source:expr) => {{

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -41,6 +41,24 @@ impl<'a> From<&'a MdElem> for MdElemRef<'a> {
     }
 }
 
+impl<'a> From<ListItemRef<'a>> for MdElemRef<'a> {
+    fn from(value: ListItemRef<'a>) -> Self {
+        MdElemRef::ListItem(value)
+    }
+}
+
+impl<'a> From<&'a Image> for MdElemRef<'a> {
+    fn from(value: &'a Image) -> Self {
+        MdElemRef::Image(value)
+    }
+}
+
+impl<'a> From<&'a Link> for MdElemRef<'a> {
+    fn from(value: &'a Link) -> Self {
+        MdElemRef::Link(value)
+    }
+}
+
 impl<'a> From<&'a Section> for MdElemRef<'a> {
     fn from(value: &'a Section) -> Self {
         MdElemRef::Section(value)


### PR DESCRIPTION
Instead of only selecting the body, it selects the title as well. This also brings in a simplification to remove `fn pick(..)`, if we provide various `Into<MdElemRef>`s.

Resolves #108.