### PR TITLE
require whitespace after `>` and `#` selectors

### DIFF
--- a/src/select/sel_block_quote.rs
+++ b/src/select/sel_block_quote.rs
@@ -11,6 +11,7 @@ pub struct BlockQuoteSelector {
 
 impl BlockQuoteSelector {
     pub fn read(iter: &mut ParsingIterator) -> ParseResult<Self> {
+        iter.require_whitespace_or(SELECTOR_SEPARATOR, ">")?;
         let matcher = StringMatcher::read(iter, SELECTOR_SEPARATOR)?;
         Ok(Self { matcher })
     }

--- a/src/select/sel_section.rs
+++ b/src/select/sel_section.rs
@@ -11,6 +11,7 @@ pub struct SectionSelector {
 
 impl SectionSelector {
     pub fn read(iter: &mut ParsingIterator) -> ParseResult<Self> {
+        iter.require_whitespace_or(SELECTOR_SEPARATOR, "#")?;
         let matcher = StringMatcher::read(iter, SELECTOR_SEPARATOR)?;
         Ok(Self { matcher })
     }


### PR DESCRIPTION
This lets us add modifiers to them later if we want, like `#3`? idk.

See #120