### PR TITLE
test util cleanups

### DIFF
--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -57,12 +57,6 @@ pub enum ReferencePlacement {
     Doc,
 }
 
-impl Default for ReferencePlacement {
-    fn default() -> Self {
-        Self::Section
-    }
-}
-
 pub fn write_md<'md, I, W>(options: &'md MdOptions, out: &mut Output<W>, nodes: I)
 where
     I: Iterator<Item = MdElemRef<'md>>,
@@ -469,7 +463,6 @@ pub mod tests {
     use indoc::indoc;
 
     use crate::fmt_md::MdOptions;
-    use crate::fmt_md_inlines::MdInlinesWriterOptions;
     use crate::link_transform::LinkTransform;
     use crate::m_node;
     use crate::md_elem;
@@ -1569,7 +1562,6 @@ pub mod tests {
 
     mod link {
         use super::*;
-        use crate::fmt_md_inlines::MdInlinesWriterOptions;
 
         #[test]
         fn single_link() {
@@ -1657,13 +1649,7 @@ pub mod tests {
         #[test]
         fn reference_transform_smoke_test() {
             check_render_refs_with(
-                &MdOptions {
-                    link_reference_placement: ReferencePlacement::Section,
-                    footnote_reference_placement: ReferencePlacement::Section,
-                    inline_options: MdInlinesWriterOptions {
-                        link_format: LinkTransform::Reference,
-                    },
-                },
+                &MdOptions::new_with(|mdo| mdo.inline_options.link_format = LinkTransform::Reference),
                 vec![MdElemRef::Link(&Link {
                     text: vec![mdq_inline!("link text")],
                     link_definition: LinkDefinition {
@@ -1682,7 +1668,6 @@ pub mod tests {
 
     mod image {
         use super::*;
-        use crate::fmt_md_inlines::MdInlinesWriterOptions;
 
         #[test]
         fn single_image() {
@@ -1740,13 +1725,7 @@ pub mod tests {
         #[test]
         fn reference_transform_smoke_test() {
             check_render_refs_with(
-                &MdOptions {
-                    link_reference_placement: ReferencePlacement::Section,
-                    footnote_reference_placement: ReferencePlacement::Section,
-                    inline_options: MdInlinesWriterOptions {
-                        link_format: LinkTransform::Reference,
-                    },
-                },
+                &MdOptions::new_with(|mdo| mdo.inline_options.link_format = LinkTransform::Reference),
                 vec![MdElemRef::Image(&Image {
                     alt: "alt text".to_string(),
                     link: LinkDefinition {
@@ -1808,8 +1787,6 @@ pub mod tests {
 
     mod annotation_and_footnote_layouts {
         use super::*;
-        use crate::fmt_md_inlines::MdInlinesWriterOptions;
-        use crate::link_transform::LinkTransform;
 
         #[test]
         fn link_and_footnote() {
@@ -1844,13 +1821,10 @@ pub mod tests {
         #[test]
         fn both_in_sections() {
             check_render_with(
-                &MdOptions {
-                    link_reference_placement: ReferencePlacement::Section,
-                    footnote_reference_placement: ReferencePlacement::Section,
-                    inline_options: MdInlinesWriterOptions {
-                        link_format: LinkTransform::Keep,
-                    },
-                },
+                &MdOptions::new_with(|mdo| {
+                    mdo.link_reference_placement = ReferencePlacement::Section;
+                    mdo.footnote_reference_placement = ReferencePlacement::Section;
+                }),
                 link_and_footnote_markdown(),
                 indoc! {r#"
                     # First section
@@ -1871,13 +1845,10 @@ pub mod tests {
         #[test]
         fn only_link_in_section() {
             check_render_with(
-                &MdOptions {
-                    link_reference_placement: ReferencePlacement::Section,
-                    footnote_reference_placement: ReferencePlacement::Doc,
-                    inline_options: MdInlinesWriterOptions {
-                        link_format: LinkTransform::Keep,
-                    },
-                },
+                &MdOptions::new_with(|mdo| {
+                    mdo.link_reference_placement = ReferencePlacement::Section;
+                    mdo.footnote_reference_placement = ReferencePlacement::Doc;
+                }),
                 link_and_footnote_markdown(),
                 indoc! {r#"
                     # First section
@@ -1901,13 +1872,10 @@ pub mod tests {
         #[test]
         fn no_sections_but_writing_to_sections() {
             check_render_with(
-                &MdOptions {
-                    link_reference_placement: ReferencePlacement::Section,
-                    footnote_reference_placement: ReferencePlacement::Section,
-                    inline_options: MdInlinesWriterOptions {
-                        link_format: LinkTransform::Keep,
-                    },
-                },
+                &MdOptions::new_with(|mdo| {
+                    mdo.link_reference_placement = ReferencePlacement::Section;
+                    mdo.footnote_reference_placement = ReferencePlacement::Section;
+                }),
                 md_elems![Paragraph {
                     body: vec![m_node!(Inline::Link {
                         text: vec![mdq_inline!("link description")],
@@ -1928,13 +1896,10 @@ pub mod tests {
         #[test]
         fn only_footnote_in_section() {
             check_render_with(
-                &MdOptions {
-                    link_reference_placement: ReferencePlacement::Doc,
-                    footnote_reference_placement: ReferencePlacement::Section,
-                    inline_options: MdInlinesWriterOptions {
-                        link_format: LinkTransform::Keep,
-                    },
-                },
+                &MdOptions::new_with(|mdo| {
+                    mdo.link_reference_placement = ReferencePlacement::Doc;
+                    mdo.footnote_reference_placement = ReferencePlacement::Section;
+                }),
                 link_and_footnote_markdown(),
                 indoc! {r#"
                     # First section
@@ -1958,13 +1923,10 @@ pub mod tests {
         #[test]
         fn both_bottom_of_doc() {
             check_render_with(
-                &MdOptions {
-                    link_reference_placement: ReferencePlacement::Doc,
-                    footnote_reference_placement: ReferencePlacement::Doc,
-                    inline_options: MdInlinesWriterOptions {
-                        link_format: LinkTransform::Keep,
-                    },
-                },
+                &MdOptions::new_with(|mdo| {
+                    mdo.link_reference_placement = ReferencePlacement::Doc;
+                    mdo.footnote_reference_placement = ReferencePlacement::Doc;
+                }),
                 link_and_footnote_markdown(),
                 indoc! {r#"
                     # First section
@@ -1987,13 +1949,10 @@ pub mod tests {
         #[test]
         fn ordering() {
             check_render_with(
-                &MdOptions {
-                    link_reference_placement: ReferencePlacement::Doc,
-                    footnote_reference_placement: ReferencePlacement::Doc,
-                    inline_options: MdInlinesWriterOptions {
-                        link_format: LinkTransform::Keep,
-                    },
-                },
+                &MdOptions::new_with(|mdo| {
+                    mdo.link_reference_placement = ReferencePlacement::Doc;
+                    mdo.footnote_reference_placement = ReferencePlacement::Doc;
+                }),
                 // Define them in the opposite order that we'd expect them
                 md_elems![Paragraph {
                     body: vec![
@@ -2114,7 +2073,7 @@ pub mod tests {
     }
 
     fn check_render(nodes: Vec<MdElem>, expect: &str) {
-        check_render_with(&default_opts(), nodes, expect);
+        check_render_with(&MdOptions::default_for_tests(), nodes, expect);
     }
 
     fn check_render_with(options: &MdOptions, nodes: Vec<MdElem>, expect: &str) {
@@ -2126,7 +2085,7 @@ pub mod tests {
     }
 
     fn check_render_refs(nodes: Vec<MdElemRef>, expect: &str) {
-        check_render_refs_with(&default_opts(), nodes, expect)
+        check_render_refs_with(&MdOptions::default_for_tests(), nodes, expect)
     }
 
     fn check_render_refs_with(options: &MdOptions, nodes: Vec<MdElemRef>, expect: &str) {
@@ -2136,15 +2095,5 @@ pub mod tests {
         write_md(options, &mut out, nodes.into_iter());
         let actual = out.take_underlying().unwrap();
         assert_eq!(&actual, expect);
-    }
-
-    fn default_opts() -> MdOptions {
-        MdOptions {
-            link_reference_placement: Default::default(),
-            footnote_reference_placement: Default::default(),
-            inline_options: MdInlinesWriterOptions {
-                link_format: LinkTransform::Keep,
-            },
-        }
     }
 }

--- a/src/utils_for_test.rs
+++ b/src/utils_for_test.rs
@@ -5,7 +5,43 @@ pub use test_utils::*;
 // export its contents.
 #[cfg(test)]
 mod test_utils {
+    use crate::fmt_md::{MdOptions, ReferencePlacement};
+    use crate::fmt_md_inlines::MdInlinesWriterOptions;
+    use crate::link_transform::LinkTransform;
     use std::fmt::Debug;
+
+    impl LinkTransform {
+        pub fn default_for_tests() -> Self {
+            Self::Keep
+        }
+    }
+
+    impl ReferencePlacement {
+        pub fn default_for_tests() -> Self {
+            Self::Section
+        }
+    }
+
+    impl MdOptions {
+        pub fn default_for_tests() -> Self {
+            Self {
+                link_reference_placement: ReferencePlacement::default_for_tests(),
+                footnote_reference_placement: ReferencePlacement::default_for_tests(),
+                inline_options: MdInlinesWriterOptions {
+                    link_format: LinkTransform::default_for_tests(),
+                },
+            }
+        }
+
+        pub fn new_with<F>(init: F) -> Self
+        where
+            F: FnOnce(&mut MdOptions),
+        {
+            let mut mdo = Self::default_for_tests();
+            init(&mut mdo);
+            mdo
+        }
+    }
 
     pub fn get_only<T: Debug, C: IntoIterator<Item = T>>(col: C) -> T {
         let mut iter = col.into_iter();

--- a/src/utils_for_test.rs
+++ b/src/utils_for_test.rs
@@ -50,14 +50,26 @@ mod test_utils {
     /// Creates a static object named `$name` that looks for all the variants of enum `E`.
     ///
     /// ```
-    /// variants_checker(CHECKER_NAME = MyEnum { Variant1, Variant2(_), ... })
+    /// use mdq::variants_checker;
+    ///
+    /// enum MyEnum {
+    ///   Variant1,
+    ///   Variant2(usize)
+    /// }
+    /// variants_checker!(CHECKER_NAME = MyEnum { Variant1, Variant2(_) });
     /// ```
     ///
     /// You can also mark some variants as ignored; these will be added to the pattern match, but not be required to
     /// be seen:
     ///
     /// ```
-    /// variants_checker(CHECKER_NAME = MyEnum { Variant1, ... } ignore { Variant2, ... } )
+    /// use mdq::variants_checker;
+    ///
+    /// enum MyEnum {
+    ///   Variant1,
+    ///   Variant2(usize)
+    /// }
+    /// variants_checker!(CHECKER_NAME = MyEnum { Variant1 } ignore { Variant2(_) });
     /// ```
     ///
     /// If you see a compilation failure here, it means the call site is missing variants (or has an unknown


### PR DESCRIPTION
- fix the rustdoc comments
- create a builder-like constructor fn for `MdOptions`, and move some `Default` impls to `cfg(test)` (and make them not actually be `Default`)