### PR TITLE
html selector: `</>`

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ You can select...
   ```bash
   $ cat example.md | mdq '- foo'       # find unordered list items containing "foo"
   $ cat example.md | mdq '1. foo'      # find ordered list items containing "foo"
-                                       #(note: the number must be exactly "1.")
+                                       #   (note: the number must be exactly "1.")
   $ cat example.md | mdq '- [ ] foo'   # find uncompleted task items containing "foo"
   $ cat example.md | mdq '- [x] foo'   # find completed task items containing "foo"
   $ cat example.md | mdq '- [?] foo'   # find all task items containing "foo"
@@ -110,6 +110,12 @@ You can select...
 
   ```bash
   $ cat example.md | mdq '```rust fizz'  # find code blocks for rust with "fizz" within them
+  ```
+
+- HTML (inline or block):
+
+  ```bash
+  $ cat example.md | mdq '</> foo'  # find html tags containing "foo"
   ```
 
 The `foo`s and `bar`s above can be:

--- a/examples/hello.md
+++ b/examples/hello.md
@@ -108,3 +108,14 @@ Block B
 ```
 foo
 ```
+
+## Html Stuff
+
+First some <span>inline</span>.
+
+<div class="then some"
+href="#block-level">
+
+With paragraph text between it.
+
+</div>

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -163,7 +163,7 @@ impl<'s, 'a> MdWriterState<'s, 'a> {
             MdElemRef::Link(link) => self.inlines_writer.write_linklike(out, link),
             MdElemRef::Image(image) => self.inlines_writer.write_linklike(out, image),
             MdElemRef::Html(html) => out.with_block(Block::Plain, |out| {
-                out.write_str(html);
+                out.write_str(html.0);
             }),
         }
     }

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -3,13 +3,14 @@ use crate::parsing_iter::ParsingIterator;
 use crate::select::base::Selector;
 use crate::select::sel_block_quote::BlockQuoteSelector;
 use crate::select::sel_code_block::CodeBlockSelector;
+use crate::select::sel_html::HtmlSelector;
 use crate::select::sel_image::ImageSelector;
 use crate::select::sel_link::LinkSelector;
 use crate::select::sel_list_item::ListItemSelector;
 use crate::select::sel_list_item::ListItemType;
 use crate::select::sel_section::SectionSelector;
-use crate::tree::{Formatting, Inline, Link, Text};
-use crate::tree_ref::{ListItemRef, MdElemRef};
+use crate::tree::{Formatting, Inline, Link, Text, TextVariant};
+use crate::tree_ref::{HtmlRef, ListItemRef, MdElemRef};
 use std::fmt::{Display, Formatter};
 
 pub type ParseResult<T> = Result<T, ParseErrorReason>;
@@ -136,6 +137,8 @@ selectors![
     {'>'} BlockQuote,
 
     {'`'} CodeBlock,
+
+    {'<'} Html,
 ];
 
 impl MdqRefSelector {
@@ -243,6 +246,9 @@ impl MdqRefSelector {
                 Inline::Footnote(footnote) => vec![MdElemRef::Doc(&footnote.text)],
                 Inline::Link(link) => vec![MdElemRef::Link(link)],
                 Inline::Image(image) => vec![MdElemRef::Image(image)],
+                Inline::Text(Text { variant, value }) if variant == &TextVariant::Html => {
+                    vec![MdElemRef::Html(HtmlRef(value))]
+                }
                 Inline::Text(Text { .. }) => Vec::new(),
             },
 
@@ -349,6 +355,7 @@ mod test {
             Image(_),
             BlockQuote(_),
             CodeBlock(_),
+            Html(_),
         });
     }
 

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -334,6 +334,14 @@ mod test {
         }
 
         #[test]
