### PR TITLE
inline a macro invocation

### DIFF
--- a/src/tree.rs
+++ b/src/tree.rs
@@ -491,7 +491,7 @@ impl MdElem {
         let mut headers: Vec<HContainer> = Vec::with_capacity(result.capacity());
         for child_mdq in iter {
             let child_mdq = child_mdq?;
-            if let m_node!(MdElem::Section {
+            if let MdElem::Section(Section {
                 depth,
                 title,
                 body: children,


### PR DESCRIPTION
RustRover incorrectly identifies the `else` of this `if` as unreachable when it's a macro. Inlining it fixes that.