### PR TITLE
minor: use docker image when checking readme for rustc version

### DIFF
--- a/.github/workflows/readme-checks.yml
+++ b/.github/workflows/readme-checks.yml
@@ -13,14 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
+    - run: docker pull yshavit/mdq
     - name: find version mentioned in readme
       id: readme-version
       run: |
         set -euo pipefail
-        pwd
-        mkdir -p target/debug
-        cargo build
-        readme_version="$(cat README.md | ./target/debug/mdq '# Development | P: "Requires rustc >=" ' | awk '{print $NF}')"
+        readme_version="$(cat README.md | docker -i --rm yshavit/mdq '# Development | P: "Requires rustc >=" ' | awk '{print $NF}')"
         echo "result=$readme_version" >> "$GITHUB_OUTPUT"
     - name: pull cargo-msrv from docker hub
       run: docker pull foresterre/cargo-msrv

--- a/.github/workflows/readme-checks.yml
+++ b/.github/workflows/readme-checks.yml
@@ -18,7 +18,7 @@ jobs:
       id: readme-version
       run: |
         set -euo pipefail
-        readme_version="$(cat README.md | docker -i --rm yshavit/mdq '# Development | P: "Requires rustc >=" ' | awk '{print $NF}')"
+        readme_version="$(cat README.md | docker run -i --rm yshavit/mdq '# Development | P: "Requires rustc >=" ' | awk '{print $NF}')"
         echo "result=$readme_version" >> "$GITHUB_OUTPUT"
     - name: pull cargo-msrv from docker hub
       run: docker pull foresterre/cargo-msrv


### PR DESCRIPTION
Instead of running `cargo build`, just use the docker image we now publish.