### PR TITLE
escape for backticks

### DIFF
--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -180,6 +180,7 @@ impl StringMatcher {
                         'n' => '\n',
                         'r' => '\r',
                         't' => '\t',
+                        '`' => '`',
                         'u' => {
                             chars.require_char('{')?;
                             let mut hex_str = String::with_capacity(6);
@@ -437,8 +438,8 @@ mod test {
     #[test]
     fn double_quoted_string() {
         parse_and_check(
-            r#" "hello world's ☃ \' \" \r \n \t says \"\u{2603}\" to me"_"#,
-            re("hello world's ☃ ' \" \r \n \t says \"☃\" to me"),
+            r#" "hello world's ☃ \' \" \` \r \n \t says \"\u{2603}\" to me"_"#,
+            re("hello world's ☃ ' \" ` \r \n \t says \"☃\" to me"),
             "_",
         );
     }
@@ -449,8 +450,8 @@ mod test {
     #[test]
     fn single_quoted_string() {
         parse_and_check(
-            r#" 'hello world\'s ☃ \' \" \r \n \t says "\u{2603}" to me'_"#,
-            re("hello world's ☃ ' \" \r \n \t says \"☃\" to me"),
+            r#" 'hello world\'s ☃ \' \" \` \r \n \t says "\u{2603}" to me'_"#,
+            re("hello world's ☃ ' \" ` \r \n \t says \"☃\" to me"),
             "_",
         );
     }


### PR DESCRIPTION
`` \` ``  ->  `` ` ``

Resolves #136 