### PR TITLE
build a docker image on merge to main

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -3,6 +3,16 @@ name: build-release
 on:
   push:
     branches: [ "main" ]
+  workflow_dispatch:
+    inputs:
+      docker-tag-type:
+        description: The docker tag to upload as
+        required: true
+        default: latest-unstable
+        type: choice
+        options:
+          - latest-unstable
+          - stable
 
 env:
   CARGO_TERM_COLOR: always
@@ -14,6 +24,41 @@ permissions:
   contents: read
 
 jobs:
+  docker:
+    environment: Docker Release
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - name: get tag
+      id: get-tag
+      run: |
+        if [[ "${DOCKER_TAG_TYPE}" = 'stable' ]]; then
+          tag="$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "mdq") | .version')"
+        else
+          tag=latest-unstable
+        fi
+        echo "tag=$tag" >> "$GITHUB_OUTPUT"
+      env:
+        DOCKER_TAG_TYPE: ${{ inputs.docker-tag-type }}
+        DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v3
+      with:
+        username: ${{ vars.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PAT }}
+    - name: Gather metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ${{ vars.DOCKER_USERNAME }}/mdq
+    - name: Build and push
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        push: true
+        tags: ${{ vars.DOCKER_USERNAME}}/mdq:${{ steps.get-tag.outputs.tag }}
+        labels: ${{ steps.meta.outputs.labels }}
+
   build:
     strategy:
       matrix:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -25,7 +25,7 @@ permissions:
 
 jobs:
   docker:
-    environment: Docker Release
+    environment: Docker Hub
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
@@ -40,23 +40,23 @@ jobs:
         echo "tag=$tag" >> "$GITHUB_OUTPUT"
       env:
         DOCKER_TAG_TYPE: ${{ inputs.docker-tag-type }}
-        DOCKER_USERNAME: ${{ vars.DOCKER_USERNAME }}
+        DOCKER_USERNAME: ${{ vars.DOCKERHUB_USERNAME }}
     - name: Log in to Docker Hub
       uses: docker/login-action@v3
       with:
-        username: ${{ vars.DOCKER_USERNAME }}
-        password: ${{ secrets.DOCKER_PAT }}
+        username: ${{ vars.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_PAT }}
     - name: Gather metadata
       id: meta
       uses: docker/metadata-action@v5
       with:
-        images: ${{ vars.DOCKER_USERNAME }}/mdq
+        images: ${{ vars.DOCKERHUB_USERNAME }}/mdq
     - name: Build and push
       uses: docker/build-push-action@v6
       with:
         context: .
         push: true
-        tags: ${{ vars.DOCKER_USERNAME}}/mdq:${{ steps.get-tag.outputs.tag }}
+        tags: ${{ vars.DOCKERHUB_USERNAME}}/mdq:${{ steps.get-tag.outputs.tag }}
         labels: ${{ steps.meta.outputs.labels }}
 
   build:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -8,10 +8,10 @@ on:
       docker-tag-type:
         description: The docker tag to upload as
         required: true
-        default: latest-unstable
+        default: latest
         type: choice
         options:
-          - latest-unstable
+          - latest
           - stable
 
 env:
@@ -35,7 +35,7 @@ jobs:
         if [[ "${DOCKER_TAG_TYPE}" = 'stable' ]]; then
           tag="$(cargo metadata --format-version 1 | jq -r '.packages[] | select(.name == "mdq") | .version')"
         else
-          tag=latest-unstable
+          tag=latest
         fi
         echo "tag=$tag" >> "$GITHUB_OUTPUT"
       env:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Any of these will work:
    ```
 3. ```bash
    docker pull yshavit/mdq
-   docker run --rm yshavit/mdq
+   echo 'My [example](https://github.com/yshavit/mdq) markdown' | docker run --rm -i yshavit/mdq '[]()'
    ```
 4. Download binaries from [the latest release] (or any other release, of course).
 

--- a/README.md
+++ b/README.md
@@ -46,8 +46,13 @@ Any of these will work:
 2. ```shell
    brew install mdq
    ```
-3. Download binaries from [the latest release] (or any other release, of course).
-4. You can also grab the binaries from the latest [build-release] workflow run. You must be logged into GitHub to do
+3. ```bash
+   docker pull yshavit/mdq
+   docker run --rm yshavit/mdq
+   ```
+4. Download binaries from [the latest release] (or any other release, of course).
+
+   You can also grab the binaries from the latest [build-release] workflow run. You must be logged into GitHub to do
    that (this is GitHub's limitation, not mine). You'll have to `chmod +x` them before you can run them.
 
 <details>


### PR DESCRIPTION
Push to `yshavit/mdq:latest` on merge to main, with an option to also push to a stable release version (e.g. `0.3.1`).

In service of #217.