### PR TITLE
handle backticks within inline code blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "markdown"
-version = "1.0.0-alpha.17"
+version = "1.0.0-alpha.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21e27d6220ce21f80ce5c4201f23a37c6f1ad037c72c9d1ff215c2919605a5d6"
+checksum = "8bf98a7fcfa423e67aafbaf1bfe7b689ce064434bfed02fa4d9d6db0fc8cc50b"
 dependencies = [
  "unicode-id",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/yshavit/mdq"
 
 [dependencies]
 clap = { version = "4.5.7", features = ["derive"] }
-markdown = "1.0.0-alpha.16"
+markdown = "1.0.0-alpha.19"
 paste = "1.0"
 regex = "1.10.4"
 serde = { version = "1", features = ["derive"] }

--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -141,7 +141,7 @@ impl<'md> MdInlinesWriter<'md> {
                             Cow::Owned("`".repeat(backticks_info.count + 1))
                         };
                         (surround_ch, backticks_info.at_either_end)
-                    },
+                    }
                 };
                 out.write_str(&surround_ch);
                 if surround_space {
@@ -262,10 +262,7 @@ impl From<&String> for BackticksInfo {
         }
         let count = max(current_stretch, overall_max);
         let at_either_end = s.starts_with('`') || s.ends_with('`');
-        Self {
-            count,
-            at_either_end,
-        }
+        Self { count, at_either_end }
     }
 }
 

--- a/src/utils_for_test.rs
+++ b/src/utils_for_test.rs
@@ -7,7 +7,7 @@ pub use test_utils::*;
 mod test_utils {
     use std::fmt::Debug;
 
-    pub fn get_only<T: Debug, C: IntoIterator<Item=T>>(col: C) -> T {
+    pub fn get_only<T: Debug, C: IntoIterator<Item = T>>(col: C) -> T {
         let mut iter = col.into_iter();
         let Some(result) = iter.next() else {
             panic!("expected an element, but was empty");

--- a/src/utils_for_test.rs
+++ b/src/utils_for_test.rs
@@ -1,7 +1,29 @@
+#[cfg(test)]
+pub use test_utils::*;
+
 // We this file's contents from prod by putting them in a submodule guarded by cfg(test), but then "pub use" it to
 // export its contents.
 #[cfg(test)]
 mod test_utils {
+    use std::fmt::Debug;
+
+    pub fn get_only<T: Debug, C: IntoIterator<Item=T>>(col: C) -> T {
+        let mut iter = col.into_iter();
+        let Some(result) = iter.next() else {
+            panic!("expected an element, but was empty");
+        };
+        match iter.next() {
+            None => result,
+            Some(extra) => {
+                let mut all = Vec::new();
+                all.push(result);
+                all.push(extra);
+                all.extend(iter);
+                panic!("expected exactly one element, but found {}: {all:?}", all.len());
+            }
+        }
+    }
+
     /// Turn a pattern match into an `if let ... { else panic! }`.
     #[macro_export]
     macro_rules! unwrap {


### PR DESCRIPTION
An inline code block starts with a string of at least one backtick, but possibly more: `` ` ``, ` `` `, etc. It then continues until that same sting again.

The actual surrounding backticks don't matter, as long as they don't appear in the contents. The following are equivalent, and both produce `a``b`:

```markdown
`a``b`
```a``b```
```

The easiest way to handle this is to count the longest stretch of backticks in the contents, and then use a string of N+1 backticks for the inline code markers. So, that's what this PR does.

I can imagine nicer formatting, like finding the first available empty spot; or maybe just special-casing ` `` `. But for now, I'm keeping things simple.

If the contents start or end with backspace, we add a single space on either side of the contents (between it and the backticks). The CommonMark spec says these should be stripped on parse; they're currently not, because of newly-filed #171.

This PR resolves #157.