### PR TITLE
add ability to select tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,14 @@ You can select...
   ```bash
   $ cat example.md | mdq 'P: foo'  # find paragraphs containing "foo"
   ```
+  
+- Tables
+
+  ```bash
+  $ cat example.md | mdq ':-: "some headers" :-: "some rows"'
+  ```
+  (Tables selection differs from other selections in that you can actually select only certain headers and rows.
+  See the wiki for more.)
 
 The `foo`s and `bar`s above can be:
 

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -985,6 +985,41 @@ pub mod tests {
                 | i | ii | iii |"#},
             );
         }
+
+        /// Test of a table slice, instead of the table ref directly. This is just a smoke test,
+        /// because the implementations are the same (one forwards to the other); this test is
+        /// here just to validate that the delegation happens, as opposed to "oops, I forgot to
+        /// actually implement the delegation."
+        #[test]
+        fn slice() {
+            let table = Table {
+                alignments: vec![
+                    mdast::AlignKind::Left,
+                    mdast::AlignKind::Right,
+                ],
+                rows: vec![
+                    // Header row
+                    vec![
+                        // columns
+                        vec![mdq_inline!("Left")],
+                        vec![mdq_inline!("Right")],
+                    ],
+                    // Data row
+                    vec![
+                        // columns
+                        vec![mdq_inline!("a")],
+                        vec![mdq_inline!("b")],
+                    ],
+                ],
+            };
+            check_render_refs(
+                vec![MdElemRef::TableSlice((&table).into())],
+                indoc! {r#"
+                    | Left | Right |
+                    |:-----|------:|
+                    | a    |     b |"#},
+            );
+        }
     }
 
     mod thematic_break {

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -993,10 +993,7 @@ pub mod tests {
         #[test]
         fn slice() {
             let table = Table {
-                alignments: vec![
-                    mdast::AlignKind::Left,
-                    mdast::AlignKind::Right,
-                ],
+                alignments: vec![mdast::AlignKind::Left, mdast::AlignKind::Right],
                 rows: vec![
                     // Header row
                     vec![

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -8,7 +8,7 @@ use crate::link_transform::LinkLabel;
 use crate::output::{Block, Output, SimpleWrite};
 use crate::str_utils::{pad_to, standard_align, CountingWriter};
 use crate::tree::*;
-use crate::tree_ref::{ListItemRef, MdElemRef};
+use crate::tree_ref::{ListItemRef, MdElemRef, TableSlice};
 
 pub struct MdOptions {
     pub link_reference_placement: ReferencePlacement,
@@ -156,7 +156,8 @@ impl<'s, 'a> MdWriterState<'s, 'a> {
             MdElemRef::Paragraph(para) => self.write_paragraph(out, para),
             MdElemRef::BlockQuote(block) => self.write_block_quote(out, block),
             MdElemRef::List(list) => self.write_list(out, list),
-            MdElemRef::Table(table) => self.write_table(out, table),
+            MdElemRef::Table(table) => self.write_table(out, table.into()), // TODO maybe have a generic table trait, so I don't need to do the copying?
+            MdElemRef::TableSlice(table) => self.write_table(out, table),
             MdElemRef::Inline(inline) => {
                 self.inlines_writer.write_inline_element(out, inline);
             }
@@ -193,15 +194,16 @@ impl<'s, 'a> MdWriterState<'s, 'a> {
         });
     }
 
-    fn write_table<W: SimpleWrite>(&mut self, out: &mut Output<W>, table: &'a Table) {
-        let Table { alignments, rows } = table;
+    fn write_table<W: SimpleWrite>(&mut self, out: &mut Output<W>, table: TableSlice<'a>) {
+        let alignments = table.alignments();
+        let rows = table.rows();
 
-        let mut row_strs = Vec::with_capacity(rows.len());
+        let mut row_strs = Vec::with_capacity(alignments.len());
 
         let mut column_widths = [0].repeat(alignments.len());
         if !alignments.is_empty() {
             for (idx, alignment) in alignments.iter().enumerate() {
-                let width = match standard_align(alignment) {
+                let width = match standard_align(*alignment) {
                     Some(Alignment::Left | Alignment::Right) => 2,
                     Some(Alignment::Center) => 3,
                     None => 1,
@@ -213,8 +215,8 @@ impl<'s, 'a> MdWriterState<'s, 'a> {
         // Pre-calculate all the cells, and also how wide each column needs to be
         for row in rows {
             let mut col_strs = Vec::with_capacity(row.len());
-            for (idx, col) in row.iter().enumerate() {
-                let col_str = self.line_to_string(col);
+            for (idx, &col) in row.iter().enumerate() {
+                let col_str = col.map(|ln| self.line_to_string(ln)).unwrap_or("".to_string());
                 // Extend the row_sizes if needed. This happens if we had fewer alignments than columns in any
                 // row. I'm not sure if that's possible, but it's easy to guard against.
                 while column_widths.len() <= idx {
@@ -266,7 +268,7 @@ impl<'s, 'a> MdWriterState<'s, 'a> {
         // Headers
         if !alignments.is_empty() {
             out.write_char('|');
-            for (idx, align) in alignments.iter().enumerate() {
+            for (idx, &align) in alignments.iter().enumerate() {
                 let width = column_widths
                     .get(idx)
                     .unwrap_or_else(|| match standard_align(align) {
@@ -517,6 +519,7 @@ pub mod tests {
         BlockQuote(_),
         List(_),
         Table(_),
+        TableSlice(_),
     });
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,7 @@ mod tree_ref;
 mod tree_ref_serde;
 mod tree_test_utils;
 mod utils_for_test;
+mod vec_utils;
 
 pub fn run_in_memory(cli: &Cli, contents: &str) -> (bool, String) {
     let mut out = Vec::with_capacity(256); // just a guess

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -86,7 +86,6 @@ impl StringMatcher {
         match peek_ch {
             '*' => {
                 let _ = chars.next(); // drop the char we peeked
-                chars.drop_whitespace();
                 Ok(StringMatcher::any())
             }
             '/' => {

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -10,7 +10,6 @@ pub struct StringMatcher {
     re: Regex,
 }
 
-#[cfg(test)]
 impl PartialEq for StringMatcher {
     fn eq(&self, other: &Self) -> bool {
         self.re.as_str() == other.re.as_str()

--- a/src/matcher.rs
+++ b/src/matcher.rs
@@ -10,6 +10,7 @@ pub struct StringMatcher {
     re: Regex,
 }
 
+#[cfg(test)]
 impl PartialEq for StringMatcher {
     fn eq(&self, other: &Self) -> bool {
         self.re.as_str() == other.re.as_str()
@@ -86,6 +87,7 @@ impl StringMatcher {
         match peek_ch {
             '*' => {
                 let _ = chars.next(); // drop the char we peeked
+                chars.drop_whitespace();
                 Ok(StringMatcher::any())
             }
             '/' => {

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -9,6 +9,7 @@ use crate::select::sel_list_item::ListItemSelector;
 use crate::select::sel_list_item::ListItemType;
 use crate::select::sel_paragraph::ParagraphSelector;
 use crate::select::sel_section::SectionSelector;
+use crate::select::sel_table::TableSelector;
 use crate::tree::{Formatting, Inline, Link, Text, TextVariant};
 use crate::tree_ref::{HtmlRef, ListItemRef, MdElemRef};
 use std::fmt::{Display, Formatter};
@@ -17,7 +18,7 @@ pub type ParseResult<T> = Result<T, ParseErrorReason>;
 
 pub const SELECTOR_SEPARATOR: char = '|';
 
-pub trait Selector<'a, I: Into<MdElemRef<'a>>> {
+pub trait Selector<'a, I: Into<MdElemRef<'a>>> { // TODO I should really rename all these 'a to 'md
     fn try_select(&self, item: I) -> Option<MdElemRef<'a>>;
 }
 
@@ -145,6 +146,8 @@ selectors![
     {'`'} CodeBlock,
 
     {'<'} Html,
+
+    {':'} Table,
 ];
 
 impl MdqRefSelector {
@@ -455,7 +458,7 @@ mod test {
             let inline = Inline::Link(mk_link());
             let node_ref = MdElemRef::Inline(&inline);
             let children = MdqRefSelector::find_children(node_ref);
-            assert_eq!(children, vec![MdElemRef::Link(&mk_link()),]);
+            assert_eq!(children, vec![MdElemRef::Link(&mk_link())]);
         }
     }
 }

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -233,19 +233,23 @@ impl MdqRefSelector {
                 result
             }
             MdElemRef::Table(table) => {
-                let count_estimate = table.rows.len() * table.rows.first().map(|tr| tr.len()).unwrap_or(0);
+                Self::find_children(MdElemRef::TableSlice(table.into()))
+            }
+            MdElemRef::TableSlice(table) => {
+                let table_rows_estimate = 8; // TODO expose this from the table.rows() trait
+                let first_row_cols = table.rows().next().map(Vec::len).unwrap_or(0);
+                let count_estimate = table_rows_estimate * first_row_cols;
                 let mut result = Vec::with_capacity(count_estimate);
-                for row in &table.rows {
-                    for col in row {
-                        for cell in col {
-                            result.push(MdElemRef::Inline(cell));
+                for row in table.rows() {
+                    for maybe_col in row {
+                        if let Some(col) = maybe_col {
+                            for cell in *col {
+                                result.push(MdElemRef::Inline(cell));
+                            }
                         }
                     }
                 }
                 result
-            }
-            MdElemRef::TableSlice(table) => {
-                todo!()
             }
             MdElemRef::ThematicBreak | MdElemRef::CodeBlock(_) => Vec::new(),
             MdElemRef::Inline(inline) => match inline {

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -397,6 +397,7 @@ mod test {
             CodeBlock(_),
             Html(_),
             Paragraph(_),
+            Table(_),
         });
     }
 

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -17,7 +17,7 @@ pub type ParseResult<T> = Result<T, ParseErrorReason>;
 
 pub const SELECTOR_SEPARATOR: char = '|';
 
-pub trait Selector<'a, I: Copy + Into<MdElemRef<'a>>> {
+pub trait Selector<'a, I: Into<MdElemRef<'a>>> {
     fn try_select(&self, item: I) -> Option<MdElemRef<'a>>;
 }
 
@@ -192,7 +192,7 @@ impl MdqRefSelector {
 
     fn build_output<'a>(&self, out: &mut Vec<MdElemRef<'a>>, node: MdElemRef<'a>) {
         // try_select_node is defined in macro_helpers::selectors!
-        match self.try_select_node(node) {
+        match self.try_select_node(node.clone()) { // TODO can we remove this? I don't think so, but let's follow up
             Some(found) => out.push(found),
             None => {
                 for child in Self::find_children(node) {
@@ -208,7 +208,7 @@ impl MdqRefSelector {
     /// selector-specific. For example, an [MdqNode::Section] has child nodes both in its title and in its body, but
     /// only the body nodes are relevant for select recursion. `MdqNode` shouldn't need to know about that oddity; it
     /// belongs here.
-    fn find_children<'a>(node: MdElemRef) -> Vec<MdElemRef> {
+    fn find_children(node: MdElemRef) -> Vec<MdElemRef> {
         match node {
             MdElemRef::Doc(body) => {
                 let mut wrapped = Vec::with_capacity(body.len());
@@ -243,6 +243,9 @@ impl MdqRefSelector {
                     }
                 }
                 result
+            }
+            MdElemRef::TableSlice(table) => {
+                todo!()
             }
             MdElemRef::ThematicBreak | MdElemRef::CodeBlock(_) => Vec::new(),
             MdElemRef::Inline(inline) => match inline {

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -373,6 +373,15 @@ mod test {
             expect_ok(mdq_ref_sel_parsed, MdqRefSelector::Paragraph(item_parsed));
         }
 
+        /// See `mod sel_table::tests` for more extensive tests
+        #[test]
+        fn table_smoke() {
+            let input = ":-: * :-:";
+            let mdq_ref_sel_parsed = MdqRefSelector::parse_selector(&mut ParsingIterator::new(input));
+            let item_parsed = TableSelector::read(&mut ParsingIterator::new(&input[1..])).unwrap();
+            expect_ok(mdq_ref_sel_parsed, MdqRefSelector::Table(item_parsed));
+        }
+
         #[test]
         fn unknown() {
             let input = "\u{2603}";

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -18,7 +18,8 @@ pub type ParseResult<T> = Result<T, ParseErrorReason>;
 
 pub const SELECTOR_SEPARATOR: char = '|';
 
-pub trait Selector<'a, I: Into<MdElemRef<'a>>> { // TODO I should really rename all these 'a to 'md
+pub trait Selector<'a, I: Into<MdElemRef<'a>>> {
+    // TODO I should really rename all these 'a to 'md
     fn try_select(&self, item: I) -> Option<MdElemRef<'a>>;
 }
 
@@ -199,7 +200,8 @@ impl MdqRefSelector {
 
     fn build_output<'a>(&self, out: &mut Vec<MdElemRef<'a>>, node: MdElemRef<'a>) {
         // try_select_node is defined in macro_helpers::selectors!
-        match self.try_select_node(node.clone()) { // TODO can we remove this? I don't think so, but let's follow up
+        match self.try_select_node(node.clone()) {
+            // TODO can we remove this? I don't think so, but let's follow up
             Some(found) => out.push(found),
             None => {
                 for child in Self::find_children(node) {
@@ -239,9 +241,7 @@ impl MdqRefSelector {
                 }
                 result
             }
-            MdElemRef::Table(table) => {
-                Self::find_children(MdElemRef::TableSlice(table.into()))
-            }
+            MdElemRef::Table(table) => Self::find_children(MdElemRef::TableSlice(table.into())),
             MdElemRef::TableSlice(table) => {
                 let table_rows_estimate = 8; // TODO expose this from the table.rows() trait
                 let first_row_cols = table.rows().next().map(Vec::len).unwrap_or(0);

--- a/src/select/match_selector.rs
+++ b/src/select/match_selector.rs
@@ -3,14 +3,14 @@ use crate::tree_ref::MdElemRef;
 
 /// MatchSelector is a helper trait for implementing [Selector]. Simply provide the boolean predicate for whether a
 /// given item matches, and MatchSelector will do the rest.
-pub trait MatchSelector<'a, I: Copy + Into<MdElemRef<'a>>> {
+pub trait MatchSelector<I> {
     fn matches(&self, item: I) -> bool;
 }
 
 impl<'a, I, M> Selector<'a, I> for M
 where
     I: Copy + Into<MdElemRef<'a>>,
-    M: MatchSelector<'a, I>,
+    M: MatchSelector<I>,
 {
     fn try_select(&self, item: I) -> Option<MdElemRef<'a>> {
         if self.matches(item) {

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -8,5 +8,6 @@ mod sel_link;
 mod sel_list_item;
 mod sel_paragraph;
 mod sel_section;
+mod sel_table;
 
 pub use api::*;

--- a/src/select/sel_block_quote.rs
+++ b/src/select/sel_block_quote.rs
@@ -17,7 +17,7 @@ impl BlockQuoteSelector {
     }
 }
 
-impl<'a> MatchSelector<'a, &'a BlockQuote> for BlockQuoteSelector {
+impl<'a> MatchSelector<&'a BlockQuote> for BlockQuoteSelector {
     fn matches(&self, block_quote: &'a BlockQuote) -> bool {
         self.matcher.matches_any(&block_quote.body)
     }

--- a/src/select/sel_block_quote.rs
+++ b/src/select/sel_block_quote.rs
@@ -17,8 +17,8 @@ impl BlockQuoteSelector {
     }
 }
 
-impl<'a> MatchSelector<&'a BlockQuote> for BlockQuoteSelector {
-    fn matches(&self, block_quote: &'a BlockQuote) -> bool {
+impl MatchSelector<&BlockQuote> for BlockQuoteSelector {
+    fn matches(&self, block_quote: &BlockQuote) -> bool {
         self.matcher.matches_any(&block_quote.body)
     }
 }

--- a/src/select/sel_code_block.rs
+++ b/src/select/sel_code_block.rs
@@ -27,7 +27,7 @@ impl CodeBlockSelector {
     }
 }
 
-impl<'a> MatchSelector<'a, &'a CodeBlock> for CodeBlockSelector {
+impl<'a> MatchSelector<&'a CodeBlock> for CodeBlockSelector {
     fn matches(&self, code_block: &'a CodeBlock) -> bool {
         let lang_matches = match &code_block.variant {
             CodeVariant::Code(code_opts) => {

--- a/src/select/sel_code_block.rs
+++ b/src/select/sel_code_block.rs
@@ -27,8 +27,8 @@ impl CodeBlockSelector {
     }
 }
 
-impl<'a> MatchSelector<&'a CodeBlock> for CodeBlockSelector {
-    fn matches(&self, code_block: &'a CodeBlock) -> bool {
+impl MatchSelector<&CodeBlock> for CodeBlockSelector {
+    fn matches(&self, code_block: &CodeBlock) -> bool {
         let lang_matches = match &code_block.variant {
             CodeVariant::Code(code_opts) => {
                 let actual_lang = match code_opts {

--- a/src/select/sel_html.rs
+++ b/src/select/sel_html.rs
@@ -17,8 +17,8 @@ impl HtmlSelector {
     }
 }
 
-impl<'a> MatchSelector<HtmlRef<'a>> for HtmlSelector { // TODO can I elide the 'a?
-    fn matches(&self, html: HtmlRef<'a>) -> bool {
+impl MatchSelector<HtmlRef<'_>> for HtmlSelector {
+    fn matches(&self, html: HtmlRef) -> bool {
         self.matcher.matches(html.0)
     }
 }

--- a/src/select/sel_html.rs
+++ b/src/select/sel_html.rs
@@ -17,7 +17,7 @@ impl HtmlSelector {
     }
 }
 
-impl<'a> MatchSelector<'a, HtmlRef<'a>> for HtmlSelector {
+impl<'a> MatchSelector<HtmlRef<'a>> for HtmlSelector { // TODO can I elide the 'a?
     fn matches(&self, html: HtmlRef<'a>) -> bool {
         self.matcher.matches(html.0)
     }

--- a/src/select/sel_image.rs
+++ b/src/select/sel_image.rs
@@ -16,7 +16,7 @@ impl ImageSelector {
     }
 }
 
-impl<'a> MatchSelector<'a, &'a Image> for ImageSelector {
+impl<'a> MatchSelector<&'a Image> for ImageSelector { // TODO can I elide the 'a?
     fn matches(&self, item: &'a Image) -> bool {
         self.matchers.display_matcher.matches(&item.alt) && self.matchers.url_matcher.matches(&item.link.url)
     }

--- a/src/select/sel_image.rs
+++ b/src/select/sel_image.rs
@@ -16,8 +16,8 @@ impl ImageSelector {
     }
 }
 
-impl<'a> MatchSelector<&'a Image> for ImageSelector { // TODO can I elide the 'a?
-    fn matches(&self, item: &'a Image) -> bool {
+impl MatchSelector<&Image> for ImageSelector {
+    fn matches(&self, item: &Image) -> bool {
         self.matchers.display_matcher.matches(&item.alt) && self.matchers.url_matcher.matches(&item.link.url)
     }
 }

--- a/src/select/sel_link.rs
+++ b/src/select/sel_link.rs
@@ -16,8 +16,8 @@ impl LinkSelector {
     }
 }
 
-impl<'a> MatchSelector<&'a Link> for LinkSelector {
-    fn matches(&self, item: &'a Link) -> bool {
+impl MatchSelector<&Link> for LinkSelector {
+    fn matches(&self, item: &Link) -> bool {
         self.matchers.display_matcher.matches_inlines(&item.text)
             && self.matchers.url_matcher.matches(&item.link_definition.url)
     }

--- a/src/select/sel_link.rs
+++ b/src/select/sel_link.rs
@@ -16,7 +16,7 @@ impl LinkSelector {
     }
 }
 
-impl<'a> MatchSelector<'a, &'a Link> for LinkSelector {
+impl<'a> MatchSelector<&'a Link> for LinkSelector {
     fn matches(&self, item: &'a Link) -> bool {
         self.matchers.display_matcher.matches_inlines(&item.text)
             && self.matchers.url_matcher.matches(&item.link_definition.url)

--- a/src/select/sel_list_item.rs
+++ b/src/select/sel_list_item.rs
@@ -82,7 +82,7 @@ impl ListItemSelector {
     }
 }
 
-impl<'a> MatchSelector<'a, ListItemRef<'a>> for ListItemSelector {
+impl<'a> MatchSelector<ListItemRef<'a>> for ListItemSelector {
     fn matches(&self, item: ListItemRef<'a>) -> bool {
         let ListItemRef(idx, li) = item;
         self.li_type.matches(&idx) && self.checkbox.matches(&li.checked) && self.string_matcher.matches_any(&li.item)

--- a/src/select/sel_list_item.rs
+++ b/src/select/sel_list_item.rs
@@ -82,8 +82,8 @@ impl ListItemSelector {
     }
 }
 
-impl<'a> MatchSelector<ListItemRef<'a>> for ListItemSelector {
-    fn matches(&self, item: ListItemRef<'a>) -> bool {
+impl MatchSelector<ListItemRef<'_>> for ListItemSelector {
+    fn matches(&self, item: ListItemRef) -> bool {
         let ListItemRef(idx, li) = item;
         self.li_type.matches(&idx) && self.checkbox.matches(&li.checked) && self.string_matcher.matches_any(&li.item)
     }

--- a/src/select/sel_paragraph.rs
+++ b/src/select/sel_paragraph.rs
@@ -18,8 +18,8 @@ impl ParagraphSelector {
     }
 }
 
-impl<'a> MatchSelector<&'a Paragraph> for ParagraphSelector {
-    fn matches(&self, paragraph: &'a Paragraph) -> bool {
+impl MatchSelector<&Paragraph> for ParagraphSelector {
+    fn matches(&self, paragraph: &Paragraph) -> bool {
         self.matcher.matches_inlines(&paragraph.body)
     }
 }

--- a/src/select/sel_paragraph.rs
+++ b/src/select/sel_paragraph.rs
@@ -18,7 +18,7 @@ impl ParagraphSelector {
     }
 }
 
-impl<'a> MatchSelector<'a, &'a Paragraph> for ParagraphSelector {
+impl<'a> MatchSelector<&'a Paragraph> for ParagraphSelector {
     fn matches(&self, paragraph: &'a Paragraph) -> bool {
         self.matcher.matches_inlines(&paragraph.body)
     }

--- a/src/select/sel_section.rs
+++ b/src/select/sel_section.rs
@@ -17,8 +17,8 @@ impl SectionSelector {
     }
 }
 
-impl<'a> MatchSelector<&'a Section> for SectionSelector {
-    fn matches(&self, section: &'a Section) -> bool {
+impl MatchSelector<&Section> for SectionSelector {
+    fn matches(&self, section: &Section) -> bool {
         self.matcher.matches_inlines(&section.title)
     }
 }

--- a/src/select/sel_section.rs
+++ b/src/select/sel_section.rs
@@ -17,7 +17,7 @@ impl SectionSelector {
     }
 }
 
-impl<'a> MatchSelector<'a, &'a Section> for SectionSelector {
+impl<'a> MatchSelector<&'a Section> for SectionSelector {
     fn matches(&self, section: &'a Section) -> bool {
         self.matcher.matches_inlines(&section.title)
     }

--- a/src/select/sel_table.rs
+++ b/src/select/sel_table.rs
@@ -1,0 +1,45 @@
+use crate::matcher::StringMatcher;
+use crate::parsing_iter::ParsingIterator;
+use crate::select::{ParseErrorReason, ParseResult, Selector, SELECTOR_SEPARATOR};
+use crate::tree::Table;
+use crate::tree_ref::{MdElemRef, TableSlice};
+
+#[derive(Debug, PartialEq)]
+pub struct TableSelector {
+    headers_matcher: StringMatcher,
+    rows_matcher: StringMatcher,
+}
+
+impl TableSelector {
+    pub fn read(iter: &mut ParsingIterator) -> ParseResult<Self> {
+        // headers matcher
+        iter.require_str("-:")?;
+        iter.require_whitespace(":-:")?;
+        if iter.peek() == Some(':') {
+            return Err(ParseErrorReason::InvalidSyntax("table headers matcher may not be empty. Use an explicit \"*\" to select all columns.".to_string()))
+        }
+        let headers_matcher = StringMatcher::read(iter, ':')?;
+
+        // rows matcher
+        iter.drop_whitespace();
+        iter.require_str(":-:")?;
+        iter.require_whitespace(":-:")?;
+        let rows_matcher = StringMatcher::read(iter, SELECTOR_SEPARATOR)?;
+
+        Ok(Self{headers_matcher, rows_matcher})
+    }
+}
+
+impl<'a> Selector<'a, &'a Table> for TableSelector {
+    fn try_select(&self, item: &'a Table) -> Option<MdElemRef<'a>> {
+        let slice = TableSlice::from(item);
+        let mut slice = slice.normalize(); // TODO make this a "&mut self" that returns ()
+        let mut slice = slice.retain_columns(|line| {
+            let res = self.headers_matcher.matches_inlines(line);
+            eprint!("looking for {:?} in {line:?}: {res}\n", self.headers_matcher);
+            res
+        })?; // TODO should retain_columns return an Option<()> so I can just ?; it here?
+        let slice = slice.retain_rows(|line| self.rows_matcher.matches_inlines(line))?;
+        Some(slice.into())
+    }
+}

--- a/src/select/sel_table.rs
+++ b/src/select/sel_table.rs
@@ -16,17 +16,16 @@ impl TableSelector {
         iter.require_str("-:")?;
         iter.require_whitespace(":-:")?;
         if iter.peek() == Some(':') {
-            return Err(ParseErrorReason::InvalidSyntax("table headers matcher may not be empty. Use an explicit \"*\" to select all columns.".to_string()))
+            return Err(ParseErrorReason::InvalidSyntax("table headers matcher may not be empty. Use an explicit \"*\" to select all columns.".to_string()));
         }
         let headers_matcher = StringMatcher::read(iter, ':')?;
 
         // rows matcher
-        iter.drop_whitespace();
         iter.require_str(":-:")?;
-        iter.require_whitespace(":-:")?;
+        iter.require_whitespace_or(SELECTOR_SEPARATOR, ":-:")?;
         let rows_matcher = StringMatcher::read(iter, SELECTOR_SEPARATOR)?;
 
-        Ok(Self{headers_matcher, rows_matcher})
+        Ok(Self { headers_matcher, rows_matcher })
     }
 }
 
@@ -36,9 +35,7 @@ impl<'a> Selector<'a, &'a Table> for TableSelector {
         slice.normalize();
 
         slice.retain_columns_by_header(|line| {
-            let res = self.headers_matcher.matches_inlines(line);
-            eprint!("looking for {:?} in {line:?}: {res}\n", self.headers_matcher);
-            res
+            self.headers_matcher.matches_inlines(line)
         });
         if slice.is_empty() {
             return None;
@@ -49,5 +46,193 @@ impl<'a> Selector<'a, &'a Table> for TableSelector {
             return None;
         }
         Some(slice.into())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    mod parse {
+        use crate::select::ParseErrorReason::InvalidSyntax;
+        use super::*;
+
+        #[test]
+        fn only_row_matcher_provided() {
+            // note: no space required before the second ":-:"
+            expect_ok(":-: 'a':-:", "a", ".*");
+        }
+
+        #[test]
+        fn both_matchers_provided() {
+            expect_ok(":-: 'a' :-: 'b'", "a", "b");
+        }
+
+        #[test]
+        fn row_matcher_empty() {
+            expect_invalid(":-: :-:","table headers matcher may not be empty. Use an explicit \"*\" to select all columns.");
+        }
+
+        #[test]
+        fn row_matcher_no_space() {
+            expect_invalid(":-:X :-:",":-: must be followed by whitespace");
+        }
+
+        fn expect_ok(in_str: &str, headers_matcher_re: &str, rows_matcher_re: &str) {
+            let actual_test = |actual_str: &str| {
+                let mut in_chars = ParsingIterator::new(actual_str);
+                in_chars.require_char(':').expect("test error: bad selector format");
+
+                let actual = TableSelector::read(&mut in_chars).expect("test error: bad selector format");
+
+                let expect_headers_matcher = StringMatcher::from(headers_matcher_re);
+                let expect_rows_matcher = StringMatcher::from(rows_matcher_re);
+                assert_eq!(actual.headers_matcher, expect_headers_matcher);
+                assert_eq!(actual.rows_matcher, expect_rows_matcher);
+            };
+
+            // Run it three times: once as-is, and then with a trailing selector separator, and then
+            // with a space and separator. They should all be equivalent.
+            actual_test(in_str);
+            actual_test(&format!("{in_str}{SELECTOR_SEPARATOR}"));
+            actual_test(&format!("{in_str} {SELECTOR_SEPARATOR}"));
+        }
+
+        fn expect_invalid(in_str: &str, expect_err: &str) {
+            let mut in_chars = ParsingIterator::new(in_str);
+            in_chars.require_char(':').expect("test error: bad selector format");
+
+            let actual = TableSelector::read(&mut in_chars);
+            assert_eq!(actual, Err(InvalidSyntax(expect_err.to_string())))
+        }
+    }
+
+    mod select {
+        use super::*;
+        use markdown::mdast;
+        use crate::tree::{Inline, Line, Text, TextVariant};
+        use crate::unwrap;
+
+        #[test]
+        fn select_all_on_normalized_table() {
+            let table = Table{
+                alignments: vec![mdast::AlignKind::Left, mdast::AlignKind::Right],
+                rows: vec![
+                    vec![cell("header a"), cell("header b")],
+                    vec![cell("data 1 a"), cell("data 1 b")],
+                ],
+            };
+            let maybe_selected = TableSelector {
+                headers_matcher: ".*".into(),
+                rows_matcher: ".*".into(),
+            }.try_select(&table);
+
+            unwrap!(maybe_selected, Some(MdElemRef::TableSlice(table)));
+            assert_eq!(
+                table.alignments(),
+                &vec![mdast::AlignKind::Left, mdast::AlignKind::Right]
+            );
+            assert_eq!(
+                table.rows().collect::<Vec<_>>(),
+                vec![
+                    &vec![Some(&cell("header a")), Some(&cell("header b"))],
+                    &vec![Some(&cell("data 1 a")), Some(&cell("data 1 b"))],
+                ]
+            );
+        }
+
+        #[test]
+        fn select_columns_on_normalized_table() {
+            let table = Table{
+                alignments: vec![mdast::AlignKind::Left, mdast::AlignKind::Right],
+                rows: vec![
+                    vec![cell("header a"), cell("KEEP b")],
+                    vec![cell("data 1 a"), cell("data 1 b")],
+                ],
+            };
+            let maybe_selected = TableSelector {
+                headers_matcher: "KEEP".into(),
+                rows_matcher: ".*".into(),
+            }.try_select(&table);
+
+            unwrap!(maybe_selected, Some(MdElemRef::TableSlice(table)));
+            assert_eq!(
+                table.alignments(),
+                &vec![mdast::AlignKind::Right]
+            );
+            assert_eq!(
+                table.rows().collect::<Vec<_>>(),
+                vec![
+                    &vec![Some(&cell("KEEP b"))],
+                    &vec![Some(&cell("data 1 b"))],
+                ]
+            );
+        }
+
+        #[test]
+        fn select_rows_on_normalized_table() {
+            let table = Table{
+                alignments: vec![mdast::AlignKind::Left, mdast::AlignKind::Right],
+                rows: vec![
+                    vec![cell("header a"), cell("header b")],
+                    vec![cell("data 1 a"), cell("data 1 b")],
+                    vec![cell("data 2 a"), cell("data 2 b")],
+                ],
+            };
+            let maybe_selected = TableSelector {
+                headers_matcher: ".*".into(),
+                rows_matcher: "data 2".into(),
+            }.try_select(&table);
+
+            unwrap!(maybe_selected, Some(MdElemRef::TableSlice(table)));
+            assert_eq!(
+                table.alignments(),
+                &vec![mdast::AlignKind::Left, mdast::AlignKind::Right]
+            );
+            assert_eq!(
+                table.rows().collect::<Vec<_>>(),
+                vec![
+                    // note: header always gets retained
+                    &vec![Some(&cell("header a")), Some(&cell("header b"))],
+                    &vec![Some(&cell("data 2 a")), Some(&cell("data 2 b"))],
+                ]
+            );
+        }
+
+        /// Tests (a) that the table gets normalized, and (b) a smoke test of the matchers.
+        /// More extensive tests for the `retain_*` methods can be found in [TableSlice]'s tests.
+        #[test]
+        fn jagged_table() {
+            let table = Table{
+                // only 1 align; rest will be filled with None
+                alignments: vec![mdast::AlignKind::Left],
+                rows: vec![
+                    vec![cell("header a")],
+                    vec![cell("data 1 a"), cell("data 1 b")],
+                    vec![cell("data 2 a"), cell("data 2 b"), cell("data 2 c")],
+                ],
+            };
+            let maybe_selected = TableSelector {
+                headers_matcher: ".*".into(),
+                rows_matcher: "data 1".into(),
+            }.try_select(&table);
+
+            unwrap!(maybe_selected, Some(MdElemRef::TableSlice(table)));
+            assert_eq!(
+                table.alignments(),
+                &vec![mdast::AlignKind::Left, mdast::AlignKind::None, mdast::AlignKind::None]
+            );
+            assert_eq!(
+                table.rows().collect::<Vec<_>>(),
+                vec![
+                    &vec![Some(&cell("header a")), None, None],
+                    &vec![Some(&cell("data 1 a")), Some(&cell("data 1 b")), None],
+                ]
+            );
+        }
+
+        fn cell(cell_str: &str) -> Line {
+            vec![Inline::Text(Text{variant: TextVariant::Plain, value: cell_str.to_string()})]
+        }
     }
 }

--- a/src/str_utils.rs
+++ b/src/str_utils.rs
@@ -43,17 +43,17 @@ where
 }
 
 pub trait ToAlignment {
-    fn to_alignment(&self) -> Option<Alignment>;
+    fn to_alignment(self) -> Option<Alignment>;
 }
 
 impl ToAlignment for Alignment {
-    fn to_alignment(&self) -> Option<Alignment> {
-        Some(*self)
+    fn to_alignment(self) -> Option<Alignment> {
+        Some(self)
     }
 }
 
-impl ToAlignment for &AlignKind {
-    fn to_alignment(&self) -> Option<Alignment> {
+impl ToAlignment for AlignKind {
+    fn to_alignment(self) -> Option<Alignment> {
         match self {
             AlignKind::Left => Some(Alignment::Left),
             AlignKind::Right => Some(Alignment::Right),
@@ -64,7 +64,7 @@ impl ToAlignment for &AlignKind {
 }
 
 impl<A: Borrow<AlignKind>> ToAlignment for Option<A> {
-    fn to_alignment(&self) -> Option<Alignment> {
+    fn to_alignment(self) -> Option<Alignment> {
         match self {
             Some(a) => a.borrow().to_alignment(),
             None => None,

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -1776,6 +1776,44 @@ mod tests {
             });
         }
 
+        #[test]
+        fn jagged_table() {
+            let (root, lookups) = parse_with(
+                &ParseOptions::gfm(),
+                indoc! {r#"
+                    | Header A | Header B |
+                    |:---------|---------:|
+                    |        1 | 2        |
+                    |        3
+                    |        4 | 5        | 6 |
+                    "#},
+            );
+            assert_eq!(root.children.len(), 1);
+            check!(&root.children[0], Node::Table(_), lookups => m_node!(MdElem::Table{alignments, rows}) = {
+                assert_eq!(alignments, vec![mdast::AlignKind::Left, mdast::AlignKind::Right]);
+                assert_eq!(rows,
+                    vec![ // rows
+                        vec![// Header row
+                            vec![mdq_inline!("Header A")], // cells, each being a spans of inline
+                            vec![mdq_inline!("Header B")],
+                        ],
+                        vec![// data row
+                            vec![mdq_inline!("1")], // cells, each being a spans of inline
+                            vec![mdq_inline!("2")],
+                        ],
+                        vec![// data row
+                            vec![mdq_inline!("3")], // cells, each being a spans of inline
+                        ],
+                        vec![// data row
+                            vec![mdq_inline!("4")], // cells, each being a spans of inline
+                            vec![mdq_inline!("5")],
+                            vec![mdq_inline!("6")],
+                        ],
+                    ],
+                );
+            });
+        }
+
         fn parse(md: &str) -> (mdast::Root, Lookups) {
             parse_with(&ParseOptions::default(), md)
         }

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -61,8 +61,7 @@ impl<'a> TableSlice<'a> {
         Some(Self { alignments, rows })
     }
 
-    // TODO rename to "retain_columns"
-    pub fn filter_columns<F>(mut self, f: F) -> Option<Self>
+    pub fn retain_columns<F>(mut self, f: F) -> Option<Self>
     where
         F: Fn(&Line) -> bool,
     {
@@ -82,8 +81,7 @@ impl<'a> TableSlice<'a> {
         Some(self)
     }
 
-    // TODO rename to "retain_rows"
-    pub fn filter_rows<F>(mut self, f: F) -> Option<Self>
+    pub fn retain_rows<F>(mut self, f: F) -> Option<Self>
     where
         F: Fn(&Line) -> bool,
     {

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -69,10 +69,10 @@ impl<'a> TableSlice<'a> {
         let first_row = self.rows.first()?;
         let removals = IndexRemover::for_items(first_row, |_, &i| f(i));
 
-        if removals.count_removals() == 0 {
+        if removals.count_keeps() == first_row.len() {
             return Some(self);
         }
-        if removals.count_removals() == first_row.len() {
+        if removals.count_keeps() == 0 {
             // all columns filtered out!
             return None;
         }

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -69,12 +69,10 @@ impl<'a> TableSlice<'a> {
         let first_row = self.rows.first()?;
         let removals = IndexRemover::for_items(first_row, |_, &i| f(i));
 
-        if removals.count_keeps() == first_row.len() {
-            return Some(self);
-        }
-        if removals.count_keeps() == 0 {
-            // all columns filtered out!
-            return None;
+        match removals.count_keeps() {
+            0 => return None,
+            n if n == first_row.len() => return Some(self),
+            _ => {}
         }
 
         removals.apply(&mut self.alignments);

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -90,9 +90,9 @@ impl<'a> TableSlice<'a> {
         F: Fn(&Line) -> bool,
     {
         self.rows
-            .retain_with_index(|idx, row| if idx == 0 { true } else { row.iter().any(|&col| f(col)) });
+            .retain_with_index(|idx, row| idx == 0 || row.iter().any(|&col| f(col)));
 
-        // We always keep the first row; but if we then removed all the other rows, this is empty.
+        // We always keep the first row; but if we then removed all the other rows, this TableSlice is empty.
         if self.rows.len() <= 1 {
             return None;
         }

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -75,9 +75,9 @@ impl<'a> TableSlice<'a> {
             _ => {}
         }
 
-        removals.apply(&mut self.alignments);
+        self.alignments.retain_with_index(removals.retain_fn());
         for row in self.rows.iter_mut() {
-            removals.apply(row);
+            row.retain_with_index(removals.retain_fn());
         }
         Some(self)
     }

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -1,4 +1,6 @@
-use crate::tree::{BlockQuote, CodeBlock, Image, Inline, Line, Link, List, ListItem, MdElem, Paragraph, Section, Table};
+use crate::tree::{
+    BlockQuote, CodeBlock, Image, Inline, Line, Link, List, ListItem, MdElem, Paragraph, Section, Table,
+};
 use crate::vec_utils::{IndexKeeper, ItemRetainer};
 use markdown::mdast;
 
@@ -58,7 +60,7 @@ impl<'a> TableSlice<'a> {
         &self.alignments
     }
 
-    pub fn rows(&self) -> impl Iterator<Item=&TableRowSlice<'a>> {
+    pub fn rows(&self) -> impl Iterator<Item = &TableRowSlice<'a>> {
         self.rows.iter()
     }
 
@@ -80,7 +82,10 @@ impl<'a> TableSlice<'a> {
         if self.alignments.len() > max_cols {
             self.alignments.truncate(max_cols);
         } else {
-            let nones = [mdast::AlignKind::None].iter().cycle().take(max_cols - self.alignments.len());
+            let nones = [mdast::AlignKind::None]
+                .iter()
+                .cycle()
+                .take(max_cols - self.alignments.len());
             self.alignments.extend(nones);
         }
     }
@@ -105,11 +110,11 @@ impl<'a> TableSlice<'a> {
                 self.alignments.clear();
                 self.rows.clear();
                 return;
-            },
+            }
             n if n == first_row.len() => {
                 // all columns match: no need to go one by one, just return without modifications
-                return
-            },
+                return;
+            }
             _ => {
                 // some columns match: retain those, and discard the rest
                 self.alignments.retain_with_index(keeper_indices.retain_fn());
@@ -124,17 +129,16 @@ impl<'a> TableSlice<'a> {
     where
         F: FnMut(&Line) -> bool,
     {
-        self.rows
-            .retain_with_index(|idx, row| {
-                if idx == 0 {
-                    return true
-                }
-                row.iter().any(|opt_cell| {
-                    let empty_cell = Line::new();
-                    let resolved_cell = opt_cell.unwrap_or(&empty_cell);
-                    f(resolved_cell)
-                })
-            });
+        self.rows.retain_with_index(|idx, row| {
+            if idx == 0 {
+                return true;
+            }
+            row.iter().any(|opt_cell| {
+                let empty_cell = Line::new();
+                let resolved_cell = opt_cell.unwrap_or(&empty_cell);
+                f(resolved_cell)
+            })
+        });
     }
 
     pub fn is_empty(&self) -> bool {
@@ -270,26 +274,40 @@ mod tests {
             ]);
             {
                 let plain_slice = TableSlice::from(&table);
-                assert_eq!(plain_slice.alignments, vec![mdast::AlignKind::Left, mdast::AlignKind::Right]);
+                assert_eq!(
+                    plain_slice.alignments,
+                    vec![mdast::AlignKind::Left, mdast::AlignKind::Right]
+                );
                 assert_eq!(
                     plain_slice.rows,
                     vec![
                         vec![Some(&cell("header a")), Some(&cell("header b"))],
                         vec![Some(&cell("data 1 a"))],
-                        vec![Some(&cell("data 2 a")), Some(&cell("data 2 b")), Some(&cell("data 2 c"))],
+                        vec![
+                            Some(&cell("data 2 a")),
+                            Some(&cell("data 2 b")),
+                            Some(&cell("data 2 c"))
+                        ],
                     ]
                 );
             }
             {
                 let mut normalized_slice = TableSlice::from(&table);
                 normalized_slice.normalize();
-                assert_eq!(normalized_slice.alignments, vec![mdast::AlignKind::Left, mdast::AlignKind::Right, mdast::AlignKind::None]);
+                assert_eq!(
+                    normalized_slice.alignments,
+                    vec![mdast::AlignKind::Left, mdast::AlignKind::Right, mdast::AlignKind::None]
+                );
                 assert_eq!(
                     normalized_slice.rows,
                     vec![
                         vec![Some(&cell("header a")), Some(&cell("header b")), None],
                         vec![Some(&cell("data 1 a")), None, None],
-                        vec![Some(&cell("data 2 a")), Some(&cell("data 2 b")), Some(&cell("data 2 c"))],
+                        vec![
+                            Some(&cell("data 2 a")),
+                            Some(&cell("data 2 b")),
+                            Some(&cell("data 2 c"))
+                        ],
                     ]
                 );
             }
@@ -335,22 +353,25 @@ mod tests {
             });
 
             // normalization
-            assert_eq!(slice.alignments, vec![mdast::AlignKind::Left, mdast::AlignKind::Right, mdast::AlignKind::None]);
+            assert_eq!(
+                slice.alignments,
+                vec![mdast::AlignKind::Left, mdast::AlignKind::Right, mdast::AlignKind::None]
+            );
             assert_eq!(
                 slice.rows,
                 vec![
                     vec![Some(&cell("header a")), Some(&cell("header b")), None],
-                    vec![Some(&cell("data 1 a")), Some(&cell("data 1 b")), Some(&cell("data 1 c"))],
+                    vec![
+                        Some(&cell("data 1 a")),
+                        Some(&cell("data 1 b")),
+                        Some(&cell("data 1 c"))
+                    ],
                     vec![Some(&cell("data 2 a")), None, None],
                 ]
             );
             assert_eq!(
                 seen_lines,
-                vec![
-                    "header a".to_string(),
-                    "header b".to_string(),
-                    "".to_string(),
-                ],
+                vec!["header a".to_string(), "header b".to_string(), "".to_string(),],
             );
         }
 
@@ -376,8 +397,16 @@ mod tests {
             assert_eq!(
                 slice.rows,
                 vec![
-                    vec![Some(&cell("header a")), Some(&cell("header b")), Some(&cell("header c"))],
-                    vec![Some(&cell("data 2 a")), Some(&cell("KEEPER b")), Some(&cell("data 2 c"))],
+                    vec![
+                        Some(&cell("header a")),
+                        Some(&cell("header b")),
+                        Some(&cell("header c"))
+                    ],
+                    vec![
+                        Some(&cell("data 2 a")),
+                        Some(&cell("KEEPER b")),
+                        Some(&cell("data 2 c"))
+                    ],
                 ]
             );
         }
@@ -402,7 +431,10 @@ mod tests {
             });
 
             // normalization
-            assert_eq!(slice.alignments, vec![mdast::AlignKind::Left, mdast::AlignKind::Right, mdast::AlignKind::None]);
+            assert_eq!(
+                slice.alignments,
+                vec![mdast::AlignKind::Left, mdast::AlignKind::Right, mdast::AlignKind::None]
+            );
             assert_eq!(
                 slice.rows,
                 vec![
@@ -447,11 +479,11 @@ mod tests {
                 mdast::AlignKind::Right,
                 mdast::AlignKind::Center,
             ]
-                .iter()
-                .cycle()
-                .take(first_row.len())
-                .map(ToOwned::to_owned)
-                .collect();
+            .iter()
+            .cycle()
+            .take(first_row.len())
+            .map(ToOwned::to_owned)
+            .collect();
             let mut rows = Vec::with_capacity(cells.len());
 
             while let Some(row_strings) = rows_iter.next() {
@@ -476,7 +508,7 @@ mod tests {
             let mut result = String::with_capacity(32);
             for segment in line {
                 match segment {
-                    Inline::Text(Text{ variant, value}) if variant == &TextVariant::Plain => {
+                    Inline::Text(Text { variant, value }) if variant == &TextVariant::Plain => {
                         result.push_str(value);
                     }
                     _ => {

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -93,15 +93,13 @@ impl<'a> TableSlice<'a> {
         Self { alignments, rows }
     }
 
-    pub fn retain_columns<F>(mut self, f: F) -> Option<Self>
+    pub fn retain_columns<F>(mut self, f: F) -> Option<Self> // TODO rename to retain_columns_by_header.
     where
         F: Fn(&Line) -> bool,
     {
         let first_row = self.rows.first()?;
         let mut keeper_indices = IndexKeeper::new();
-        for row in &self.rows {
-            keeper_indices.retain_when(row, |_, opt_line| opt_line.map(|line| f(line)).unwrap_or(false));
-        }
+        keeper_indices.retain_when(first_row, |_, opt_line| opt_line.map(|line| f(line)).unwrap_or(false));
 
         match keeper_indices.count_keeps() {
             0 => return None,
@@ -148,6 +146,7 @@ impl<'a> From<&'a MdElem> for MdElemRef<'a> {
     }
 }
 
+// TODO do I need all these explicit 'a lifetimes? I think I can do '_
 impl<'a> From<&'a BlockQuote> for MdElemRef<'a> {
     fn from(value: &'a BlockQuote) -> Self {
         MdElemRef::BlockQuote(value)
@@ -193,6 +192,18 @@ impl<'a> From<&'a Paragraph> for MdElemRef<'a> {
 impl<'a> From<&'a Section> for MdElemRef<'a> {
     fn from(value: &'a Section) -> Self {
         MdElemRef::Section(value)
+    }
+}
+
+impl<'a> From<&'a Table> for MdElemRef<'a> {
+    fn from(value: &'a Table) -> Self {
+        MdElemRef::Table(value)
+    }
+}
+
+impl<'a> From<TableSlice<'a>> for MdElemRef<'a> {
+    fn from(value: TableSlice<'a>) -> Self {
+        MdElemRef::TableSlice(value)
     }
 }
 

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -39,16 +39,6 @@ pub struct TableSlice<'a> {
     rows: Vec<TableRowSlice<'a>>,
 }
 
-impl<'a> TableSlice<'a> {
-    pub fn alignments(&self) -> &Vec<mdast::AlignKind> {
-        &self.alignments
-    }
-
-    pub fn rows(&self) -> impl Iterator<Item=&TableRowSlice<'a>> {
-        self.rows.iter()
-    }
-}
-
 pub type TableRowSlice<'a> = Vec<Option<&'a Line>>;
 
 impl<'a> From<&'a Table> for TableSlice<'a> {
@@ -64,7 +54,15 @@ impl<'a> From<&'a Table> for TableSlice<'a> {
 }
 
 impl<'a> TableSlice<'a> {
-    /// Creates a normalized version of this slice, where every row has the same number of columns.
+    pub fn alignments(&self) -> &Vec<mdast::AlignKind> {
+        &self.alignments
+    }
+
+    pub fn rows(&self) -> impl Iterator<Item=&TableRowSlice<'a>> {
+        self.rows.iter()
+    }
+
+    /// Normalizes this slice, so that every row has the same number of columns.
     ///
     /// If the table is jagged, all jagged rows will be filled in with [None] cells. Any missing
     /// alignments will be filled in as `None`.

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -90,7 +90,7 @@ impl<'a> TableSlice<'a> {
         F: Fn(&Line) -> bool,
     {
         self.rows
-            .retain_if_with_index(|idx, row| if idx == 0 { true } else { row.iter().any(|&col| f(col)) });
+            .retain_with_index(|idx, row| if idx == 0 { true } else { row.iter().any(|&col| f(col)) });
 
         // We always keep the first row; but if we then removed all the other rows, this is empty.
         if self.rows.len() <= 1 {

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -157,7 +157,7 @@ impl<'a> SerdeDoc<'a> {
             footnotes: HashMap::with_capacity(DEFAULT_CAPACITY),
         };
         for elem in elems {
-            let top = SerdeElem::build(*elem, &mut inlines_writer);
+            let top = SerdeElem::build(elem.to_owned(), &mut inlines_writer);
             result.items.push(top);
         }
         for (link_label, url) in inlines_writer.drain_pending_links() {
@@ -262,6 +262,9 @@ impl<'a> SerdeElem<'a> {
                     rows: rendered_rows,
                 }
             }
+            MdElemRef::TableSlice(table) => {
+                todo!()
+            }
             MdElemRef::ThematicBreak => Self::ThematicBreak,
             MdElemRef::ListItem(li) => {
                 let index = match li.0 {
@@ -318,6 +321,7 @@ mod tests {
         Paragraph(_),
         Section(_),
         Table(_),
+        TableSlice(_),
         ThematicBreak,
         Html(_),
 

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -311,7 +311,7 @@ mod tests {
     use crate::md_elems;
     use crate::tree::MdElem;
     use crate::tree::*;
-    use crate::tree_ref::{ListItemRef, TableSlice};
+    use crate::tree_ref::{ListItemRef};
     use crate::variants_checker;
     use crate::{md_elem, mdq_inline};
 

--- a/src/tree_ref_serde.rs
+++ b/src/tree_ref_serde.rs
@@ -248,9 +248,7 @@ impl<'a> SerdeElem<'a> {
                 let body = Self::build_multi(body, inlines_writer);
                 Self::Section { depth, title, body }
             }
-            MdElemRef::Table(table) => {
-                Self::build(MdElemRef::TableSlice(table.into()), inlines_writer)
-            }
+            MdElemRef::Table(table) => Self::build(MdElemRef::TableSlice(table.into()), inlines_writer),
             MdElemRef::TableSlice(table) => {
                 let mut rendered_rows = Vec::with_capacity(8); // TODO this is a guess; expose it via the trait?
                 for row in table.rows() {
@@ -258,7 +256,7 @@ impl<'a> SerdeElem<'a> {
                     for maybe_cell in row {
                         let rendered_cell = match maybe_cell {
                             Some(cell) => inlines_to_string(*cell, inlines_writer),
-                            None => "".to_string()
+                            None => "".to_string(),
                         };
                         rendered_cells.push(rendered_cell)
                     }
@@ -311,7 +309,7 @@ mod tests {
     use crate::md_elems;
     use crate::tree::MdElem;
     use crate::tree::*;
-    use crate::tree_ref::{ListItemRef};
+    use crate::tree_ref::ListItemRef;
     use crate::variants_checker;
     use crate::{md_elem, mdq_inline};
 
@@ -664,13 +662,13 @@ mod tests {
 
     #[test]
     fn table_slice() {
-        let table = Table{
-                alignments: vec![AlignKind::Left, AlignKind::None],
-                rows: vec![
-                    vec![vec![mdq_inline!("R1C1")], vec![mdq_inline!("R1C2")]],
-                    vec![vec![mdq_inline!("R2C1")], vec![mdq_inline!("R2C2")]],
-                ]
-            };
+        let table = Table {
+            alignments: vec![AlignKind::Left, AlignKind::None],
+            rows: vec![
+                vec![vec![mdq_inline!("R1C1")], vec![mdq_inline!("R1C2")]],
+                vec![vec![mdq_inline!("R2C1")], vec![mdq_inline!("R2C2")]],
+            ],
+        };
 
         check_md_ref(
             MdElemRef::TableSlice((&table).into()),

--- a/src/vec_utils.rs
+++ b/src/vec_utils.rs
@@ -32,6 +32,24 @@ impl IndexRemover {
     }
 }
 
+pub trait ItemRetainer<I> {
+    fn retain_if_with_index<F>(&mut self, f: F)
+    where
+        F: Fn(usize, &I) -> bool;
+}
+
+impl<I> ItemRetainer<I> for Vec<I> {
+    fn retain_if_with_index<F>(&mut self, f: F)
+    where
+        F: Fn(usize, &I) -> bool,
+    {
+        // TODO we don't need the IndexRemover here! We can just do the swapping logic directly here.
+        // In fact, IndexRemover::apply should invoke this method.
+        let remover = IndexRemover::for_items(self, f);
+        remover.apply(self)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]

--- a/src/vec_utils.rs
+++ b/src/vec_utils.rs
@@ -3,6 +3,8 @@ pub struct IndexRemover {
     to_remove_order_asc: Vec<usize>,
 }
 
+// TODO actually, I should just rm this struct altogether. The one place I need it, I can just construct the Vec<usize>
+// directly, and then invoke retrain_if_with_index
 impl IndexRemover {
     pub fn for_items<I, F>(items: &[I], allow_filter: F) -> Self
     where
@@ -33,13 +35,13 @@ impl IndexRemover {
 }
 
 pub trait ItemRetainer<I> {
-    fn retain_if_with_index<F>(&mut self, f: F)
+    fn retain_with_index<F>(&mut self, f: F)
     where
         F: Fn(usize, &I) -> bool;
 }
 
 impl<I> ItemRetainer<I> for Vec<I> {
-    fn retain_if_with_index<F>(&mut self, f: F)
+    fn retain_with_index<F>(&mut self, f: F)
     where
         F: Fn(usize, &I) -> bool,
     {

--- a/src/vec_utils.rs
+++ b/src/vec_utils.rs
@@ -1,0 +1,45 @@
+pub struct IndexRemover {
+    /// must be ordered!
+    to_remove_order_asc: Vec<usize>,
+}
+
+impl IndexRemover {
+    pub fn for_items<I, F>(items: &[I], allow_filter: F) -> Self
+    where
+        F: Fn(usize, &I) -> bool,
+    {
+        let mut indices = Vec::with_capacity(items.len());
+        for (idx, item) in items.iter().enumerate() {
+            if !allow_filter(idx, item) {
+                indices.push(idx);
+            }
+        }
+        Self {
+            to_remove_order_asc: indices,
+        }
+    }
+
+    pub fn apply<I>(&self, items: &mut Vec<I>) {
+        // TODO: this is O(n^2): it loops N=rows times, and each row.remove is O(M=columns).
+        // We could do this more efficiently by swapping the to-be-saved items in, and then truncating the rest.
+        for to_rm in self.to_remove_order_asc.iter().rev() {
+            items.remove(*to_rm);
+        }
+    }
+
+    pub fn count_removals(&self) -> usize {
+        self.to_remove_order_asc.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn todo() {
+        todo!("add some tests!")
+        // - remover is empty
+        // - remover is lal
+        // - remover is some items (but not all)
+        // - remover has more indices than target vec (should silently ignore)
+    }
+}

--- a/tests/md_cases/select_block_quote.toml
+++ b/tests/md_cases/select_block_quote.toml
@@ -41,3 +41,10 @@ cli_args = ['> | - *'] # note: space between the - and [ is required
 output = '''
 - Four
 '''
+
+
+[expect."chained"]
+cli_args = ['> two | > two'] # note: space between the - and [ is required
+output = '''
+> Two
+'''

--- a/tests/md_cases/select_tables.toml
+++ b/tests/md_cases/select_tables.toml
@@ -37,20 +37,20 @@ output = '''
 | Foo  | Not a fizz  |                             |
 | Bar  | Not a buzz  |                             |
 | Barn | Big, red.   | And this is an extra column |
-| Fuzz |             |                             |
-'''
+| Fuzz |             |                             |'''
 
 
 [expect."select only name"]
-cli_args = [":-: name :-:"]
+# note: "Name" has an 'a', "Description" doesn't. There are other rows that do contain 'a' in the Description column,
+# but the first matcher only checks the header cells (by design).
+cli_args = [":-: a :-:"]
 output = '''
 | Name |
 |:----:|
 | Foo  |
 | Bar  |
 | Barn |
-| Fuzz |
-'''
+| Fuzz |'''
 
 
 [expect."select only description"]
@@ -61,8 +61,7 @@ output = '''
 | Not a fizz  |
 | Not a buzz  |
 | Big, red.   |
-|             |
-'''
+|             |'''
 
 
 [expect."select only the big red row"]
@@ -71,5 +70,17 @@ cli_args = [":-: * :-: 'Big, red' "]
 output = '''
 | Name | Description |                             |
 |:----:|-------------|-----------------------------|
+| Barn | Big, red.   | And this is an extra column |'''
+
+
+[expect."chained"]
+# chaining onen all-cells selector into another; the second should be a noop
+# TODO need to add "chained" tests for all! And maybe even require it in the build.rs code
+cli_args = [":-: * :-: * | :-: * :-: * | "]
+output = '''
+| Name | Description |                             |
+|:----:|-------------|-----------------------------|
+| Foo  | Not a fizz  |                             |
+| Bar  | Not a buzz  |                             |
 | Barn | Big, red.   | And this is an extra column |
-'''
+| Fuzz |             |                             |'''

--- a/tests/md_cases/select_tables.toml
+++ b/tests/md_cases/select_tables.toml
@@ -1,0 +1,75 @@
+[given]
+md = '''
+Are you ready for a table?
+
+| Name | Description |
+|:----:|-------------|
+| Foo  | Not a fizz  |
+| Bar  | Not a buzz  |
+| Barn | Big, red.   | And this is an extra column |
+| Fuzz |
+
+Note that the "Barn" row has an extra column, and the "Fuzz" row is missing one.
+'''
+
+
+[expect."table not normalized by default"]
+cli_args = [""]
+output = '''
+Are you ready for a table?
+
+| Name | Description |
+|:----:|-------------|
+| Foo  | Not a fizz  |
+| Bar  | Not a buzz  |
+| Barn | Big, red.   | And this is an extra column |
+| Fuzz |
+
+Note that the "Barn" row has an extra column, and the "Fuzz" row is missing one.
+'''
+
+
+[expect."select all table cells normalizes"]
+cli_args = [":-: * :-:"]
+output = '''
+| Name | Description |                             |
+|:----:|-------------|-----------------------------|
+| Foo  | Not a fizz  |                             |
+| Bar  | Not a buzz  |                             |
+| Barn | Big, red.   | And this is an extra column |
+| Fuzz |             |                             |
+'''
+
+
+[expect."select only name"]
+cli_args = [":-: name :-:"]
+output = '''
+| Name |
+|:----:|
+| Foo  |
+| Bar  |
+| Barn |
+| Fuzz |
+'''
+
+
+[expect."select only description"]
+cli_args = [":-: description :-:"]
+output = '''
+| Description |
+|-------------|
+| Not a fizz  |
+| Not a buzz  |
+| Big, red.   |
+|             |
+'''
+
+
+[expect."select only the big red row"]
+# Note: header row always survives
+cli_args = [":-: * :-: 'Big, red' "]
+output = '''
+| Name | Description |                             |
+|:----:|-------------|-----------------------------|
+| Barn | Big, red.   | And this is an extra column |
+'''


### PR DESCRIPTION
At long last! Table selectors.

Syntax:

```
:-: headers matcher :-: rows matcher
```

- The `headers matcher` _must_ be specified explicitly: if you want "all columns", use `*`
- Header rows are always matched, regardless of the `rows matcher`
- If the table is jagged (not all rows have the same number of columns), it will be normalized by extending all short rows with empty columns. This is a departure from the official spec, which says that the number of columns is dictated by the header row, and all longer rows are truncated. I'm making that departure intentionally, because I think it's nicer, and the output I'll provide will always be valid markdown. I may later provide a switch to control that behavior.

This resolves #141.