### PR TITLE
change `--json` to `--output json`

### DIFF
--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -102,10 +102,10 @@ impl<'a> MdInlinesWriter<'a> {
         self.pending_references.footnotes.drain().collect()
     }
 
-    pub fn write_line<W, I>(&mut self, out: &mut Output<W>, elems: I)
+    pub fn write_line<I, W>(&mut self, out: &mut Output<W>, elems: I)
     where
-        W: SimpleWrite,
         I: IntoIterator<Item = &'a Inline>,
+        W: SimpleWrite,
     {
         for elem in elems {
             self.write_inline_element(out, elem);

--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -5,7 +5,7 @@ use crate::tree::{
     TextVariant,
 };
 use serde::Serialize;
-use std::borrow::{Borrow, Cow};
+use std::borrow::Cow;
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Copy, Clone)]
@@ -102,13 +102,13 @@ impl<'a> MdInlinesWriter<'a> {
         self.pending_references.footnotes.drain().collect()
     }
 
-    pub fn write_line<E, W>(&mut self, out: &mut Output<W>, elems: &'a [E])
+    pub fn write_line<W, I>(&mut self, out: &mut Output<W>, elems: I)
     where
-        E: Borrow<Inline>,
         W: SimpleWrite,
+        I: IntoIterator<Item = &'a Inline>,
     {
         for elem in elems {
-            self.write_inline_element(out, elem.borrow());
+            self.write_inline_element(out, elem);
         }
     }
 
@@ -174,7 +174,7 @@ impl<'a> MdInlinesWriter<'a> {
         out.write_char('[');
         match &label {
             LinkLabel::Text(text) => out.write_str(text),
-            LinkLabel::Inline(text) => self.write_line(out, text),
+            LinkLabel::Inline(text) => self.write_line(out, *text),
         }
         out.write_char(']');
 

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -1,4 +1,3 @@
-use crate::fmt_md;
 use crate::fmt_md_inlines::{MdInlinesWriter, MdInlinesWriterOptions, UrlAndTitle};
 use crate::link_transform::LinkLabel;
 use crate::output::Output;
@@ -287,9 +286,8 @@ fn inlines_to_string<'a, I>(inlines: I, writer: &mut MdInlinesWriter<'a>) -> Str
 where
     I: IntoIterator<Item = &'a Inline>,
 {
-    let md: Vec<_> = inlines.into_iter().map(|inline| MdElemRef::Inline(inline)).collect();
     let mut output = Output::new(String::with_capacity(16)); // guess
-    fmt_md::write_md_inlines(&mut output, md.into_iter().map(|e| e), writer);
+    writer.write_line(&mut output, inlines);
     output.take_underlying().unwrap()
 }
 

--- a/tests/md_cases/output_format.toml
+++ b/tests/md_cases/output_format.toml
@@ -1,0 +1,40 @@
+[given]
+md = '''
+Test _one_ two[1] three.
+
+[1]: https://example.com/1
+'''
+
+
+[expect."default"]
+cli_args = []
+output = '''
+Test _one_ two[1] three.
+
+[1]: https://example.com/1
+'''
+
+
+[expect."md"]
+cli_args = ['-o', 'md']
+output = '''
+Test _one_ two[1] three.
+
+[1]: https://example.com/1
+'''
+
+
+[expect."markdown"]
+cli_args = ['--output', 'markdown']
+output = '''
+Test _one_ two[1] three.
+
+[1]: https://example.com/1
+'''
+
+
+[expect."json"]
+cli_args = ['--output', 'json']
+output = '''
+{"items":[{"document":[{"paragraph":"Test _one_ two[1] three."}]}],"links":{"1":{"url":"https://example.com/1"}}}
+'''

--- a/tests/md_cases/output_format.toml
+++ b/tests/md_cases/output_format.toml
@@ -1,6 +1,6 @@
 [given]
 md = '''
-Test _one_ two[1] three.
+Test _one_ [two][1] three.
 
 [1]: https://example.com/1
 '''
@@ -9,7 +9,7 @@ Test _one_ two[1] three.
 [expect."default"]
 cli_args = []
 output = '''
-Test _one_ two[1] three.
+Test _one_ [two][1] three.
 
 [1]: https://example.com/1
 '''
@@ -18,7 +18,7 @@ Test _one_ two[1] three.
 [expect."md"]
 cli_args = ['-o', 'md']
 output = '''
-Test _one_ two[1] three.
+Test _one_ [two][1] three.
 
 [1]: https://example.com/1
 '''
@@ -27,7 +27,7 @@ Test _one_ two[1] three.
 [expect."markdown"]
 cli_args = ['--output', 'markdown']
 output = '''
-Test _one_ two[1] three.
+Test _one_ [two][1] three.
 
 [1]: https://example.com/1
 '''
@@ -36,5 +36,4 @@ Test _one_ two[1] three.
 [expect."json"]
 cli_args = ['--output', 'json']
 output = '''
-{"items":[{"document":[{"paragraph":"Test _one_ two[1] three."}]}],"links":{"1":{"url":"https://example.com/1"}}}
-'''
+{"items":[{"document":[{"paragraph":"Test _one_ [two][1] three."}]}],"links":{"1":{"url":"https://example.com/1"}}}'''


### PR DESCRIPTION
Default is `--output markdown`.

This way is more flexible in the future, if I want more output formats for whatever reason.

Also fix an unrelated bug in the JSON output, which I found when I added an integ test for it.

Resolves a TODO, in service of #11.