### PR TITLE
handle brackets in link text and img alt

### DIFF
--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -429,6 +429,89 @@ mod tests {
         }
     }
 
+    mod link_description {
+        use super::*;
+
+        #[test]
+        fn simple() {
+            check_link_description("hello, world", "hello, world");
+        }
+
+        #[test]
+        fn matched_brackets() {
+            check_link_description("link [foo [bar]]", "link \\[foo \\[bar\\]\\]");
+        }
+
+        #[test]
+        fn unmatched_brackets() {
+            check_link_description("link [foo bar", "link \\[foo bar");
+        }
+
+        fn check_link_description(input_description: &str, expected: &str) {
+            let mut output = Output::new(String::new());
+            let mut writer = MdInlinesWriter::new(MdInlinesWriterOptions {
+                link_format: LinkTransform::Keep,
+            });
+            let link = Inline::Link(Link {
+                text: vec![Inline::Text(Text {
+                    variant: TextVariant::Plain,
+                    value: input_description.to_string(),
+                })],
+                link_definition: LinkDefinition {
+                    url: "https://www.example.com".to_string(),
+                    title: None,
+                    reference: LinkReference::Inline,
+                },
+            });
+            writer.write_inline_element(&mut output, &link);
+
+            assert_eq!(
+                output.take_underlying().unwrap(),
+                format!("[{expected}](https://www.example.com)")
+            );
+        }
+    }
+
+    mod img_alt {
+        use super::*;
+
+        #[test]
+        fn simple() {
+            check_img_alt("hello, world", "hello, world");
+        }
+
+        #[test]
+        fn matched_brackets() {
+            check_img_alt("link [foo [bar]]", "link \\[foo \\[bar\\]\\]");
+        }
+
+        #[test]
+        fn unmatched_brackets() {
+            check_img_alt("link [foo bar", "link \\[foo bar");
+        }
+
+        fn check_img_alt(input_description: &str, expected: &str) {
+            let mut output = Output::new(String::new());
+            let mut writer = MdInlinesWriter::new(MdInlinesWriterOptions {
+                link_format: LinkTransform::Keep,
+            });
+            let link = Inline::Image(Image {
+                alt: input_description.to_string(),
+                link: LinkDefinition {
+                    url: "https://www.example.com".to_string(),
+                    title: None,
+                    reference: LinkReference::Inline,
+                },
+            });
+            writer.write_inline_element(&mut output, &link);
+
+            assert_eq!(
+                output.take_underlying().unwrap(),
+                format!("![{expected}](https://www.example.com)")
+            );
+        }
+    }
+
     /// Not a pure unit test; semi-integ. Checks that writing an inline to markdown and then parsing
     /// that markdown results in the original inline.
     fn round_trip(orig: &Inline, expect: &Inline) {

--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -193,6 +193,11 @@ impl<'md> MdInlinesWriter<'md> {
             LinkLabel::Inline(text) => {
                 // Write to a string, and then dump that to out. This lets us escaping, and will
                 // eventually let us handle matched square brackets.
+                // Note that it's not really worth it to do the transformation "on the fly":
+                // the SimpleWrite trait only writes strings anyway (not chars), so even if we
+                // had an intercepting transform, it would still have to work on allocated strings.
+                // So we may as well just do it once.
+                // This could be output a bit nicer: see #183.
                 let mut sub_out = Output::new(String::with_capacity(64));
                 self.write_line(&mut sub_out, *text);
                 let as_string = sub_out.take_underlying().unwrap();


### PR DESCRIPTION
Fixes #88

We could output things a bit nicer, but I'm deferring that to #183. The approach in this change is functionally correct.