### PR TITLE
fix `--version`

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -1,5 +1,5 @@
-name: build-release
 
+name: build-release
 on:
   push:
     branches: [ "main" ]
@@ -34,6 +34,13 @@ jobs:
     - uses: actions/checkout@v4
     - name: build
       run: cargo build --release
+    - name: check for any changes in the git tree
+      run: |
+        if [[ -n "$(git status --porcelain)" ]]; then
+          echo '::error title=post-build check::changes detected in git tree'
+          git status
+          exit 1
+        fi
     - name: Attest Build Provenance
       uses: actions/attest-build-provenance@v1
       with:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -16,6 +16,13 @@ jobs:
     - uses: actions/checkout@v4
     - name: cargo build
       run: scripts/cargo_to_gh rustc --message-format json -- -Awarnings
+    - name: check for any changes in the git tree
+      run: |
+        if [[ -n "$(git status --porcelain)" ]]; then
+          echo '::error title=post-build check::changes detected in git tree'
+          git status
+          exit 1
+        fi
 
   check:
     runs-on: ubuntu-latest

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,12 +18,15 @@ jobs:
       run: scripts/cargo_to_gh rustc --message-format json -- -Awarnings
     - name: check for any changes in the git tree
       run: |
-        if [[ -n "$(git status --porcelain)" ]]; then
-          echo '::error title=post-build check::changes detected in git tree'
-          git status
-          exit 1
-        fi
-
+        exit_code=0
+        while read -r status_code file_path; do
+          if [[ -z "$status_code" ]]; then
+            continue
+          fi
+          exit_code=1
+          echo "::error file=$file_path,title=git-status::<$status_code> $file_path"
+        done <<<"$(git status --porcelain)"
+        exit "$exit_code"
   check:
     runs-on: ubuntu-latest
     needs: build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "mdq"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "indoc",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "mdq"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "clap",
  "indoc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "mdq"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 description = "Select specific elements in a Markdown document"


### PR DESCRIPTION
- add a check that `cargo build` doesn't result in a dirty git tree; this ensures that `Cargo.toml` and `Cargo.lock` are in sync
- fix the `Cargo.lock`, which will in turn fix `--version`

Resolves #222