### PR TITLE
block-level html elements

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -33,8 +33,9 @@ jobs:
     - name: cargo test
       run: |
         # convert e.g. "thread 'fmt_str::tests::text_html' panicked at src/fmt_str.rs:75:9:" to
-        #              "::error file=src/fmt_str,line=75,col=9,title=test failure::fmt_str::tests::text_html"
-        cargo test --verbose | sed -E "s/thread '([^']+)' panicked at ([^:]+):([0-9]+):([0-9]+):$/FOO/"
+        #              "::error file=src/fmt_str,line=75,col=9,title=test failure:: atfmt_str::tests::text_html"
+        set -o pipefail
+        cargo test --verbose | sed -E "s/thread '([^']+)' panicked at ([^:]+):([0-9]+):([0-9]+):$/::error file=\\2,line=\\3,col=\\4,title=test failure::at \\1/"
     - name: list ignored tests
       run: |
         (find . -name '*.rs' -exec grep --fixed-strings -Hno '#[ignore]' {} \; || true) | sed -E 's/^([^:]+):([^:]+):.*/::warning file=\1,line=\2,title=Ignored test::Regex indicates this test is probably ignored/'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,7 +31,10 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: cargo test
-      run: cargo test --verbose
+      run: |
+        # convert e.g. "thread 'fmt_str::tests::text_html' panicked at src/fmt_str.rs:75:9:" to
+        #              "::error file=src/fmt_str,line=75,col=9,title=test failure::fmt_str::tests::text_html"
+        cargo test --verbose | sed -E "s/thread '([^']+)' panicked at ([^:]+):([0-9]+):([0-9]+):$/FOO/"
     - name: list ignored tests
       run: |
         (find . -name '*.rs' -exec grep --fixed-strings -Hno '#[ignore]' {} \; || true) | sed -E 's/^([^:]+):([^:]+):.*/::warning file=\1,line=\2,title=Ignored test::Regex indicates this test is probably ignored/'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
         # convert e.g. "thread 'fmt_str::tests::text_html' panicked at src/fmt_str.rs:75:9:" to
         #              "::error file=src/fmt_str,line=75,col=9,title=test failure:: atfmt_str::tests::text_html"
         set -o pipefail
-        cargo test --verbose | sed -E "s/thread '([^']+)' panicked at ([^:]+):([0-9]+):([0-9]+):$/::error file=\\2,line=\\3,col=\\4,title=test failure::at\\n \\1/"
+        cargo test --verbose | sed -E "s/thread '([^']+)' panicked at ([^:]+):([0-9]+):([0-9]+):$/::error file=\\2,line=\\3,col=\\4,title=test failure::at\\\\n \\1/"
     - name: list ignored tests
       run: |
         (find . -name '*.rs' -exec grep --fixed-strings -Hno '#[ignore]' {} \; || true) | sed -E 's/^([^:]+):([^:]+):.*/::warning file=\1,line=\2,title=Ignored test::Regex indicates this test is probably ignored/'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
         # convert e.g. "thread 'fmt_str::tests::text_html' panicked at src/fmt_str.rs:75:9:" to
         #              "::error file=src/fmt_str,line=75,col=9,title=test failure:: atfmt_str::tests::text_html"
         set -o pipefail
-        cargo test --verbose | sed -E "s/thread '([^']+)' panicked at ([^:]+):([0-9]+):([0-9]+):$/::error file=\\2,line=\\3,col=\\4,title=test failure::at\\\\n \\1/"
+        cargo test --verbose | sed -E "s/thread '([^']+)' panicked at ([^:]+):([0-9]+):([0-9]+):$/::error file=\\2,line=\\3,col=\\4,title=test failure::at \\1/"
     - name: list ignored tests
       run: |
         (find . -name '*.rs' -exec grep --fixed-strings -Hno '#[ignore]' {} \; || true) | sed -E 's/^([^:]+):([^:]+):.*/::warning file=\1,line=\2,title=Ignored test::Regex indicates this test is probably ignored/'

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -35,7 +35,7 @@ jobs:
         # convert e.g. "thread 'fmt_str::tests::text_html' panicked at src/fmt_str.rs:75:9:" to
         #              "::error file=src/fmt_str,line=75,col=9,title=test failure:: atfmt_str::tests::text_html"
         set -o pipefail
