### PR TITLE
add new release instructions

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -13,6 +13,12 @@ on:
           - latest
           - stable
           - none
+  workflow_call:
+    inputs:
+      docker-tag-type:
+        description: The docker tag to upload as
+        required: true
+        type: string
 
 env:
   CARGO_TERM_COLOR: always

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,11 @@
+name: Post-release
+on:
+  push:
+    branches: [ "main" ]
+
+jobs:
+  bump_version:
+    if: startsWith(github.head_ref, 'releases/')
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "The head of this PR starts with 'releases/'. TODO!"

--- a/.github/workflows/release-assets.yml
+++ b/.github/workflows/release-assets.yml
@@ -1,0 +1,13 @@
+name: Upload release assets
+on:
+  pull_request:
+    types: [ "opened", "synchronize" ]
+    branches: [ "releases/*" ]
+
+jobs:
+  bump_version:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "The head of this PR starts with 'releases/'. TODO!"
+
+

--- a/release_procedure.md
+++ b/release_procedure.md
@@ -41,7 +41,7 @@
         - The branch should always be against main, and have exactly one extra commit.
         - The release-assets workflow will re-run each time you update the PR.
 
-3. Follow the instructions on the PR description to validate it.
+3. Follow the instructions in the PR description to validate it.
 
 4. When you're satisfied with the PR, merge it via a fast-forward commit. This must be done locally.
 

--- a/release_procedure.md
+++ b/release_procedure.md
@@ -21,7 +21,7 @@
    Select the following options:
 
    | Option                                         | Value    |
-                                                            |------------------------------------------------|----------|
+   |------------------------------------------------|----------|
    | version to cut a release as                    | `v0.2.0` |
    | the new dev to prepare (w/o "-dev" suffix)     | `v0.2.1` |
    | the git ref to go against                      | `main`   |
@@ -67,4 +67,4 @@ That's it!
 
 [build-release]: https://github.com/yshavit/mdq/actions/workflows/build-release.yml
 
-[post-assets]: https://github.com/yshavit/mdq/actions/workflows/post-release.yml
+[post-release]: https://github.com/yshavit/mdq/actions/workflows/post-release.yml

--- a/release_procedure.md
+++ b/release_procedure.md
@@ -1,0 +1,70 @@
+# Cutting new releases
+
+## tldr
+
+1. run [prepare-new-release], which will create a PR and draft release
+2. wait for CIs to succeed on the PR
+3. validate the release (instructions will be on the PR)
+4. do a fast-forward commit
+5. immediately merge the subsequent PR that gets created (a different one from step 1)
+
+## Details
+
+1. Run the [prepare-new-release] action.
+
+   To illustrate the values to pass to that, let's say:
+
+    - `main` is currently at `v0.1.2-dev`
+    - you want to cut a release named `v0.2.0`
+    - after the release, you want `main` to be on version `v0.2.1-dev`.
+
+   Select the following options:
+
+   | Option                                         | Value    |
+                                                            |------------------------------------------------|----------|
+   | version to cut a release as                    | `v0.2.0` |
+   | the new dev to prepare (w/o "-dev" suffix)     | `v0.2.1` |
+   | the git ref to go against                      | `main`   |
+   | verify current dev version (w/o "-dev" suffix) | `v0.1.2` |
+
+2. A workflow will create a PR to update `v0.1.2-dev` to `v0.2.0`, and create a release for that PR's sha in draft
+   mode. The PR's branch will be named `pending-releases/v0.2.0`
+
+    1. The [release-assets] workflow will:
+
+        1. Validate that the PR has a linear history to main with just one additional commit.
+        2. Use the [build-release] workflow to build the binaries
+        3. Upload the artifacts to the draft PR.
+
+    2. If you need to make any changes (like adding a new commit), rebase and force-push to `pending-releases/v0.2.0`.
+
+        - The branch should always be against main, and have exactly one extra commit.
+        - The release-assets workflow will re-run each time you update the PR.
+
+3. Follow the instructions on the PR description to validate it.
+
+4. When you're satisfied with the PR, merge it via a fast-forward commit. This must be done locally.
+
+   ```bash
+   git fetch
+   git checkout main
+   git pull origin main
+   git merge --ff-only origin/pending-releases/v0.2.0
+   git push
+   ```
+
+5. Another workflow ([post-release]) will publish the release and create a new PR to bump the version to `v0.2.1-dev`
+
+   > [!important]
+   > Merge this PR immediately! Even if there are any CI failures, just merge it. (It's okay to hit retries on the
+   > CIs if you need to, but don't do any other code change.)
+
+That's it!
+
+[prepare-new-release]: https://github.com/yshavit/mdq/actions/workflows/prepare-new-release.yml
+
+[release-assets]: https://github.com/yshavit/mdq/actions/workflows/release-assets.yml
+
+[build-release]: https://github.com/yshavit/mdq/actions/workflows/build-release.yml
+
+[post-assets]: https://github.com/yshavit/mdq/actions/workflows/post-release.yml


### PR DESCRIPTION
This is in preparation for #243.

- Add a readme describing the process
- Create two new workflow (`release-assets` an `post-release`). They don't do anything yet, but I need them in main so that when I fill them out later, they'll run as part of CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Introduced a new document titled "Cutting new releases" that outlines the procedure for creating new software releases, including step-by-step instructions and relevant workflows.
- **New Features**
	- Added a new GitHub Actions workflow for post-release processes.
	- Introduced a new workflow for uploading release assets.
	- Enhanced the build-release workflow with a new input parameter for Docker tag specification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->