### PR TITLE
rm a couple generic bounds on structs

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -17,7 +17,7 @@ impl SimpleWrite for String {
     }
 }
 
-pub struct Stream<W: std::io::Write>(pub W);
+pub struct Stream<W>(pub W);
 
 impl<W: std::io::Write> SimpleWrite for Stream<W> {
     fn write_str(&mut self, text: &str) -> std::io::Result<()> {

--- a/src/str_utils.rs
+++ b/src/str_utils.rs
@@ -72,7 +72,7 @@ impl<A: Borrow<AlignKind>> ToAlignment for Option<A> {
     }
 }
 
-pub struct CountingWriter<'a, W: SimpleWrite> {
+pub struct CountingWriter<'a, W> {
     underlying: &'a mut W,
     count: usize,
 }


### PR DESCRIPTION
They're not needed, and I just learned it's more idiomatic to leave them off.