### PR TITLE
add "chained" integ tests

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -44,8 +44,18 @@ fn generate_integ_test_cases(out_dir: &String) -> Result<(), String> {
                 }
             });
 
+            let mut found_chained_case = false;
             for case in spec_file_parsed.get_cases() {
+                found_chained_case |= case.case_name.eq("chained");
                 case.write_test_fn_to(out);
+            }
+            if !found_chained_case {
+                out.writeln("#[test]");
+                out.writeln("fn test() {");
+                out.with_indent(|out| {
+                    out.writeln("panic!(\"missing 'chained' test case\");");
+                });
+                out.writeln("}");
             }
         });
 

--- a/build.rs
+++ b/build.rs
@@ -33,6 +33,8 @@ fn generate_integ_test_cases(out_dir: &String) -> Result<(), String> {
             let spec_file_parsed: TestSpecFile =
                 toml::from_str(&contents).map_err(|e| spec_file.err_string(e)).unwrap();
 
+            let chained_needed = spec_file_parsed.chained.map(|ch| ch.needed).unwrap_or(true);
+
             out.write("const MD: &str = indoc::indoc! {r#\"");
             out.with_indent(|out| {
                 let mut iter = spec_file_parsed.given.md.trim().split('\n').peekable();
@@ -49,13 +51,14 @@ fn generate_integ_test_cases(out_dir: &String) -> Result<(), String> {
                 found_chained_case |= case.case_name.eq("chained");
                 case.write_test_fn_to(out);
             }
+
+            match (chained_needed, found_chained_case) {
+                (true, false) => Case::write_failing_test(out, "chained", "missing 'chained' test case"),
+                (false, true) => Case::write_failing_test(out, "chained__extra", "provided 'chained' test case even though it was marked as not needed"),
+                _ => {}
+            }
+
             if !found_chained_case {
-                out.writeln("#[test]");
-                out.writeln("fn test() {");
-                out.with_indent(|out| {
-                    out.writeln("panic!(\"missing 'chained' test case\");");
-                });
-                out.writeln("}");
             }
         });
 
@@ -112,6 +115,7 @@ impl DirEntryHelper {
 struct TestSpecFile {
     given: TestGiven,
     expect: HashMap<String, TestExpect>,
+    chained: Option<Chained>,
 }
 
 #[derive(Deserialize)]
@@ -125,6 +129,11 @@ struct TestExpect {
     output: String,
     expect_success: Option<bool>,
     ignore: Option<String>,
+}
+
+#[derive(Deserialize, Copy, Clone)]
+struct Chained {
+    needed: bool,
 }
 
 impl TestSpecFile {
@@ -153,6 +162,15 @@ struct Case {
 }
 
 impl Case {
+    fn write_failing_test(out: &mut Writer, name: &str, err_msg: &str) {
+        out.writeln("#[test]");
+        out.writes(&["fn ", name, "() {"]);
+        out.with_indent(|out| {
+            out.writes(&["panic!(\"", err_msg, "\");"]);
+        });
+        out.writeln("}");
+    }
+
     fn write_test_fn_to(&self, out: &mut Writer) {
         let fn_name = self.case_name.replace(|ch: char| !ch.is_alphanumeric(), "_");
         if self.ignored {

--- a/build.rs
+++ b/build.rs
@@ -54,12 +54,15 @@ fn generate_integ_test_cases(out_dir: &String) -> Result<(), String> {
 
             match (chained_needed, found_chained_case) {
                 (true, false) => Case::write_failing_test(out, "chained", "missing 'chained' test case"),
-                (false, true) => Case::write_failing_test(out, "chained__extra", "provided 'chained' test case even though it was marked as not needed"),
+                (false, true) => Case::write_failing_test(
+                    out,
+                    "chained__extra",
+                    "provided 'chained' test case even though it was marked as not needed",
+                ),
                 _ => {}
             }
 
-            if !found_chained_case {
-            }
+            if !found_chained_case {}
         });
 
         out.writeln("}");

--- a/tests/md_cases/link_placement.toml
+++ b/tests/md_cases/link_placement.toml
@@ -11,6 +11,9 @@ Some section text.
 [1]: https://example.com/interesting
 '''
 
+[chained]
+needed = false
+
 
 [expect."standard link placement"]
 cli_args = []

--- a/tests/md_cases/links_references.toml
+++ b/tests/md_cases/links_references.toml
@@ -16,6 +16,9 @@ md = '''
 [shortcut link]: https://example.com/shortcut
 '''
 
+[chained]
+needed = false
+
 
 [expect."default"]
 cli_args = []
@@ -72,3 +75,4 @@ output = '''
 - a [link with a title](https://example.com "my title")
 - a [link with a title that contains double-quotes](https://example.com 'my "alleged" title')
 '''
+

--- a/tests/md_cases/matchers.toml
+++ b/tests/md_cases/matchers.toml
@@ -6,6 +6,8 @@ md = '''
 - lorem ipsum dolor sit amet.
 '''
 
+[chained]
+needed = false
 
 [expect."bareword"]
 cli_args = ['- world '] # note: trailing space is ignored

--- a/tests/md_cases/output_format.toml
+++ b/tests/md_cases/output_format.toml
@@ -5,6 +5,9 @@ Test _one_ [two][1] three.
 [1]: https://example.com/1
 '''
 
+[chained]
+needed = false
+
 
 [expect."default"]
 cli_args = []

--- a/tests/md_cases/select_exit_code.toml
+++ b/tests/md_cases/select_exit_code.toml
@@ -3,6 +3,9 @@ md = '''
 [fizz](https://example.com/buzz)
 '''
 
+[chained]
+needed = false
+
 
 [expect."match and output"]
 cli_args = ["--link-format", "keep", "[]()"]

--- a/tests/md_cases/select_html.toml
+++ b/tests/md_cases/select_html.toml
@@ -62,3 +62,10 @@ output = '''
 <div
 class="block>
 '''
+
+
+[expect."chained"]
+cli_args = ['</> span | </> "<span>"']
+output = '''
+<span>
+'''

--- a/tests/md_cases/select_link.toml
+++ b/tests/md_cases/select_link.toml
@@ -36,3 +36,10 @@ output = '''
 ![image alt text](https://example.com/hylas-and-nymphs.png)'''
 
 
+[expect."chained"]
+cli_args = ['[inline]() | [](example.com)']
+output = '''
+[an inline link][1]
+
+[1]: https://example.com/inline
+'''

--- a/tests/md_cases/select_lists.toml
+++ b/tests/md_cases/select_lists.toml
@@ -78,3 +78,10 @@ cli_args = ['1. [?]']
 output = '''
 1. [ ] ordered tasks are possible, too
 '''
+
+
+[expect."chained"]
+cli_args = ['- a point | - a point']
+output = '''
+- a point
+'''

--- a/tests/md_cases/select_paragraphs.toml
+++ b/tests/md_cases/select_paragraphs.toml
@@ -65,3 +65,10 @@ cli_args = ["P : *"]
 expect_success = false
 output = '''
 '''
+
+
+[expect."chained"]
+cli_args = ['P: hello | P: world']
+output = '''
+Hello, world.
+'''

--- a/tests/md_cases/select_sections.toml
+++ b/tests/md_cases/select_sections.toml
@@ -55,3 +55,12 @@ Hello, world.
 
 My second section.
 '''
+
+
+[expect."chained"]
+cli_args = ['# bravo | # bravo']
+output = '''
+# Bravo
+
+My second section.
+'''

--- a/tests/md_cases/select_tables.toml
+++ b/tests/md_cases/select_tables.toml
@@ -74,8 +74,6 @@ output = '''
 
 
 [expect."chained"]
-# chaining onen all-cells selector into another; the second should be a noop
-# TODO need to add "chained" tests for all! And maybe even require it in the build.rs code
 cli_args = [":-: * :-: * | :-: * :-: * | "]
 output = '''
 | Name | Description |                             |


### PR DESCRIPTION
These are tests of chaining a selector into a selector of the same type, like `# foo | #foo`. This should always apply a second filter to the same elements; it basically ANDs them together.

I added these tests for tables initially, since there are separate Table and TableSlice variants for MdElemRef; this meant that the chaining needed to be specifically supported, and was no longer a given. But, then I figured I may as well formalize that.

Some toml test case files don't need this, so there's also a mechanism to mark the chained tests as unneeded. Otherwise, a test case file without a case named "chained" will fail (the `build.rs` will auto-generate a "chained" test that trivially fails).