### PR TITLE
test stderr in integ tests

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,6 +35,7 @@ mod utils_for_test;
 mod vec_utils;
 mod words_buffer;
 
+#[derive(Debug)]
 pub enum Error {
     QueryParse { query_string: String, error: ParseError },
     MarkdownParse(InvalidMd),
@@ -72,7 +73,7 @@ pub fn run_in_memory(cli: &Cli, contents: &str) -> Result<(bool, String), Error>
     let mut out = Vec::with_capacity(256); // just a guess
 
     let result = run(&cli, contents.to_string(), || &mut out)?;
-    let out_str = String::from_utf8(out).map_err(|_| "UTF-8 decode error").unwrap();
+    let out_str = String::from_utf8(out).unwrap_or_else(|err| String::from_utf8_lossy(err.as_bytes()).into_owned());
     Ok((result, out_str))
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,13 +2,15 @@ use crate::fmt_md::MdOptions;
 use crate::fmt_md_inlines::MdInlinesWriterOptions;
 use crate::output::{OutputOpts, Stream};
 use crate::select::{ParseError, SelectorAdapter};
-use crate::tree::{MdDoc, ReadOptions};
+use crate::tree::{InvalidMd, MdDoc, ReadOptions};
 use crate::tree_ref::MdElemRef;
 use crate::tree_ref_serde::SerdeDoc;
 use cli::{Cli, OutputFormat};
 use output::Output;
 use pest::error::ErrorVariant;
 use pest::Span;
+use std::borrow::Cow;
+use std::fmt::{Display, Formatter};
 use std::io;
 use std::io::{stdin, Read, Write};
 
@@ -33,12 +35,45 @@ mod utils_for_test;
 mod vec_utils;
 mod words_buffer;
 
-pub fn run_in_memory(cli: &Cli, contents: &str) -> (bool, String) {
+pub enum Error {
+    QueryParse { query_string: String, error: ParseError },
+    MarkdownParse(InvalidMd),
+}
+
+impl Display for Error {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Error::QueryParse { query_string, error } => {
+                let pest_err = match error {
+                    ParseError::Pest(err) => Cow::Borrowed(err),
+                    ParseError::Other(span, message) => {
+                        let full_span = Span::new(query_string, span.start, span.end);
+                        Cow::Owned(query::Error::new_from_span(
+                            ErrorVariant::CustomError {
+                                message: message.to_string(),
+                            },
+                            full_span.unwrap(),
+                        ))
+                    }
+                };
+
+                writeln!(f, "Syntax error in select specifier:")?;
+                writeln!(f, "{pest_err}")
+            }
+            Error::MarkdownParse(err) => {
+                writeln!(f, "Markdown parse error:")?;
+                writeln!(f, "{err}")
+            }
+        }
+    }
+}
+
+pub fn run_in_memory(cli: &Cli, contents: &str) -> Result<(bool, String), Error> {
     let mut out = Vec::with_capacity(256); // just a guess
 
-    let result = run(&cli, contents.to_string(), || &mut out);
+    let result = run(&cli, contents.to_string(), || &mut out)?;
     let out_str = String::from_utf8(out).map_err(|_| "UTF-8 decode error").unwrap();
-    (result, out_str)
+    Ok((result, out_str))
 }
 
 pub fn run_stdio(cli: &Cli) -> bool {
@@ -47,10 +82,13 @@ pub fn run_stdio(cli: &Cli) -> bool {
     }
     let mut contents = String::new();
     stdin().read_to_string(&mut contents).expect("invalid input (not utf8)");
-    run(&cli, contents, || io::stdout().lock())
+    run(&cli, contents, || io::stdout().lock()).unwrap_or_else(|err| {
+        eprintln!("{err}");
+        false
+    })
 }
 
-fn run<W, F>(cli: &Cli, contents: String, get_out: F) -> bool
+fn run<W, F>(cli: &Cli, contents: String, get_out: F) -> Result<bool, Error>
 where
     F: FnOnce() -> W,
     W: Write,