+        fn html() {
+            let input = "</>";
+            let mdq_ref_sel_parsed = MdqRefSelector::parse_selector(&mut ParsingIterator::new(input));
+            let item_parsed = HtmlSelector::read(&mut ParsingIterator::new(&input[1..])).unwrap();
+            expect_ok(mdq_ref_sel_parsed, MdqRefSelector::Html(item_parsed));
+        }
+
+        #[test]
         fn unknown() {
             let input = "\u{2603}";
             let mdq_ref_sel_parsed = MdqRefSelector::parse_selector(&mut ParsingIterator::new(input));

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -2,6 +2,7 @@ mod api;
 mod base;
 mod sel_block_quote;
 mod sel_code_block;
+mod sel_html;
 mod sel_image;
 mod sel_link;
 mod sel_list_item;

--- a/src/select/sel_html.rs
+++ b/src/select/sel_html.rs
@@ -1,0 +1,24 @@
+use crate::matcher::StringMatcher;
+use crate::parsing_iter::ParsingIterator;
+use crate::select::base::Selector;
+use crate::select::{ParseResult, SELECTOR_SEPARATOR};
+use crate::tree_ref::HtmlRef;
+
+#[derive(Debug, PartialEq)]
+pub struct HtmlSelector {
+    matcher: StringMatcher,
+}
+
+impl HtmlSelector {
+    pub fn read(iter: &mut ParsingIterator) -> ParseResult<Self> {
+        iter.require_str("/>")?;
+        let matcher = StringMatcher::read(iter, SELECTOR_SEPARATOR)?;
+        Ok(Self { matcher })
+    }
+}
+
+impl<'a> Selector<'a, HtmlRef<'a>> for HtmlSelector {
+    fn matches(&self, html: HtmlRef<'a>) -> bool {
+        self.matcher.matches(html.0)
+    }
+}

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -15,7 +15,7 @@ pub enum MdElemRef<'a> {
     Paragraph(&'a Paragraph),
     Section(&'a Section),
     Table(&'a Table),
-    Html(&'a String),
+    Html(HtmlRef<'a>),
     ThematicBreak,
 
     // sub-elements
@@ -26,6 +26,9 @@ pub enum MdElemRef<'a> {
 
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct ListItemRef<'a>(pub Option<u32>, pub &'a ListItem);
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct HtmlRef<'a>(pub &'a String);
 
 impl<'a> From<&'a MdElem> for MdElemRef<'a> {
     fn from(value: &'a MdElem) -> Self {
@@ -38,7 +41,7 @@ impl<'a> From<&'a MdElem> for MdElemRef<'a> {
             MdElem::BlockQuote(block) => Self::BlockQuote(block),
             MdElem::Section(section) => Self::Section(section),
             MdElem::Inline(child) => MdElemRef::Inline(child),
-            MdElem::Html(html) => MdElemRef::Html(html),
+            MdElem::Html(html) => MdElemRef::Html(HtmlRef(html)),
         }
     }
 }
@@ -58,6 +61,12 @@ impl<'a> From<&'a CodeBlock> for MdElemRef<'a> {
 impl<'a> From<ListItemRef<'a>> for MdElemRef<'a> {
     fn from(value: ListItemRef<'a>) -> Self {
         MdElemRef::ListItem(value)
+    }
+}
+
+impl<'a> From<HtmlRef<'a>> for MdElemRef<'a> {
+    fn from(value: HtmlRef<'a>) -> Self {
+        Self::Html(HtmlRef(value.0))
     }
 }
 

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -281,7 +281,7 @@ impl<'a> SerdeElem<'a> {
                 alt: &img.alt,
                 link: (&img.link).into(),
             },
-            MdElemRef::Html(value) => Self::Html { value },
+            MdElemRef::Html(value) => Self::Html { value: value.0 },
         }
     }
 }

--- a/tests/md_cases/select_html.toml
+++ b/tests/md_cases/select_html.toml
@@ -1,0 +1,64 @@
+[given]
+md = '''
+Text with <span>inline html</span>.
+
+<div
+class="block>
+
+and a div block
+
+</div>
+'''
+
+
+[expect."select all"]
+cli_args = ['</>']
+output = '''
+<span>
+
+   -----
+
+</span>
+
+   -----
+
+<div
+class="block>
+
+   -----
+
+</div>
+'''
+
+
+[expect."inline with matcher"]
+cli_args = ['</> span']
+output = '''
+<span>
+
+   -----
+
+</span>
+'''
+
+
+[expect."inline with matcher tag"]
+cli_args = ['</> "<span>"']
+output = '''
+<span>
+'''
+
+
+[expect."unquoted tag"]
+cli_args = ['</> <span>']
+expect_success = false # unquoted string must start with a letter, not a '<'
+output = '''
+'''
+
+
+[expect."block with matcher"]
+cli_args = ['</> class']
+output = '''
+<div
+class="block>
+'''


### PR DESCRIPTION
Works for both inline and block html. The selector doesn't differentiate between them.

Resolves #153 (modulo tests)