-        cargo test --verbose | sed -E "s/thread '([^']+)' panicked at ([^:]+):([0-9]+):([0-9]+):$/::error file=\\2,line=\\3,col=\\4,title=test failure::at \\1/"
+        cargo test --verbose | sed -E "s/thread '([^']+)' panicked at ([^:]+):([0-9]+):([0-9]+):$/::error file=\\2,line=\\3,col=\\4,title=test failure::at\\n \\1/"
     - name: list ignored tests
       run: |
         (find . -name '*.rs' -exec grep --fixed-strings -Hno '#[ignore]' {} \; || true) | sed -E 's/^([^:]+):([^:]+):.*/::warning file=\1,line=\2,title=Ignored test::Regex indicates this test is probably ignored/'

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -2028,19 +2028,23 @@ pub mod tests {
         #[test]
         fn inline() {
             check_render(
-                md_elems![Paragraph{
+                md_elems![Paragraph {
                     body: vec![
                         Inline::Text(Text {
-                            variant: TextVariant::Plain, value: "Hello ".to_string()
+                            variant: TextVariant::Plain,
+                            value: "Hello ".to_string()
                         }),
                         Inline::Text(Text {
-                            variant: TextVariant::Html, value: "<span class=\"greeting\">".to_string()
+                            variant: TextVariant::Html,
+                            value: "<span class=\"greeting\">".to_string()
                         }),
                         Inline::Text(Text {
-                            variant: TextVariant::Plain, value: "world".to_string()
+                            variant: TextVariant::Plain,
+                            value: "world".to_string()
                         }),
                         Inline::Text(Text {
-                            variant: TextVariant::Html, value: "</span>".to_string()
+                            variant: TextVariant::Html,
+                            value: "</span>".to_string()
                         }),
                     ]
                 }],
@@ -2051,20 +2055,13 @@ pub mod tests {
 
         #[test]
         fn block_single_line() {
-            check_render(
-                vec![
-                    MdElem::Html("<div>".to_string()),
-                ],
-                indoc! {r#"<div>"#},
-            )
+            check_render(vec![MdElem::Html("<div>".to_string())], indoc! {r#"<div>"#})
         }
 
         #[test]
         fn block_multi_line() {
             check_render(
-                vec![
-                    MdElem::Html("<div\nselected>".to_string()),
-                ],
+                vec![MdElem::Html("<div\nselected>".to_string())],
                 indoc! {r#"
                 <div
                 selected>"#},

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -2022,6 +2022,56 @@ pub mod tests {
         }
     }
 
+    mod html {
+        use super::*;
+
+        #[test]
+        fn inline() {
+            check_render(
+                md_elems![Paragraph{
+                    body: vec![
+                        Inline::Text(Text {
+                            variant: TextVariant::Plain, value: "Hello ".to_string()
+                        }),
+                        Inline::Text(Text {
+                            variant: TextVariant::Html, value: "<span class=\"greeting\">".to_string()
+                        }),
+                        Inline::Text(Text {
+                            variant: TextVariant::Plain, value: "world".to_string()
+                        }),
+                        Inline::Text(Text {
+                            variant: TextVariant::Html, value: "</span>".to_string()
+                        }),
+                    ]
+                }],
+                indoc! {r#"
+                Hello <span class="greeting">world</span>"#},
+            )
+        }
+
+        #[test]
+        fn block_single_line() {
+            check_render(
+                vec![
+                    MdElem::Html("<div>".to_string()),
+                ],
+                indoc! {r#"<div>"#},
+            )
+        }
+
+        #[test]
+        fn block_multi_line() {
+            check_render(
+                vec![
+                    MdElem::Html("<div\nselected>".to_string()),
+                ],
+                indoc! {r#"
+                <div
+                selected>"#},
+            )
+        }
+    }
+
     fn check_render(nodes: Vec<MdElem>, expect: &str) {
         check_render_with(&default_opts(), nodes, expect);
     }

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -162,6 +162,9 @@ impl<'s, 'a> MdWriterState<'s, 'a> {
             }
             MdElemRef::Link(link) => self.inlines_writer.write_linklike(out, link),
             MdElemRef::Image(image) => self.inlines_writer.write_linklike(out, image),
+            MdElemRef::Html(html) => out.with_block(Block::Plain, |out| {
+                out.write_str(html);
+            }),
         }
     }
 
@@ -471,6 +474,7 @@ pub mod tests {
         ListItem(..),
         Link(..),
         Image(..),
+        Html(..),
 
         Inline(Inline::Formatting(Formatting{variant: FormattingVariant::Delete, ..})),
         Inline(Inline::Formatting(Formatting{variant: FormattingVariant::Emphasis, ..})),

--- a/src/fmt_str.rs
+++ b/src/fmt_str.rs
@@ -1,4 +1,4 @@
-use crate::tree::{Formatting, Image, Inline, Link, Text, TextVariant};
+use crate::tree::{Formatting, Image, Inline, Link, Text};
 use std::borrow::Borrow;
 
 pub fn inlines_to_plain_string<N: Borrow<Inline>>(inlines: &[N]) -> String {

--- a/src/fmt_str.rs
+++ b/src/fmt_str.rs
@@ -16,7 +16,7 @@ fn build_inlines<N: Borrow<Inline>>(out: &mut String, inlines: &[N]) {
 fn build_inline(out: &mut String, elem: &Inline) {
     match elem {
         Inline::Formatting(Formatting { children, .. }) => build_inlines(out, children),
-        Inline::Text(Text { variant, value, .. }) => out.push_str(value),
+        Inline::Text(Text { value, .. }) => out.push_str(value),
         Inline::Link(Link { text, .. }) => build_inlines(out, text),
         Inline::Image(Image { alt, .. }) => out.push_str(alt),
         Inline::Footnote(footnote) => {

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -55,6 +55,7 @@ impl StringMatcher {
                 }
                 self.matches_any(&section.body)
             }
+            MdElem::Html(html) => self.matches(html),
             MdElem::Inline(inline) => self.matches_inlines(&[inline]),
         }
     }

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -248,6 +248,7 @@ impl MdqRefSelector {
 
             MdElemRef::Link(Link { text, .. }) => text.iter().map(|child| MdElemRef::Inline(child)).collect(),
             MdElemRef::Image(_) => Vec::new(),
+            MdElemRef::Html(_) => Vec::new(),
         }
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -572,6 +572,8 @@ impl MdElem {
         let mdq_children = Self::all(children, lookups)?;
         let mut result = Vec::with_capacity(mdq_children.len());
         for child in mdq_children {
+            // Get this child as an Inline, or complain. HTML can be either inline or block; Self::all will always
+            // return it as a block, but we can just extract the String and convert it to an Inline.
             let inline = match child {
                 MdElem::Inline(inline) => inline,
                 MdElem::Html(html) => Inline::Text(Text {

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -15,6 +15,7 @@ pub enum MdElemRef<'a> {
     Paragraph(&'a Paragraph),
     Section(&'a Section),
     Table(&'a Table),
+    Html(&'a String),
     ThematicBreak,
 
     // sub-elements
@@ -37,6 +38,7 @@ impl<'a> From<&'a MdElem> for MdElemRef<'a> {
             MdElem::BlockQuote(block) => Self::BlockQuote(block),
             MdElem::Section(section) => Self::Section(section),
             MdElem::Inline(child) => MdElemRef::Inline(child),
+            MdElem::Html(html) => MdElemRef::Html(html),
         }
     }
 }

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -58,6 +58,9 @@ pub enum SerdeElem<'a> {
         alignments: Vec<AlignSerde>,
         rows: Vec<Vec<String>>,
     },
+    Html {
+        value: &'a String,
+    },
 }
 
 fn serialize_thematic_break<S: Serializer>(ser: S) -> Result<S::Ok, S::Error> {
@@ -278,6 +281,7 @@ impl<'a> SerdeElem<'a> {
                 alt: &img.alt,
                 link: (&img.link).into(),
             },
+            MdElemRef::Html(value) => Self::Html { value },
         }
     }
 }
@@ -303,6 +307,7 @@ mod tests {
     use crate::tree_ref::ListItemRef;
     use crate::variants_checker;
     use crate::{md_elem, mdq_inline};
+    use markdown::mdast::Html;
 
     variants_checker!(CHECKER = MdElemRef {
         Doc(_),
@@ -315,6 +320,7 @@ mod tests {
         Section(_),
         Table(_),
         ThematicBreak,
+        Html(_),
 
         ListItem(_),
         Link(_),
@@ -643,6 +649,20 @@ mod tests {
                             [ "R1C1", "R1C2" ],
                             [ "R2C1", "R2C2" ]
                         ]
+                    }}
+                ]}
+            ),
+        );
+    }
+
+    #[test]
+    fn block_html() {
+        check(
+            MdElem::Html("<div />".to_string()),
+            json_str!(
+                {"items":[
+                    {"html":{
+                        "value": "<div />"
                     }}
                 ]}
             ),

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -307,7 +307,6 @@ mod tests {
     use crate::tree_ref::ListItemRef;
     use crate::variants_checker;
     use crate::{md_elem, mdq_inline};
-    use markdown::mdast::Html;
 
     variants_checker!(CHECKER = MdElemRef {
         Doc(_),


### PR DESCRIPTION
HTML can be [block-level or inline][1], but the previous implementation only allowed inline. It treated block-level HTML as a paragraph with a single HTML inline element, which has (at least) two problems: it serializes to JSON incorrectly, and it means that a paragraph search (#140) would incorrectly include these block-level HTMLs.

This resolves #34.

This issue blocks implementation of #153.

[1]: https://github.github.com/gfm/#html-blocks