### PR TITLE
add ignored test for bug

### DIFF
--- a/tests/md_cases/select_tables.toml
+++ b/tests/md_cases/select_tables.toml
@@ -64,6 +64,18 @@ output = '''
 |             |'''
 
 
+[expect."select only description by regex"]
+ignore = '#211'
+cli_args = [":-: /description/ :-:"]
+output = '''
+| Description |
+|-------------|
+| Not a fizz  |
+| Not a buzz  |
+| Big, red.   |
+|             |'''
+
+
 [expect."select only the big red row"]
 # Note: header row always survives
 cli_args = [":-: * :-: 'Big, red' "]


### PR DESCRIPTION
The error we get is:

```
Syntax error in select specifier:
┃ :-: /description/ :-:
┃                  ↑ expected ":"
```

see #211