### PR TITLE
improve json integ tests

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -130,6 +130,7 @@ struct TestGiven {
 struct TestExpect {
     cli_args: Vec<String>,
     output: String,
+    output_json: Option<bool>,
     expect_success: Option<bool>,
     ignore: Option<String>,
 }
@@ -147,6 +148,7 @@ impl TestSpecFile {
                 case_name,
                 cli_args: test_expect.cli_args,
                 expect_output: test_expect.output,
+                output_json: test_expect.output_json.unwrap_or(false),
                 expect_success: test_expect.expect_success.unwrap_or(true),
                 ignored: test_expect.ignore.is_some(),
             })
@@ -161,6 +163,7 @@ struct Case {
     ignored: bool,
     cli_args: Vec<String>,
     expect_output: String,
+    output_json: bool,
     expect_success: bool,
 }
 
@@ -190,6 +193,7 @@ impl Case {
             out.write("Case {");
             out.with_indent(|out| {
                 out.writeln(&format!("cli_args: {:?},", &self.cli_args));
+                out.writeln(&format!("expect_output_json: {},", self.output_json));
                 if self.expect_output.is_empty() {
                     out.write("expect_output: \"\",");
                 } else {

--- a/build.rs
+++ b/build.rs
@@ -175,7 +175,10 @@ impl Case {
     }
 
     fn write_test_fn_to(&self, out: &mut Writer) {
-        let fn_name = self.case_name.replace(|ch: char| !ch.is_alphanumeric(), "_");
+        let fn_name = self
+            .case_name
+            .replace(|ch: char| !(ch.is_alphanumeric() || ch.is_whitespace()), "")
+            .replace(|ch: char| ch.is_whitespace(), "_");
         if self.ignored {
             // separate out ign-ore to two lines, so that it doesn't trigger the CI check for ignored tests
             out.write("#[ign");

--- a/tests/integ_test.rs
+++ b/tests/integ_test.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 struct Case<const N: usize> {
     cli_args: [&'static str; N],
     expect_output: &'static str,
+    expect_output_json: bool,
     md: &'static str,
     expect_success: bool,
 }
@@ -13,7 +14,14 @@ impl<const N: usize> Case<N> {
         let all_cli_args = ["cmd"].iter().chain(&self.cli_args);
         let cli = mdq::cli::Cli::try_parse_from(all_cli_args).unwrap();
         let (actual_success, actual_out) = mdq::run_in_memory(&cli, self.md);
-        assert_eq!(actual_out, self.expect_output);
+        if self.expect_output_json {
+            assert_eq!(
+                serde_json::from_str::<serde_json::Value>(&actual_out).unwrap(),
+                serde_json::from_str::<serde_json::Value>(self.expect_output).unwrap()
+            );
+        } else {
+            assert_eq!(actual_out, self.expect_output);
+        }
         assert_eq!(actual_success, self.expect_success);
     }
 }

--- a/tests/md_cases/output_format.toml
+++ b/tests/md_cases/output_format.toml
@@ -38,5 +38,22 @@ Test _one_ [two][1] three.
 
 [expect."json"]
 cli_args = ['--output', 'json']
+output_json = true
 output = '''
-{"items":[{"document":[{"paragraph":"Test _one_ [two][1] three."}]}],"links":{"1":{"url":"https://example.com/1"}}}'''
+{
+    "items": [
+        {
+            "document": [
+                {
+                    "paragraph": "Test _one_ [two][1] three."
+                }
+            ]
+        }
+    ],
+    "links": {
+        "1": {
+            "url": "https://example.com/1"
+        }
+    }
+}
+'''


### PR DESCRIPTION
JSON is hard to read when it's all one line, so this makes it easier to see what's actually happening.

Also drop non-alphanumeric, non-whitespace chars from the integ test names. Otherwise, they become double underlines (`foo: bar` -> `foo__bar`), which triggers style warnings.