### PR TITLE
separate footnote bodies into a doc-scoped context

### DIFF
--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -667,7 +667,6 @@ pub mod tests {
     }
 
     mod block_quote {
-
         use super::*;
 
         #[test]
@@ -1792,10 +1791,7 @@ pub mod tests {
         fn single_line() {
             check_render(
                 vec![
-                    MdElem::Inline(Inline::Footnote(Footnote {
-                        label: "a".to_string(),
-                        text: md_elems!["Hello, world."],
-                    })),
+                    MdElem::Inline(Inline::Footnote("a".into())),
                     m_node!(MdElem::ThematicBreak),
                 ],
                 indoc! {r#"
@@ -1811,10 +1807,7 @@ pub mod tests {
         fn two_lines() {
             check_render(
                 vec![
-                    MdElem::Inline(Inline::Footnote(Footnote {
-                        label: "a".to_string(),
-                        text: md_elems!["Hello,\nworld."],
-                    })),
+                    MdElem::Inline(Inline::Footnote("a".into())),
                     m_node!(MdElem::ThematicBreak),
                 ],
                 indoc! {r#"
@@ -1854,16 +1847,15 @@ pub mod tests {
 
         fn footnote_a_in_paragraph() -> Paragraph {
             Paragraph {
-                body: vec![Inline::Footnote(Footnote {
-                    label: "a".to_string(),
-                    text: md_elems!("the footnote text"),
-                })],
+                body: vec![Inline::Footnote("a".into())],
             }
         }
     }
 
     mod annotation_and_footnote_layouts {
         use super::*;
+        use crate::md_elems;
+        use indoc::indoc;
 
         #[test]
         fn link_and_footnote() {
@@ -1880,10 +1872,7 @@ pub mod tests {
                             }
                         }),
                         mdq_inline!("! This is interesting"),
-                        Inline::Footnote(Footnote {
-                            label: "a".to_string(),
-                            text: md_elems!["this is my note"],
-                        }),
+                        Inline::Footnote("a".into()),
                         mdq_inline!("."),
                     ],
                 }],
@@ -2033,14 +2022,8 @@ pub mod tests {
                 // Define them in the opposite order that we'd expect them
                 md_elems![Paragraph {
                     body: vec![
-                        Inline::Footnote(Footnote {
-                            label: "d".to_string(),
-                            text: md_elems!["footnote 1"]
-                        }),
-                        Inline::Footnote(Footnote {
-                            label: "c".to_string(),
-                            text: md_elems!["footnote 2"]
-                        }),
+                        Inline::Footnote("d".into()),
+                        Inline::Footnote("c".into()),
                         m_node!(Inline::Link {
                             text: vec![mdq_inline!("b-text")],
                             link_definition: LinkDefinition {
@@ -2085,10 +2068,7 @@ pub mod tests {
                                 },
                             }),
                             mdq_inline!(" and then a thought"),
-                            Inline::Footnote(Footnote {
-                                label: "a".to_string(),
-                                text: md_elems!["the footnote"],
-                            }),
+                            Inline::Footnote("a".into()),
                             mdq_inline!("."),
                         ],
                     }],
@@ -2104,6 +2084,8 @@ pub mod tests {
 
     mod html {
         use super::*;
+        use crate::md_elems;
+        use indoc::indoc;
 
         #[test]
         fn inline() {

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -2110,8 +2110,6 @@ pub mod tests {
 
     mod html {
         use super::*;
-        use crate::md_elems;
-        use indoc::indoc;
 
         #[test]
         fn inline() {

--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -5,7 +5,6 @@ use crate::tree::{
     FootnoteId, Formatting, FormattingVariant, Image, Inline, Link, LinkDefinition, LinkReference, MdContext, MdElem,
     Text, TextVariant,
 };
-use crate::tree_ref::md_elems_placeholder;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::cmp::max;
@@ -112,7 +111,8 @@ impl<'md> MdInlinesWriter<'md> {
 
         for fid in self.pending_references.footnotes.drain() {
             let transformed_k = to_stringer.transform(fid);
-            let footnote_value = md_elems_placeholder(self.ctx, &transformed_k.clone().into());
+            let ctx = self.ctx;
+            let footnote_value = ctx.get_footnote(&&fid);
             result.push((transformed_k, footnote_value))
         }
         result
@@ -182,7 +182,8 @@ impl<'md> MdInlinesWriter<'md> {
     fn add_footnote(&mut self, label: &'md FootnoteId) {
         if self.seen_footnotes.insert(label) {
             self.pending_references.footnotes.insert(label);
-            let text = md_elems_placeholder(self.ctx, label);
+            let ctx = self.ctx;
+            let text = ctx.get_footnote(&label);
             self.find_references_in_footnote_elems(text);
         }
     }

--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -2,13 +2,14 @@ use crate::footnote_transform::FootnoteTransformer;
 use crate::link_transform::{LinkLabel, LinkTransform, LinkTransformation, LinkTransformer};
 use crate::output::{Output, SimpleWrite};
 use crate::tree::{
-    Formatting, FormattingVariant, Image, Inline, Link, LinkDefinition, LinkReference, MdElem, Text, TextVariant,
+    FootnoteId, Formatting, FormattingVariant, Image, Inline, Link, LinkDefinition, LinkReference, MdElem, Text,
+    TextVariant,
 };
+use crate::tree_ref::md_elems_placeholder;
 use serde::Serialize;
 use std::borrow::Cow;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
-use std::ops::Deref;
 
 #[derive(Debug, Copy, Clone)]
 pub struct MdInlinesWriterOptions {
@@ -26,14 +27,14 @@ pub struct MdInlinesWriter<'md> {
 
 struct PendingReferences<'md> {
     pub links: HashMap<LinkLabel<'md>, UrlAndTitle<'md>>,
-    pub footnotes: HashMap<&'md String, &'md Vec<MdElem>>,
+    pub footnotes: HashSet<&'md FootnoteId>,
 }
 
 impl<'md> PendingReferences<'md> {
     fn with_capacity(capacity: usize) -> Self {
         Self {
             links: HashMap::with_capacity(capacity),
-            footnotes: HashMap::with_capacity(capacity),
+            footnotes: HashSet::with_capacity(capacity),
         }
     }
 }
@@ -107,9 +108,10 @@ impl<'md> MdInlinesWriter<'md> {
         let mut result = Vec::with_capacity(self.pending_references.footnotes.len());
         let mut to_stringer = self.footnote_transformer.new_to_stringer();
 
-        for (k, v) in self.pending_references.footnotes.drain() {
-            let transformed_k = to_stringer.transform(k);
-            result.push((transformed_k, v))
+        for fid in self.pending_references.footnotes.drain() {
+            let transformed_k = to_stringer.transform(fid);
+            let footnote_value = md_elems_placeholder(&transformed_k.clone().into());
+            result.push((transformed_k, footnote_value))
         }
         result
     }
@@ -170,14 +172,15 @@ impl<'md> MdInlinesWriter<'md> {
                 out.write_str("[^");
                 self.footnote_transformer.write(out, &footnote_id);
                 out.write_char(']');
-                self.add_footnote(footnote_id.deref(), text);
+                self.add_footnote(footnote_id);
             }
         }
     }
 
-    fn add_footnote(&mut self, label: &'md String, text: &'md Vec<MdElem>) {
+    fn add_footnote(&mut self, label: &'md FootnoteId) {
         if self.seen_footnotes.insert(label) {
-            self.pending_references.footnotes.insert(label, text);
+            self.pending_references.footnotes.insert(label);
+            let text = md_elems_placeholder(label); // TODO
             self.find_references_in_footnote_elems(text);
         }
     }
@@ -227,7 +230,7 @@ impl<'md> MdInlinesWriter<'md> {
         for inline in text.into_iter() {
             match inline {
                 Inline::Footnote(footnote) => {
-                    self.add_footnote(&footnote.label, &footnote.text);
+                    self.add_footnote(footnote);
                 }
                 Inline::Formatting(item) => {
                     self.find_references_in_footnote_inlines(&item.children);
@@ -430,7 +433,7 @@ impl TitleQuote {
 mod tests {
     use super::*;
     use crate::output::Output;
-    use crate::tree::ReadOptions;
+    use crate::tree::{MdDoc, ReadOptions};
     use crate::unwrap;
     use crate::utils_for_test::get_only;
 
@@ -639,7 +642,7 @@ mod tests {
         let md_str = output.take_underlying().unwrap();
 
         let ast = markdown::to_mdast(&md_str, &markdown::ParseOptions::gfm()).unwrap();
-        let md_tree = MdElem::read(ast, &ReadOptions::default()).unwrap();
+        let md_tree = MdDoc::read(ast, &ReadOptions::default()).unwrap().roots;
 
         unwrap!(&md_tree[0], MdElem::Paragraph(p));
         let parsed = get_only(&p.body);

--- a/src/fmt_md_inlines.rs
+++ b/src/fmt_md_inlines.rs
@@ -2,13 +2,13 @@ use crate::footnote_transform::FootnoteTransformer;
 use crate::link_transform::{LinkLabel, LinkTransform, LinkTransformation, LinkTransformer};
 use crate::output::{Output, SimpleWrite};
 use crate::tree::{
-    Footnote, Formatting, FormattingVariant, Image, Inline, Link, LinkDefinition, LinkReference, MdElem, Text,
-    TextVariant,
+    Formatting, FormattingVariant, Image, Inline, Link, LinkDefinition, LinkReference, MdElem, Text, TextVariant,
 };
 use serde::Serialize;
 use std::borrow::Cow;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
+use std::ops::Deref;
 
 #[derive(Debug, Copy, Clone)]
 pub struct MdInlinesWriterOptions {
@@ -166,11 +166,11 @@ impl<'md> MdInlinesWriter<'md> {
             }
             Inline::Link(link) => self.write_linklike(out, link),
             Inline::Image(image) => self.write_linklike(out, image),
-            Inline::Footnote(Footnote { label, text }) => {
+            Inline::Footnote(footnote_id) => {
                 out.write_str("[^");
-                self.footnote_transformer.write(out, label);
+                self.footnote_transformer.write(out, &footnote_id);
                 out.write_char(']');
-                self.add_footnote(label, text);
+                self.add_footnote(footnote_id.deref(), text);
             }
         }
     }

--- a/src/fmt_str.rs
+++ b/src/fmt_str.rs
@@ -21,7 +21,7 @@ fn build_inline(out: &mut String, elem: &Inline) {
         Inline::Image(Image { alt, .. }) => out.push_str(alt),
         Inline::Footnote(footnote) => {
             out.push_str("[^");
-            out.push_str(&footnote.label);
+            out.push_str(&footnote);
             out.push(']');
         }
     }
@@ -32,7 +32,7 @@ mod tests {
     use super::*;
     use indoc::indoc;
 
-    use crate::tree::{FormattingVariant, Inline, MdElem, ReadOptions, TextVariant};
+    use crate::tree::{FormattingVariant, Inline, MdDoc, MdElem, ReadOptions, TextVariant};
     use crate::unwrap;
     use markdown::ParseOptions;
 
@@ -67,7 +67,7 @@ mod tests {
     #[test]
     fn inline_html() {
         let node = markdown::to_mdast("Hello <foo> world", &ParseOptions::gfm()).unwrap();
-        let md_elems = MdElem::read(node, &ReadOptions::default()).unwrap();
+        let md_elems = MdDoc::read(node, &ReadOptions::default()).unwrap().roots;
         unwrap!(&md_elems[0], MdElem::Paragraph(contents));
         unwrap!(&contents.body[1], inline @ Inline::Text(_));
         VARIANTS_CHECKER.see(inline);
@@ -118,7 +118,7 @@ mod tests {
         let mut options = ParseOptions::gfm();
         options.constructs.math_text = true;
         let node = markdown::to_mdast(md, &options).unwrap();
-        let md_elems = MdElem::read(node, &ReadOptions::default()).unwrap();
+        let md_elems = MdDoc::read(node, &ReadOptions::default()).unwrap().roots;
         unwrap!(&md_elems[0], MdElem::Paragraph(p));
         p.body.iter().for_each(|inline| VARIANTS_CHECKER.see(inline));
         let actual = inlines_to_plain_string(&p.body);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use crate::fmt_md::MdOptions;
 use crate::fmt_md_inlines::MdInlinesWriterOptions;
 use crate::output::Stream;
 use crate::select::ParseError;
-use crate::tree::{MdElem, ReadOptions};
+use crate::tree::{MdDoc, MdElem, ReadOptions};
 use crate::tree_ref::MdElemRef;
 use crate::tree_ref_serde::SerdeDoc;
 use select::MdqRefSelector;
@@ -55,8 +55,8 @@ where
         validate_no_conflicting_links: false,
         allow_unknown_markdown: cli.allow_unknown_markdown,
     };
-    let mdqs = match MdElem::read(ast, &read_options) {
-        Ok(mdqs) => mdqs,
+    let mdqs = match MdDoc::read(ast, &read_options) {
+        Ok(mdqs) => mdqs.roots,
         Err(err) => {
             eprintln!("error: {}", err);
             return false;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ use crate::fmt_md::MdOptions;
 use crate::fmt_md_inlines::MdInlinesWriterOptions;
 use crate::output::Stream;
 use crate::select::ParseError;
-use crate::tree::{MdDoc, MdElem, ReadOptions};
+use crate::tree::{MdDoc, ReadOptions};
 use crate::tree_ref::MdElemRef;
 use crate::tree_ref_serde::SerdeDoc;
 use select::MdqRefSelector;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,7 +74,7 @@ where
 
     let mut pipeline_nodes = vec![MdElemRef::Doc(&roots)];
     for selector in selectors {
-        let new_pipeline = selector.find_nodes(pipeline_nodes);
+        let new_pipeline = selector.find_nodes(&ctx, pipeline_nodes);
         pipeline_nodes = new_pipeline;
     }
 

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -11,7 +11,7 @@ use crate::select::sel_paragraph::ParagraphSelector;
 use crate::select::sel_section::SectionSelector;
 use crate::select::sel_table::TableSliceSelector;
 use crate::tree::{Formatting, Inline, Link, Text, TextVariant};
-use crate::tree_ref::{HtmlRef, ListItemRef, MdElemRef};
+use crate::tree_ref::{md_elems_placeholder, HtmlRef, ListItemRef, MdElemRef};
 use std::fmt::{Display, Formatter};
 
 pub type ParseResult<T> = Result<T, ParseErrorReason>;
@@ -262,7 +262,7 @@ impl MdqRefSelector {
                 Inline::Formatting(Formatting { children, .. }) => {
                     children.iter().map(|child| MdElemRef::Inline(child)).collect()
                 }
-                Inline::Footnote(footnote) => vec![MdElemRef::Doc(&footnote.text)],
+                Inline::Footnote(footnote) => vec![MdElemRef::Doc(md_elems_placeholder(footnote))],
                 Inline::Link(link) => vec![MdElemRef::Link(link)],
                 Inline::Image(image) => vec![MdElemRef::Image(image)],
                 Inline::Text(Text { variant, value }) if variant == &TextVariant::Html => {

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -11,7 +11,7 @@ use crate::select::sel_paragraph::ParagraphSelector;
 use crate::select::sel_section::SectionSelector;
 use crate::select::sel_table::TableSliceSelector;
 use crate::tree::{Formatting, Inline, Link, Text, TextVariant};
-use crate::tree_ref::{md_elems_placeholder, HtmlRef, ListItemRef, MdElemRef};
+use crate::tree_ref::{md_elems_placeholder_BAD, HtmlRef, ListItemRef, MdElemRef};
 use std::fmt::{Display, Formatter};
 
 pub type ParseResult<T> = Result<T, ParseErrorReason>;
@@ -262,7 +262,7 @@ impl MdqRefSelector {
                 Inline::Formatting(Formatting { children, .. }) => {
                     children.iter().map(|child| MdElemRef::Inline(child)).collect()
                 }
-                Inline::Footnote(footnote) => vec![MdElemRef::Doc(md_elems_placeholder(footnote))],
+                Inline::Footnote(footnote) => vec![MdElemRef::Doc(md_elems_placeholder_BAD(footnote))],
                 Inline::Link(link) => vec![MdElemRef::Link(link)],
                 Inline::Image(image) => vec![MdElemRef::Image(image)],
                 Inline::Text(Text { variant, value }) if variant == &TextVariant::Html => {

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -11,7 +11,7 @@ use crate::select::sel_paragraph::ParagraphSelector;
 use crate::select::sel_section::SectionSelector;
 use crate::select::sel_table::TableSliceSelector;
 use crate::tree::{Formatting, Inline, Link, MdContext, Text, TextVariant};
-use crate::tree_ref::{md_elems_placeholder, HtmlRef, ListItemRef, MdElemRef};
+use crate::tree_ref::{HtmlRef, ListItemRef, MdElemRef};
 use std::fmt::{Display, Formatter};
 
 pub type ParseResult<T> = Result<T, ParseErrorReason>;
@@ -262,7 +262,7 @@ impl MdqRefSelector {
                 Inline::Formatting(Formatting { children, .. }) => {
                     children.iter().map(|child| MdElemRef::Inline(child)).collect()
                 }
-                Inline::Footnote(footnote) => vec![MdElemRef::Doc(md_elems_placeholder(ctx, footnote))],
+                Inline::Footnote(footnote) => vec![MdElemRef::Doc(ctx.get_footnote(&footnote))],
                 Inline::Link(link) => vec![MdElemRef::Link(link)],
                 Inline::Image(image) => vec![MdElemRef::Image(image)],
                 Inline::Text(Text { variant, value }) if variant == &TextVariant::Html => {

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -454,6 +454,7 @@ mod test {
     /// Only a smoke test, because the code is pretty straightforward, and I don't feel like writing more. :-)
     mod find_children_smoke {
         use crate::mdq_inline;
+        use crate::select::api::SearchContext;
         use crate::select::MdqRefSelector;
         use crate::tree::{Inline, Link, LinkDefinition, LinkReference, MdContext, Text, TextVariant};
         use crate::tree_ref::MdElemRef;
@@ -469,8 +470,12 @@ mod test {
                 },
             };
             let node_ref = MdElemRef::Link(&link);
-            let ctx = MdContext::empty();
-            let children = MdqRefSelector::find_children(&ctx, node_ref);
+            let md_context = MdContext::empty();
+            let mut ctx = SearchContext {
+                md_context: &md_context,
+                seen_footnotes: Default::default(),
+            };
+            let children = MdqRefSelector::find_children(&mut ctx, node_ref);
             assert_eq!(
                 children,
                 vec![MdElemRef::Inline(&Inline::Text(Text {
@@ -494,8 +499,12 @@ mod test {
             }
             let inline = Inline::Link(mk_link());
             let node_ref = MdElemRef::Inline(&inline);
-            let ctx = MdContext::empty();
-            let children = MdqRefSelector::find_children(&ctx, node_ref);
+            let md_context = MdContext::empty();
+            let mut ctx = SearchContext {
+                md_context: &md_context,
+                seen_footnotes: Default::default(),
+            };
+            let children = MdqRefSelector::find_children(&mut ctx, node_ref);
             assert_eq!(children, vec![MdElemRef::Link(&mk_link())]);
         }
     }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -604,16 +604,16 @@ impl MdElem {
     }
 }
 
-struct NodeToMdqIter<'md, I>
+struct NodeToMdqIter<'a, I>
 where
     I: Iterator<Item = mdast::Node>,
 {
     children: I,
     pending: IntoIter<MdElem>,
-    lookups: &'md Lookups,
+    lookups: &'a Lookups,
 }
 
-impl<'md, I> Iterator for NodeToMdqIter<'md, I>
+impl<'a, I> Iterator for NodeToMdqIter<'a, I>
 where
     I: Iterator<Item = mdast::Node>,
 {

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -805,6 +805,15 @@ mod tests {
     use crate::md_elems;
     use crate::mdq_inline;
 
+    impl MdContext {
+        pub fn empty() -> Self {
+            Self {
+                footnotes: Default::default(),
+                empty_md_elems: vec![],
+            }
+        }
+    }
+
     impl From<&str> for FootnoteId {
         fn from(id: &str) -> Self {
             Self { id: id.to_owned() }

--- a/src/tree.rs
+++ b/src/tree.rs
@@ -415,13 +415,14 @@ impl MdElem {
             }
             mdast::Node::FootnoteDefinition(node) => {
                 let footnote_id = FootnoteId::new(node.identifier, node.label);
-                let entry = ctx.footnotes.entry(footnote_id);
-                return match entry {
-                    Entry::Occupied(other) => Err(InvalidMd::ConflictingReferenceDefinition(other.key().id.clone())),
-                    Entry::Vacant(entry) => {
-                        // MdElem::all(node.children, lookups, footnotes_repo)?
-                        let footnote_text = todo!();
-                        entry.insert(footnote_text);
+                return if ctx.footnotes.contains_key(&footnote_id) {
+                    Err(InvalidMd::ConflictingReferenceDefinition(footnote_id.id))
+                } else {
+                    let children = MdElem::all(node.children, lookups, ctx)?;
+                    if ctx.footnotes.contains_key(&footnote_id) {
+                        Err(InvalidMd::ConflictingReferenceDefinition(footnote_id.id))
+                    } else {
+                        ctx.footnotes.insert(footnote_id, children);
                         Ok(Vec::new())
                     }
                 };

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -1,5 +1,5 @@
 use crate::tree::{
-    BlockQuote, CodeBlock, Image, Inline, Line, Link, List, ListItem, MdElem, Paragraph, Section, Table,
+    BlockQuote, CodeBlock, FootnoteId, Image, Inline, Line, Link, List, ListItem, MdElem, Paragraph, Section, Table,
 };
 use crate::vec_utils::{IndexKeeper, ItemRetainer};
 use markdown::mdast;
@@ -27,6 +27,10 @@ pub enum MdElemRef<'md> {
     Link(&'md Link),
     Image(&'md Image),
     TableSlice(TableSlice<'md>),
+}
+
+pub fn md_elems_placeholder<'md>(_: &'_ FootnoteId) -> &'md Vec<MdElem> {
+    todo!()
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -40,21 +40,20 @@ pub enum MdElemRef<'md> {
     TableSlice(TableSlice<'md>),
 }
 
-#[derive(Debug, PartialEq)]
+// TODO do I need this class? maybe not
+#[derive(Debug, PartialEq, Copy, Clone)]
 pub struct MdRef<'md> {
     pub elem: &'md MdElem,
     pub ctx: &'md MdContext,
 }
 
-impl<'md> MdRef<'md> {
-    // TODO is this fn actually helpful? or should I just inline it?
-    pub fn get_footnote(&self, footnote_id: &'md FootnoteId) -> &'md Vec<MdElem> {
-        self.ctx.get_footnote(footnote_id)
-    }
+pub fn md_elems_placeholder_BAD<'md>(_: &'md FootnoteId) -> &'md Vec<MdElem> {
+    todo!("not yet implemented")
 }
 
-pub fn md_elems_placeholder<'md>(_: &'_ FootnoteId) -> &'md Vec<MdElem> {
-    todo!("replace w/ MdRef::get_footnote")
+pub fn md_elems_placeholder<'md>(ctx: &'md MdContext, footnote: &FootnoteId) -> &'md Vec<MdElem> {
+    // TODO should I inline this?
+    ctx.get_footnote(&footnote)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -1,6 +1,5 @@
 use crate::tree::{
-    BlockQuote, CodeBlock, FootnoteId, Image, Inline, Line, Link, List, ListItem, MdContext, MdElem, Paragraph,
-    Section, Table,
+    BlockQuote, CodeBlock, Image, Inline, Line, Link, List, ListItem, MdElem, Paragraph, Section, Table,
 };
 use crate::vec_utils::{IndexKeeper, ItemRetainer};
 use markdown::mdast;
@@ -38,11 +37,6 @@ pub enum MdElemRef<'md> {
     Link(&'md Link),
     Image(&'md Image),
     TableSlice(TableSlice<'md>),
-}
-
-pub fn md_elems_placeholder<'md>(ctx: &'md MdContext, footnote: &FootnoteId) -> &'md Vec<MdElem> {
-    // TODO should I inline this?
-    ctx.get_footnote(&footnote)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq)]

--- a/src/tree_ref.rs
+++ b/src/tree_ref.rs
@@ -40,17 +40,6 @@ pub enum MdElemRef<'md> {
     TableSlice(TableSlice<'md>),
 }
 
-// TODO do I need this class? maybe not
-#[derive(Debug, PartialEq, Copy, Clone)]
-pub struct MdRef<'md> {
-    pub elem: &'md MdElem,
-    pub ctx: &'md MdContext,
-}
-
-pub fn md_elems_placeholder_BAD<'md>(_: &'md FootnoteId) -> &'md Vec<MdElem> {
-    todo!("not yet implemented")
-}
-
 pub fn md_elems_placeholder<'md>(ctx: &'md MdContext, footnote: &FootnoteId) -> &'md Vec<MdElem> {
     // TODO should I inline this?
     ctx.get_footnote(&footnote)

--- a/tests/md_cases/footnotes_in_footnotes.toml
+++ b/tests/md_cases/footnotes_in_footnotes.toml
@@ -29,7 +29,6 @@ output = '''
 
 
 [expect."just footnote contains footnote: json"]
-# ignore = "broken, but let's not invest in this until / unless we know we want to keep json output; see #190"
 cli_args = ['- BBB | P: *', '--output', 'json']
 output_json = true
 output = '''

--- a/tests/md_cases/footnotes_in_footnotes.toml
+++ b/tests/md_cases/footnotes_in_footnotes.toml
@@ -3,11 +3,13 @@ md = '''
 - AAA: (footnotes in links don't work: see https://gist.github.com/yshavit/6af0a784e338dc32e66717aa6f495ffe )
 - BBB: footnote contains footnote[^2]
 - CCC: footnote contains link[^3]
+- DDD: footnote contains cycle[^cycle]
 
 [^1]: the link's footnote text
 [^2]: this footnote contains[^a] a footnote
 [^3]: this footnote contains a [link][3a]
 [^a]: this is the footnote's footnote
+[^cycle]: this footnote references itself[^cycle]
 
 [3a]: https://example.com/3a
 '''
@@ -89,12 +91,8 @@ output = '''
 
 
 [expect."cyclic reference does't cause infinite loop"]
-ignore = '#188'
 # When ready to add this back in, add the following to the input markdown:
 #
-#     - DDD: footnote contains cycle[^cycle]
-#
-#     [^cycle]: this footnote references itself[^cycle]
 #
 cli_args = ['- DDD | P: *']
 output = '''

--- a/tests/md_cases/footnotes_in_footnotes.toml
+++ b/tests/md_cases/footnotes_in_footnotes.toml
@@ -29,6 +29,7 @@ output = '''
 
 
 [expect."just footnote contains footnote: json"]
+# ignore = "broken, but let's not invest in this until / unless we know we want to keep json output; see #190"
 cli_args = ['- BBB | P: *', '--output', 'json']
 output_json = true
 output = '''
@@ -91,12 +92,17 @@ output = '''
 
 
 [expect."cyclic reference does't cause infinite loop"]
-# When ready to add this back in, add the following to the input markdown:
-#
-#
 cli_args = ['- DDD | P: *']
 output = '''
-- DDD: footnote contains cycle[^cycle]
+DDD: footnote contains cycle[^1]
 
-[^cycle]: this footnote references itself[^cycle]
+[^1]: this footnote references itself[^1]
+'''
+
+[expect."look for elements within a footnote"]
+cli_args = ['[]("/3a"$)']
+output = '''
+[link][3a]
+
+[3a]: https://example.com/3a
 '''


### PR DESCRIPTION
Rather than having the reference's definition (ie, body) directly into the Inline element, separate it out into a new MdContext that gets returned alongside the nodes. This forces us to add indirection when looking up footnotes, which lets us handle cycles.

Resolves #188 