### PR TITLE
handle surrounding spaces in inline code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -160,9 +160,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "markdown"
-version = "1.0.0-alpha.19"
+version = "1.0.0-alpha.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8bf98a7fcfa423e67aafbaf1bfe7b689ce064434bfed02fa4d9d6db0fc8cc50b"
+checksum = "911a8325e6fb87b89890cd4529a2ab34c2669c026279e61c26b7140a3d821ccb"
 dependencies = [
  "unicode-id",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ repository = "https://github.com/yshavit/mdq"
 
 [dependencies]
 clap = { version = "4.5.7", features = ["derive"] }
-markdown = "1.0.0-alpha.19"
+markdown = "1.0.0-alpha.20"
 paste = "1.0"
 regex = "1.10.4"
 serde = { version = "1", features = ["derive"] }

--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -412,13 +412,16 @@ mod tests {
         }
 
         fn round_trip_inline_to(orig: &str, expect: &str) {
-            round_trip(&Inline::Text(Text {
-                variant: TextVariant::Code,
-                value: orig.to_string(),
-            }), &Inline::Text(Text {
-                variant: TextVariant::Code,
-                value: expect.to_string(),
-            }));
+            round_trip(
+                &Inline::Text(Text {
+                    variant: TextVariant::Code,
+                    value: orig.to_string(),
+                }),
+                &Inline::Text(Text {
+                    variant: TextVariant::Code,
+                    value: expect.to_string(),
+                }),
+            );
         }
 
         fn round_trip_inline(inline_str: &str) {

--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -377,13 +377,11 @@ mod tests {
         }
 
         #[test]
-        #[ignore] // #171
         fn round_trip_one_backtick_at_start() {
             round_trip_inline("`hello");
         }
 
         #[test]
-        #[ignore] // #171
         fn round_trip_one_backtick_at_end() {
             round_trip_inline("hello `");
         }
@@ -394,38 +392,43 @@ mod tests {
         }
 
         #[test]
-        #[ignore] // #171
         fn round_trip_three_backticks_at_end() {
             round_trip_inline("hello `");
         }
 
         #[test]
-        #[ignore] // #171
         fn round_trip_three_backticks_at_start() {
             round_trip_inline("`hello");
         }
 
         #[test]
         fn round_trip_surrounding_whitespace() {
-            round_trip_inline(" hello ");
+            round_trip_inline_to(" hello ", "hello");
         }
 
         #[test]
         fn round_trip_backtick_and_surrounding_whitespace() {
-            round_trip_inline(" hello`world ");
+            round_trip_inline_to(" hello`world ", "hello`world");
+        }
+
+        fn round_trip_inline_to(orig: &str, expect: &str) {
+            round_trip(&Inline::Text(Text {
+                variant: TextVariant::Code,
+                value: orig.to_string(),
+            }), &Inline::Text(Text {
+                variant: TextVariant::Code,
+                value: expect.to_string(),
+            }));
         }
 
         fn round_trip_inline(inline_str: &str) {
-            round_trip(&Inline::Text(Text {
-                variant: TextVariant::Code,
-                value: inline_str.to_string(),
-            }));
+            round_trip_inline_to(inline_str, inline_str);
         }
     }
 
     /// Not a pure unit test; semi-integ. Checks that writing an inline to markdown and then parsing
     /// that markdown results in the original inline.
-    fn round_trip(orig: &Inline) {
+    fn round_trip(orig: &Inline, expect: &Inline) {
         let mut output = Output::new(String::new());
         let mut writer = MdInlinesWriter::new(MdInlinesWriterOptions {
             link_format: LinkTransform::Keep,
@@ -438,6 +441,6 @@ mod tests {
 
         unwrap!(&md_tree[0], MdElem::Paragraph(p));
         let parsed = get_only(&p.body);
-        assert_eq!(parsed, orig);
+        assert_eq!(parsed, expect);
     }
 }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -985,7 +985,7 @@ mod tests {
 
             unwrap!(&root.children[0], Node::Paragraph(p));
             check!(&p.children[0], Node::InlineMath(_), lookups => MdElem::Inline(inline) = {
-                assert_eq!(inline, Inline::Text (Text{ variant: TextVariant::Math, value: r#" 0 \ne 1 "#.to_string() }));
+                assert_eq!(inline, Inline::Text (Text{ variant: TextVariant::Math, value: r#"0 \ne 1"#.to_string() }));
             });
         }
 


### PR DESCRIPTION
The fix is just to accept the upstream fix, via a dependency update. Also update / fix tests as necessary.

This resolves #171.