@@ -63,17 +101,18 @@ where
     let MdDoc { roots, ctx } = match MdDoc::read(ast, &read_options) {
         Ok(mdqs) => mdqs,
         Err(err) => {
-            eprintln!("error: {}", err);
-            return false;
+            return Err(Error::MarkdownParse(err));
         }
     };
 
     let selectors_str = cli.selector_string();
     let selectors = match SelectorAdapter::parse(&selectors_str) {
         Ok(selectors) => selectors,
-        Err(err) => {
-            print_select_parse_error(err, &selectors_str);
-            return false;
+        Err(error) => {
+            return Err(Error::QueryParse {
+                query_string: selectors_str.into_owned(),
+                error,
+            });
         }
     };
 
@@ -117,17 +156,5 @@ where
         }
     }
 
-    found_any
-}
-
-fn print_select_parse_error(err: ParseError, query_string: &str) {
-    eprintln!("Syntax error in select specifier:");
-    let pest_err = match err {
-        ParseError::Pest(err) => err,
-        ParseError::Other(span, message) => {
-            let full_span = Span::new(query_string, span.start, span.end);
-            query::Error::new_from_span(ErrorVariant::CustomError { message }, full_span.unwrap())
-        }
-    };
-    eprintln!("{}", pest_err);
+    Ok(found_any)
 }

--- a/tests/integ_test.rs
+++ b/tests/integ_test.rs
@@ -4,6 +4,7 @@ use clap::Parser;
 struct Case<const N: usize> {
     cli_args: [&'static str; N],
     expect_output: &'static str,
+    expect_error: &'static str,
     expect_output_json: bool,
     md: &'static str,
     expect_success: bool,
@@ -11,9 +12,7 @@ struct Case<const N: usize> {
 
 impl<const N: usize> Case<N> {
     fn check(&self) {
-        let all_cli_args = ["cmd"].iter().chain(&self.cli_args);
-        let cli = mdq::cli::Cli::try_parse_from(all_cli_args).unwrap();
-        let (actual_success, actual_out) = mdq::run_in_memory(&cli, self.md);
+        let (actual_success, actual_out, actual_err) = self.run();
         let (actual_out, expect_out) = if self.expect_output_json {
             let actual_obj = serde_json::from_str::<serde_json::Value>(&actual_out).unwrap();
             let expect_obj = serde_json::from_str::<serde_json::Value>(self.expect_output).unwrap();
@@ -25,7 +24,17 @@ impl<const N: usize> Case<N> {
             (actual_out, self.expect_output.to_string())
         };
         assert_eq!(actual_out, expect_out);
+        assert_eq!(actual_err, self.expect_error);
         assert_eq!(actual_success, self.expect_success);
+    }
+
+    fn run(&self) -> (bool, String, String) {
+        let all_cli_args = ["cmd"].iter().chain(&self.cli_args);
+        let cli = mdq::cli::Cli::try_parse_from(all_cli_args).unwrap();
+        match mdq::run_in_memory(&cli, self.md) {
+            Ok((found, stdout)) => (found, stdout, String::new()),
+            Err(err) => (false, String::new(), err.to_string()),
+        }
     }
 }
 

--- a/tests/md_cases/select_html.toml
+++ b/tests/md_cases/select_html.toml
@@ -52,7 +52,14 @@ output = '''
 [expect."unquoted tag"]
 cli_args = ['</> <span>']
 expect_success = false # unquoted string must start with a letter, not a '<'
-output = '''
+output = ''
+output_err = '''Syntax error in select specifier:
+ --> 1:5
+  |
+1 | </> <span>
+  |     ^---
+  |
+  = expected end of input or string
 '''
 
 

--- a/tests/md_cases/select_paragraphs.toml
+++ b/tests/md_cases/select_paragraphs.toml
@@ -56,14 +56,28 @@ This paragraph has _inline_ **formatting**.
 [expect."no colon after p"]
 cli_args = ["P *"]
 expect_success = false
-output = '''
+output = ''
+output_err = '''Syntax error in select specifier:
+ --> 1:1
+  |
+1 | P *
+  | ^---
+  |
+  = expected valid query
 '''
 
 
 [expect."space before colon"]
 cli_args = ["P : *"]
 expect_success = false
-output = '''
+output = ''
+output_err = '''Syntax error in select specifier:
+ --> 1:1
+  |
+1 | P : *
+  | ^---
+  |
+  = expected valid query
 '''
 
 


### PR DESCRIPTION
Rather than having bad queries always just `eprintln` to stderr and then return false, have the `lib.rs` runners return a Result, where the error case is that invalid query's error. Then, use that to test for the error string.