### PR TITLE
code block selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,12 @@ You can select...
   $ cat example.md | mdq '> foo'  # find block quotes containing "foo"
   ```
 
+- Code blocks:
+
+  ```bash
+  $ cat example.md | mdq '```rust fizz'  # find code blocks for rust with "fizz" within them
+  ```
+
 The `foo`s and `bar`s above can be:
 
 - an `unquoted string` that starts with a letter, as shown above

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -256,13 +256,14 @@ mod test {
     mod single_selector_parse {
         use super::*;
         use crate::select::ParseErrorReason::UnexpectedCharacter;
+        use crate::variants_checker;
 
         #[test]
         fn section() {
             let input = "#";
             let mdq_ref_sel_parsed = MdqRefSelector::parse_selector(&mut ParsingIterator::new(input));
             let section_sel_parsed = SectionSelector::read(&mut ParsingIterator::new(&input[1..])).unwrap();
-            assert_eq!(mdq_ref_sel_parsed, Ok(MdqRefSelector::Section(section_sel_parsed)));
+            expect_ok(mdq_ref_sel_parsed, MdqRefSelector::Section(section_sel_parsed));
         }
 
         #[test]
@@ -271,7 +272,7 @@ mod test {
             let mdq_ref_sel_parsed = MdqRefSelector::parse_selector(&mut ParsingIterator::new(input));
             let item_parsed =
                 ListItemSelector::read(ListItemType::Ordered, &mut ParsingIterator::new(&input[1..])).unwrap();
-            assert_eq!(mdq_ref_sel_parsed, Ok(MdqRefSelector::ListItem(item_parsed)));
+            expect_ok(mdq_ref_sel_parsed, MdqRefSelector::ListItem(item_parsed));
         }
 
         #[test]
@@ -280,7 +281,7 @@ mod test {
             let mdq_ref_sel_parsed = MdqRefSelector::parse_selector(&mut ParsingIterator::new(input));
             let item_parsed =
                 ListItemSelector::read(ListItemType::Unordered, &mut ParsingIterator::new(&input[1..])).unwrap();
-            assert_eq!(mdq_ref_sel_parsed, Ok(MdqRefSelector::ListItem(item_parsed)));
+            expect_ok(mdq_ref_sel_parsed, MdqRefSelector::ListItem(item_parsed));
         }
 
         #[test]
@@ -288,7 +289,7 @@ mod test {
             let input = "[]()";
             let mdq_ref_sel_parsed = MdqRefSelector::parse_selector(&mut ParsingIterator::new(input));
             let item_parsed = LinkSelector::read(&mut ParsingIterator::new(&input[1..])).unwrap();
-            assert_eq!(mdq_ref_sel_parsed, Ok(MdqRefSelector::Link(item_parsed)));
+            expect_ok(mdq_ref_sel_parsed, MdqRefSelector::Link(item_parsed));
         }
 
         #[test]
@@ -297,7 +298,7 @@ mod test {
             let mdq_ref_sel_parsed = MdqRefSelector::parse_selector(&mut ParsingIterator::new(input));
             // note: input[2..] because parse_selector reads both the '!' and the '['
             let item_parsed = ImageSelector::read(&mut ParsingIterator::new(&input[2..])).unwrap();
-            assert_eq!(mdq_ref_sel_parsed, Ok(MdqRefSelector::Image(item_parsed)));
+            expect_ok(mdq_ref_sel_parsed, MdqRefSelector::Image(item_parsed));
         }
 
         #[test]
@@ -305,7 +306,7 @@ mod test {
             let input = ">";
             let mdq_ref_sel_parsed = MdqRefSelector::parse_selector(&mut ParsingIterator::new(input));
             let item_parsed = BlockQuoteSelector::read(&mut ParsingIterator::new(&input[1..])).unwrap();
-            assert_eq!(mdq_ref_sel_parsed, Ok(MdqRefSelector::BlockQuote(item_parsed)));
+            expect_ok(mdq_ref_sel_parsed, MdqRefSelector::BlockQuote(item_parsed));
         }
 
         #[test]
@@ -314,6 +315,19 @@ mod test {
             let mdq_ref_sel_parsed = MdqRefSelector::parse_selector(&mut ParsingIterator::new(input));
             assert_eq!(mdq_ref_sel_parsed, Err(UnexpectedCharacter('\u{2603}')));
         }
+
+        fn expect_ok(actual: ParseResult<MdqRefSelector>, expected: MdqRefSelector) {
+            actual.iter().for_each(|s| CHECKER.see(s));
+            assert_eq!(actual, Ok(expected))
+        }
+
+        variants_checker!(CHECKER = MdqRefSelector{
+            Section(_),
+            ListItem(_),
+            Link(_),
+            Image(_),
+            BlockQuote(_),
+        });
     }
 
     #[test]

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -1,6 +1,7 @@
 mod api;
 mod base;
 mod sel_block_quote;
+mod sel_code_block;
 mod sel_image;
 mod sel_link;
 mod sel_list_item;

--- a/src/select/sel_code_block.rs
+++ b/src/select/sel_code_block.rs
@@ -1,0 +1,107 @@
+use crate::matcher::{CharEnd, StringMatcher};
+use crate::parsing_iter::ParsingIterator;
+use crate::select::base::Selector;
+use crate::select::{ParseResult, SELECTOR_SEPARATOR};
+use crate::tree::{CodeBlock, CodeVariant};
+
+#[derive(Debug, PartialEq)]
+pub struct CodeBlockSelector {
+    lang_matcher: StringMatcher,
+    contents_matcher: StringMatcher,
+}
+
+impl CodeBlockSelector {
+    pub fn read(iter: &mut ParsingIterator) -> ParseResult<Self> {
+        iter.require_str("``")?; // first ` is from dispatcher
+
+        let lang_matcher = match iter.peek() {
+            Some(ch) if !ch.is_whitespace() => StringMatcher::read(iter, CharEnd::AtWhitespace)?,
+            _ => StringMatcher::any(),
+        };
+        iter.require_whitespace_or(SELECTOR_SEPARATOR, "```")?;
+        let contents_matcher = StringMatcher::read(iter, SELECTOR_SEPARATOR)?;
+        Ok(Self {
+            lang_matcher,
+            contents_matcher,
+        })
+    }
+}
+
+impl<'a> Selector<'a, &'a CodeBlock> for CodeBlockSelector {
+    fn matches(&self, code_block: &'a CodeBlock) -> bool {
+        let lang_matches = match &code_block.variant {
+            CodeVariant::Code(code_opts) => {
+                let actual_lang = match code_opts {
+                    Some(co) => &co.language,
+                    None => "",
+                };
+                self.lang_matcher.matches(actual_lang)
+            }
+            CodeVariant::Math { .. } | CodeVariant::Toml | CodeVariant::Yaml => false,
+        };
+        lang_matches && self.contents_matcher.matches(&code_block.value)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod parsing {
+        use super::*;
+        use crate::matcher::StringMatcher;
+        use crate::parsing_iter::ParsingIterator;
+
+        #[test]
+        fn only_backticks() {
+            let input_str = "``";
+            let actual = CodeBlockSelector::read(&mut ParsingIterator::new(input_str)).unwrap();
+            assert_eq!(
+                actual,
+                CodeBlockSelector {
+                    lang_matcher: StringMatcher::any(),
+                    contents_matcher: StringMatcher::any(),
+                },
+            )
+        }
+
+        #[test]
+        fn only_language() {
+            let input_str = "``rust";
+            let actual = CodeBlockSelector::read(&mut ParsingIterator::new(input_str)).unwrap();
+            assert_eq!(
+                actual,
+                CodeBlockSelector {
+                    lang_matcher: StringMatcher::from("(?i)rust"),
+                    contents_matcher: StringMatcher::any(),
+                },
+            )
+        }
+
+        #[test]
+        fn only_contents() {
+            let input_str = "`` foo";
+            let actual = CodeBlockSelector::read(&mut ParsingIterator::new(input_str)).unwrap();
+            assert_eq!(
+                actual,
+                CodeBlockSelector {
+                    lang_matcher: StringMatcher::any(),
+                    contents_matcher: StringMatcher::from("(?i)foo"),
+                },
+            )
+        }
+
+        #[test]
+        fn both() {
+            let input_str = "``rust fizz";
+            let actual = CodeBlockSelector::read(&mut ParsingIterator::new(input_str)).unwrap();
+            assert_eq!(
+                actual,
+                CodeBlockSelector {
+                    lang_matcher: StringMatcher::from("(?i)rust"),
+                    contents_matcher: StringMatcher::from("(?i)fizz"),
+                },
+            )
+        }
+    }
+}

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -47,6 +47,12 @@ impl<'a> From<&'a BlockQuote> for MdElemRef<'a> {
     }
 }
 
+impl<'a> From<&'a CodeBlock> for MdElemRef<'a> {
+    fn from(value: &'a CodeBlock) -> Self {
+        MdElemRef::CodeBlock(value)
+    }
+}
+
 impl<'a> From<ListItemRef<'a>> for MdElemRef<'a> {
     fn from(value: ListItemRef<'a>) -> Self {
         MdElemRef::ListItem(value)


### PR DESCRIPTION
Add code block selectors:

~~~
```           # all code blocks
```rust       # code blocks for rust
``` foo       # code blocks whose contents contains "foo"
```rust foo   # combined
~~~

Resolves #142 