### PR TITLE
add block quote selector

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,27 +28,34 @@ you can (for example) ask mdq for all uncompleted tasks:
 mdq '- [ ]'
 ```
 
-mdq is available under the Apache 2.0 or MIT licenses, at your option. I am open to other permissive licenses, if you have one you prefer.
+mdq is available under the Apache 2.0 or MIT licenses, at your option. I am open to other permissive licenses, if you
+have one you prefer.
 
 # Installation
 
 Any of these will work:
+
 1. ```shell
    cargo install --git https://github.com/yshavit/mdq
    ```
 2. You can download binaries from [the latest release] (or any other release, of course).
-3. You can also grab the binaries from the latest [build-release] workflow run. You must be logged into GitHub to do that (their limitation, not mine!)
+3. You can also grab the binaries from the latest [build-release] workflow run. You must be logged into GitHub to do
+   that (their limitation, not mine!)
 
 > [!Note]
-> - These binaries are all built on GitHub's servers, so if you trust my code (and dependencies), and you trust GitHub, you can trust the binaries.
->
->   See [the wiki page on release binaries] for information on how to verify them.
+> - These binaries are all built on GitHub's servers, so if you trust my code (and dependencies), and you trust GitHub,
+    you can trust the binaries.
+    >
+    >   See [the wiki page on release binaries] for information on how to verify them.
 > - You'll have to `chmod +x` them before you can run them.
 > - The Windows release hasn't been tested. I suspect it gets newlines wrong.
 >
-> [the wiki page on release binaries]: https://github.com/yshavit/mdq/wiki/Release-binaries
+>
+
+[the wiki page on release binaries]: https://github.com/yshavit/mdq/wiki/Release-binaries
 
 [the latest release]: https://github.com/yshavit/mdq/releases/latest
+
 [build-release]: https://github.com/yshavit/mdq/actions/workflows/build-release.yml
 
 # Basic Usage
@@ -89,6 +96,12 @@ You can select...
   $ cat example.md | mdq '[foo](bar)'  # find links with display text containing "foo"
                                        # and URL containing "bar"
   $ cat example.md | mdq '![foo](bar)' # ditto for images
+  ```
+
+- Block quotes:
+
+  ```bash
+  $ cat example.md | mdq '> foo'  # find block quotes containing "foo"
   ```
 
 The `foo`s and `bar`s above can be:

--- a/build.rs
+++ b/build.rs
@@ -114,6 +114,7 @@ struct TestExpect {
     cli_args: Vec<String>,
     output: String,
     expect_success: Option<bool>,
+    ignore: Option<String>,
 }
 
 impl TestSpecFile {
@@ -125,6 +126,7 @@ impl TestSpecFile {
                 cli_args: test_expect.cli_args,
                 expect_output: test_expect.output,
                 expect_success: test_expect.expect_success.unwrap_or(true),
+                ignored: test_expect.ignore.is_some(),
             })
         }
         results
@@ -134,6 +136,7 @@ impl TestSpecFile {
 #[derive(Debug)]
 struct Case {
     case_name: String,
+    ignored: bool,
     cli_args: Vec<String>,
     expect_output: String,
     expect_success: bool,
@@ -142,6 +145,9 @@ struct Case {
 impl Case {
     fn write_test_fn_to(&self, out: &mut Writer) {
         let fn_name = self.case_name.replace(|ch: char| !ch.is_alphanumeric(), "_");
+        if self.ignored {
+            out.writeln("#[ignore]");
+        }
         out.writeln("#[test]");
         out.writes(&["fn ", &fn_name, "() {"]);
         out.with_indent(|out| {

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -1,6 +1,7 @@
 use crate::parse_common::Position;
 use crate::parsing_iter::ParsingIterator;
 use crate::select::base::Selector;
+use crate::select::sel_block_quote::BlockQuoteSelector;
 use crate::select::sel_image::ImageSelector;
 use crate::select::sel_link::LinkSelector;
 use crate::select::sel_list_item::ListItemSelector;
@@ -130,6 +131,8 @@ selectors![
 
     {'['} Link,
     ! {'['} Image,
+
+    {'>'} BlockQuote
 ];
 
 impl MdqRefSelector {

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -1,5 +1,6 @@
 mod api;
 mod base;
+mod sel_block_quote;
 mod sel_image;
 mod sel_link;
 mod sel_list_item;

--- a/src/select/sel_block_quote.rs
+++ b/src/select/sel_block_quote.rs
@@ -1,0 +1,23 @@
+use crate::matcher::StringMatcher;
+use crate::parsing_iter::ParsingIterator;
+use crate::select::base::Selector;
+use crate::select::{ParseResult, SELECTOR_SEPARATOR};
+use crate::tree::BlockQuote;
+
+#[derive(Debug, PartialEq)]
+pub struct BlockQuoteSelector {
+    matcher: StringMatcher,
+}
+
+impl BlockQuoteSelector {
+    pub fn read(iter: &mut ParsingIterator) -> ParseResult<Self> {
+        let matcher = StringMatcher::read(iter, SELECTOR_SEPARATOR)?;
+        Ok(Self { matcher })
+    }
+}
+
+impl<'a> Selector<'a, &'a BlockQuote> for BlockQuoteSelector {
+    fn matches(&self, block_quote: &'a BlockQuote) -> bool {
+        self.matcher.matches_any(&block_quote.body)
+    }
+}

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -41,6 +41,12 @@ impl<'a> From<&'a MdElem> for MdElemRef<'a> {
     }
 }
 
+impl<'a> From<&'a BlockQuote> for MdElemRef<'a> {
+    fn from(value: &'a BlockQuote) -> Self {
+        MdElemRef::BlockQuote(value)
+    }
+}
+
 impl<'a> From<ListItemRef<'a>> for MdElemRef<'a> {
     fn from(value: ListItemRef<'a>) -> Self {
         MdElemRef::ListItem(value)

--- a/tests/md_cases/select_block_quote.toml
+++ b/tests/md_cases/select_block_quote.toml
@@ -1,0 +1,43 @@
+[given]
+md = '''
+One
+
+> Two
+
+Three
+
+> - Four
+'''
+
+
+[expect."select all block quotes"]
+cli_args = ['>']
+output = '''
+> Two
+
+   -----
+
+> - Four
+'''
+
+
+[expect."select block quote with text"]
+cli_args = ['> two']
+output = '''
+> Two
+'''
+
+
+[expect."select block quote with list text"]
+ignore = '#144'
+cli_args = ['> - four'] # note: space between the - and [ is required
+output = '''
+> - Four
+'''
+
+
+[expect."select block quote then list"]
+cli_args = ['> | - *'] # note: space between the - and [ is required
+output = '''
+- Four
+'''


### PR DESCRIPTION
- syntax:
  ```
  > matcher
  ```
- add integ tests (unit tests are #84)
- found a bug in matching (#144), so I added the ability to mark integ tests as ignored
- add to readme; will add to docs once this gets merged

Intellij auto-formatted my markdown, yay. Whatever.

This resolves #143.