### PR TITLE
make `Output::write_char` canonical

### DIFF
--- a/src/output.rs
+++ b/src/output.rs
@@ -380,6 +380,21 @@ mod tests {
     }
 
     #[test]
+    fn plain_block_with_multiple_newlines() {
+        assert_eq!(
+            out_to_str(|out| {
+                out.with_block(Block::Plain, |out| {
+                    out.write_str("hello\nworld\n\nagain");
+                });
+            }),
+            indoc! {r#"
+                hello
+                world
+                again"#}
+        );
+    }
+
+    #[test]
     fn quote_block() {
         assert_eq!(
             out_to_str(|out| {

--- a/src/output.rs
+++ b/src/output.rs
@@ -165,8 +165,8 @@ impl<W: SimpleWrite> Output<W> {
     /// - `None` basically flushes blocks, but doesn't write anything; we use this in
     ///   [Self::pop_block].
     fn write_optional_char(&mut self, ch: Option<char>) {
-        // TODO: I have a number of branches here. Can I nest some of them, so that in the happy path of a non-newline
-        // char, I just have a single check?
+        // #199: I have a number of branches here. Can I nest some of them, so that in the happy path of a non-newline
+        //       char, I just have a single check?
 
         // If we have any pending blocks, handle those first. We need to add a paragraph break, unless the first block
         // is an Indent.
@@ -185,7 +185,7 @@ impl<W: SimpleWrite> Output<W> {
         }
 
         // print pending newlines before we append any new blocks; also note whether we need to write the full indent
-        // (TODO what actually is "need full indent"?)
+        // (#199: what actually is "need full indent"?)
         let need_full_indent = if self.pending_newlines > 0 {
             for _ in 0..(self.pending_newlines - 1) {
                 self.write_raw('\n');
@@ -198,9 +198,9 @@ impl<W: SimpleWrite> Output<W> {
             matches!(self.writing_state, WritingState::HaveNotWrittenAnything)
         };
 
-        // Append the new blocks, and then write the indent if we need it (TODO that's not actually how this code is
-        // organized. Need to clean this up. See the TODO above)
+        // Append the new blocks, and then write the indent if we need it.
         // When we write that indent, though, only write it until the first new Indent (exclusive).
+        // (#199 that doesn't seem to actually how this code is organized. See the #199 comment above.)
         if need_full_indent {
             let indent_end_idx = self.blocks.len()
                 + self
@@ -223,7 +223,7 @@ impl<W: SimpleWrite> Output<W> {
             self.write_raw(ch); // will not be a '\n', since that got translated to ensure_newlines above.
             self.set_writing_state(WritingState::Normal);
         }
-        self.pending_padding_after_indent = 0; // TODO this is redundant if we called self.write_padding_after_indent()
+        self.pending_padding_after_indent = 0; // #199 this is redundant if we called self.write_padding_after_indent()
     }
 
     /// Write an indentation for a given range of indentation block. If `include_indents` is false, `Indent` blocks

--- a/src/str_utils.rs
+++ b/src/str_utils.rs
@@ -83,8 +83,10 @@ impl<'a, W: SimpleWrite> CountingWriter<'a, W> {
     }
 
     fn write_str(&mut self, text: &str) -> std::io::Result<()> {
-        self.count += text.len();
-        self.underlying.write_str(text)
+        for ch in text.chars() {
+            self.write_char(ch)?;
+        }
+        Ok(())
     }
 
     pub fn count(&self) -> usize {
@@ -93,8 +95,10 @@ impl<'a, W: SimpleWrite> CountingWriter<'a, W> {
 }
 
 impl<'a, W: SimpleWrite> SimpleWrite for CountingWriter<'a, W> {
-    fn write_str(&mut self, text: &str) -> std::io::Result<()> {
-        Self::write_str(self, text)
+    fn write_char(&mut self, ch: char) -> std::io::Result<()> {
+        self.underlying.write_char(ch)?;
+        self.count += 1;
+        Ok(())
     }
 
     fn flush(&mut self) -> std::io::Result<()> {


### PR DESCRIPTION
Rather than implementing `write_char` in terms of `write_str`, make Output more stream-like by having `write_char` be the canonical form, and `write_str` delegate to it.

This resolves #195