### PR TITLE
use `PUSH_LITERAL` to simplify grammar

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,9 +78,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
-version = "4.5.26"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8eb5e908ef3a6efbe1ed62520fb7287959888c88485abe072543190ecc66783"
+checksum = "6088f3ae8c3608d19260cd7445411865a485688711b78b5be70d78cd96136f83"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -88,9 +88,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.26"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96b01801b5fc6a0a232407abc821660c9c6d25a1cafc0d4f85f29fb8d9afc121"
+checksum = "22a7ef7f676155edfb82daa97f99441f3ebf4a58d5e32f295a56259f1b6facc8"
 dependencies = [
  "anstream",
  "anstyle",
@@ -100,9 +100,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.24"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -159,9 +159,9 @@ dependencies = [
 
 [[package]]
 name = "equivalent"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "generic-array"
@@ -187,9 +187,9 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "indexmap"
-version = "2.7.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "62f822373a4fe84d4bb149bf54e584a7f4abec90e072ed49cda0edea5b95471f"
+checksum = "3954d50fe15b02142bf25d3b8bdadb634ec3948f103d04ffe3031bc8fe9d7058"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -197,9 +197,9 @@ dependencies = [
 
 [[package]]
 name = "indoc"
-version = "2.0.5"
+version = "2.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b248f5224d1d606005e02c97f5aa4e88eeb230488bcc03bc9ca4d7991399f2b5"
+checksum = "f4c7245a08504955605670dbf141fceab975f15ca21570696aebe9d2e71576bd"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -209,9 +209,9 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "lazy_static"
@@ -221,15 +221,15 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "libc"
-version = "0.2.169"
+version = "0.2.171"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5aba8db14291edd000dfcc4d620c7ebfb122c613afb886ca8803fa4e128a20a"
+checksum = "c19937216e9d3aa9956d9bb8dfc0b0c8beb6058fc4f7a4dc4d850edf86a237d6"
 
 [[package]]
 name = "markdown"
-version = "1.0.0-alpha.21"
+version = "1.0.0-alpha.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6491e6c702bf7e3b24e769d800746d5f2c06a6c6a2db7992612e0f429029e81"
+checksum = "9047e0a37a596d4e15411a1ffbdabe71c328908cb90a721cb9bf8dcf3434e6d2"
 dependencies = [
  "unicode-id",
 ]
@@ -261,9 +261,9 @@ checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "once_cell"
-version = "1.20.2"
+version = "1.21.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
+checksum = "d75b0bedcc4fe52caa0e03d9f1151a323e4aa5e2d78ba3580400cd3c9e2bc4bc"
 
 [[package]]
 name = "paste"
@@ -273,9 +273,9 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pest"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b7cafe60d6cf8e62e1b9b2ea516a089c008945bb5a275416789e7db0bc199dc"
+checksum = "198db74531d58c70a361c42201efde7e2591e976d518caf7662a47dc5720e7b6"
 dependencies = [
  "memchr",
  "thiserror",
@@ -284,9 +284,9 @@ dependencies = [
 
 [[package]]
 name = "pest_derive"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "816518421cfc6887a0d62bf441b6ffb4536fcc926395a69e1a85852d4363f57e"
+checksum = "d725d9cfd79e87dccc9341a2ef39d1b6f6353d68c4b33c177febbe1a402c97c5"
 dependencies = [
  "pest",
  "pest_generator",
@@ -294,9 +294,9 @@ dependencies = [
 
 [[package]]
 name = "pest_generator"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d1396fd3a870fc7838768d171b4616d5c91f6cc25e377b673d714567d99377b"
+checksum = "db7d01726be8ab66ab32f9df467ae8b1148906685bbe75c82d1e65d7f5b3f841"
 dependencies = [
  "pest",
  "pest_meta",
@@ -307,9 +307,9 @@ dependencies = [
 
 [[package]]
 name = "pest_meta"
-version = "2.7.15"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1e58089ea25d717bfd31fb534e4f3afcc2cc569c70de3e239778991ea3b7dea"
+checksum = "7f9f832470494906d1fca5329f8ab5791cc60beb230c74815dff541cbd2b5ca0"
 dependencies = [
  "once_cell",
  "pest",
@@ -328,18 +328,18 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.94"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "a31971752e70b8b2686d7e46ec17fb38dad4051d94024c88df49b667caea9c84"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
@@ -375,24 +375,24 @@ checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "ryu"
-version = "1.0.18"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "serde"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02fc4265df13d6fa1d00ecff087228cc0a2b5f3c0e87e258d8b94a156e984c70"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.217"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a9bf7cf98d04a2b28aead066b7496853d4779c9cc183c440dbac457641e19a0"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -401,9 +401,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.136"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336a0c23cf42a38d9eaa7cd22c7040d04e1228a19a933890805ffd00a16437d2"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",
@@ -439,9 +439,9 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.96"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -470,9 +470,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.19"
+version = "0.8.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
+checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -491,9 +491,9 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.22.22"
+version = "0.22.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
+checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
 dependencies = [
  "indexmap",
  "serde",
@@ -522,9 +522,9 @@ checksum = "10103c57044730945224467c09f71a4db0071c123a0648cc3e818913bde6b561"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.14"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "utf8parse"
@@ -613,9 +613,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "winnow"
-version = "0.6.24"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
+checksum = "0e97b544156e9bebe1a0ffbc03484fc1ffe3100cbce3ffb17eac35f7cdd7ab36"
 dependencies = [
  "memchr",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ clap = { version = "4.5.7", features = ["derive"] }
 markdown = "1.0.0-alpha.20"
 memchr = "2.7.4"
 paste = "1.0"
-pest = "2.7"
-pest_derive = { version = "2.7", features = ["grammar-extras"] }
+pest = "2.8"
+pest_derive = { version = "2.8", features = ["grammar-extras"] }
 regex = "1.10.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1.0"

--- a/src/query/grammar.pest
+++ b/src/query/grammar.pest
@@ -18,10 +18,10 @@ selector = {
 selector_delim = _{ explicit_space | EOI }
 explicit_space = !{ " " } // making this a rule lets us have nicer error messages if the user doesn't include it
 
-select_section =  { section_start ~ #title = string_to_pipe? }
+select_section =  { section_start ~ PUSH_LITERAL("|") ~ #title = string }
 section_start  = @{ "#" ~ selector_delim }
 
-select_list_item  =  { list_start ~ list_task_options? ~ #contents = string_to_pipe? }
+select_list_item  =  { list_start ~ list_task_options? ~ PUSH_LITERAL("|") ~ #contents = string }
 list_start        = ${ (list_ordered | "-") ~ selector_delim }
 list_ordered      = ${ "1." }
 list_task_options = ${ "[" ~ (task_unchecked | task_checked | task_either) ~ task_end }
@@ -30,42 +30,40 @@ task_unchecked    = ${ " " }
 task_either       = ${ "?" }
 task_end          = ${ "]" }
 
-select_link =  { link_start ~ #display_text = string_to_bracket? ~ "](" ~ #url_text = string_to_paren? ~ ")" }
+select_link =  { link_start ~ PUSH_LITERAL("]") ~ #display_text = string ~ "](" ~ PUSH_LITERAL(")")~ #url_text = string ~ ")" }
 link_start  = ${ image_start? ~ "[" }
 image_start = @{ "!" }
 
-select_block_quote       =  { select_block_quote_start ~ #text = string_to_pipe? }
+select_block_quote       =  { select_block_quote_start ~ PUSH_LITERAL("|") ~ #text = string }
 select_block_quote_start = @{ ">" ~ selector_delim }
 
-select_code_block =  { code_block_start ~ #text = string_to_pipe? }
-code_block_start  = ${ "```" ~ #language = string_to_space? ~ selector_delim }
+select_code_block =  { code_block_start ~ PUSH_LITERAL("|") ~ #text = string }
+code_block_start  = ${ "```" ~ PUSH_LITERAL(" ") ~ #language = string ~ selector_delim }
 
-select_html =  { html_start ~ #text = string_to_pipe? }
+select_html =  { html_start ~ PUSH_LITERAL("|") ~ #text = string }
 html_start  = @{ "</>" ~ selector_delim }
 
-select_paragraph       =  { select_paragraph_start ~ #text = string_to_pipe? }
+select_paragraph       =  { select_paragraph_start ~ PUSH_LITERAL("|") ~ #text = string }
 select_paragraph_start = @{ "P:" ~ selector_delim }
 
-select_table = { table_start ~ (explicit_asterisk | #column = string_to_colon) ~ ":-:" ~ #row = string_to_pipe? }
+select_table = { table_start ~ PUSH_LITERAL(":") ~ #column = string ~ ":-:" ~ PUSH_LITERAL("|") ~ #row = string }
 table_start = ${":-:" ~ explicit_space }
-explicit_asterisk = ${ "*" }
 
-// What I'd really want is to push a literal for the closing delimiter, and then do (!("|" | PEEK) in unquoted_string.
-// But that's not possible (see GH pest-parser/pest#880), so this is the next best.
-
-// NOTE: If you add a variant here, make sure to add it to the big matcher in strings.rs's "fn build_string":
-
-string_to_pipe    = { "*" | regex | (anchor_start? ~ (quoted_string | unquoted_string_to_pipe) ~ anchor_end?) | only_anchors }
-string_to_paren   = { "*" | regex | (anchor_start? ~ (quoted_string | unquoted_string_to_paren) ~ anchor_end? | only_anchors) }
-string_to_bracket = { "*" | regex | (anchor_start? ~ (quoted_string | unquoted_string_to_bracket) ~ anchor_end? | only_anchors) }
-string_to_space   = { "*" | regex | (anchor_start? ~ (quoted_string | unquoted_string_to_space) ~ anchor_end? | only_anchors) }
-string_to_colon   = { "*" | regex | (anchor_start? ~ (quoted_string | unquoted_string_to_colon) ~ anchor_end? | only_anchors) }
-
-unquoted_string_to_pipe    = @{ LETTER ~ (!("|" | "$") ~ ANY)* }
-unquoted_string_to_paren   = @{ LETTER ~ (!(")" | "$") ~ ANY)* }
-unquoted_string_to_bracket = @{ LETTER ~ (!("]" | "$") ~ ANY)* }
-unquoted_string_to_space   = @{ LETTER ~ (!(" " | "$") ~ ANY)* }
-unquoted_string_to_colon   = @{ LETTER ~ (!(":" | "$") ~ ANY)* }
+// helper rule, just for unit tests
+string_for_unit_tests__do_not_use_pipe = { PUSH_LITERAL("|") ~ string }
+string_for_unit_tests__do_not_use_angle = { PUSH_LITERAL(">") ~ string }
+string = {
+  // end delimiter for unquoted string will have been PUSH_LITERAL'd by here
+  (
+        asterisk
+      | regex
+      | ( anchor_start? ~ ( quoted_string | unquoted_string ) ~ anchor_end? )
+      | ( anchor_start ~ anchor_end )
+  )?
+  ~ DROP
+}
+asterisk = @{ "*" }
+unquoted_string = @{ LETTER ~ (!(PEEK | "$") ~ ANY)* }
 
 regex               = ${ "/" ~ regex_char* ~ "/" }
 regex_char          = ${
@@ -84,11 +82,6 @@ quoted_char = ${
 anchor_start = @{ "^" }
 
 anchor_end = @{ "$" }
-
-only_anchors = {
-  (anchor_start ~ anchor_end?)
-  | anchor_end
-}
 
 quoted_plain_chars = @{ (!(PEEK | "\\") ~ ANY)+ }
 

--- a/src/query/query.rs
+++ b/src/query/query.rs
@@ -46,26 +46,19 @@ impl Query {
                 Rule::select_html | Rule::html_start => "_</>_",
                 Rule::select_paragraph | Rule::select_paragraph_start => "_P:_",
                 Rule::select_table | Rule::table_start => "_:-:_",
-                Rule::explicit_asterisk => "explicit _*_",
-                Rule::string_to_pipe
-                | Rule::string_to_paren
-                | Rule::string_to_bracket
-                | Rule::string_to_space
-                | Rule::string_to_colon => "string",
-                Rule::unquoted_string_to_pipe
-                | Rule::unquoted_string_to_paren
-                | Rule::unquoted_string_to_bracket
-                | Rule::unquoted_string_to_space
-                | Rule::unquoted_string_to_colon => "unquoted string",
-                Rule::regex => "_/_",
+                Rule::string
+                | Rule::string_for_unit_tests__do_not_use_angle
+                | Rule::string_for_unit_tests__do_not_use_pipe => "string",
+                Rule::unquoted_string => "unquoted string",
+                Rule::regex => "regex",
                 Rule::regex_char => "regex character",
                 Rule::regex_escaped_slash => "_/_",
                 Rule::regex_normal_char => "regex character",
                 Rule::quoted_string => "quoted string",
                 Rule::quoted_char => "character in quoted string",
+                Rule::asterisk => "_*_",
                 Rule::anchor_start => "_^_",
                 Rule::anchor_end => "_$_",
-                Rule::only_anchors => "_^_ _$_",
                 Rule::quoted_plain_chars => "character in quoted string",
                 Rule::escaped_char => "\", ', `, \\, n, r, or t",
                 Rule::unicode_seq => "1 - 6 hex characters",
@@ -85,10 +78,7 @@ mod test_helpers {
     #[derive(Clone, Copy, PartialEq, Eq)]
     pub enum StringVariant {
         Pipe,
-        Paren,
-        Bracket,
-        Space,
-        Colon,
+        AngleBracket,
     }
 
     impl StringVariant {
@@ -105,11 +95,8 @@ mod test_helpers {
 
         pub fn as_rule(self) -> Rule {
             let rule = match self {
-                StringVariant::Pipe => Rule::string_to_pipe,
-                StringVariant::Paren => Rule::string_to_paren,
-                StringVariant::Bracket => Rule::string_to_bracket,
-                StringVariant::Space => Rule::string_to_space,
-                StringVariant::Colon => Rule::string_to_colon,
+                StringVariant::AngleBracket => Rule::string_for_unit_tests__do_not_use_angle,
+                StringVariant::Pipe => Rule::string_for_unit_tests__do_not_use_pipe,
             };
             rule
         }

--- a/src/query/strings.rs
+++ b/src/query/strings.rs
@@ -164,7 +164,7 @@ mod tests {
         #[test]
         fn single_quoted_string() {
             check_parse(
-                StringVariant::AngleBracket,
+                StringVariant::Pipe,
                 "'hello'\"X",
                 parsed_text(CaseSensitive, false, "hello", false),
                 "\"X",
@@ -174,7 +174,7 @@ mod tests {
         #[test]
         fn double_quoted_string() {
             check_parse(
-                StringVariant::AngleBracket,
+                StringVariant::Pipe,
                 "\"hello\"'X",
                 parsed_text(CaseSensitive, false, "hello", false),
                 "'X",
@@ -184,7 +184,7 @@ mod tests {
         #[test]
         fn quoted_string_newline() {
             check_parse(
-                StringVariant::AngleBracket,
+                StringVariant::Pipe,
                 r"'hello\nworld'",
                 parsed_text(CaseSensitive, false, "hello\nworld", false),
                 "",
@@ -194,7 +194,7 @@ mod tests {
         #[test]
         fn quoted_string_snowman() {
             check_parse(
-                StringVariant::AngleBracket,
+                StringVariant::Pipe,
                 r"'hello\u{2603}world'",
                 parsed_text(CaseSensitive, false, "hello☃world", false),
                 "",
@@ -214,7 +214,7 @@ mod tests {
         #[test]
         fn unquoted_no_end_pipe() {
             check_parse(
-                StringVariant::AngleBracket,
+                StringVariant::Pipe,
                 r"hello world   ",
                 parsed_text(CaseInsensitive, false, r"hello world", false),
                 "",
@@ -224,7 +224,7 @@ mod tests {
         #[test]
         fn unquoted_string_to_pipe_unicode() {
             check_parse(
-                StringVariant::AngleBracket,
+                StringVariant::Pipe,
                 r"ἀλφα",
                 parsed_text(CaseInsensitive, false, r"ἀλφα", false),
                 "",
@@ -233,14 +233,14 @@ mod tests {
 
         #[test]
         fn asterisk() {
-            check_parse(StringVariant::AngleBracket, r"*", parsed_wildcard(), "");
+            check_parse(StringVariant::Pipe, r"*", parsed_wildcard(), "");
             assert!(parsed_wildcard().is_equivalent_to_asterisk());
         }
 
         #[test]
         fn empty() {
             check_parse(
-                StringVariant::AngleBracket,
+                StringVariant::Pipe,
                 r"",
                 parsed_text(CaseSensitive, false, "", false),
                 "",
@@ -251,7 +251,7 @@ mod tests {
         #[test]
         fn anchors_double_quoted_no_space() {
             check_parse(
-                StringVariant::AngleBracket,
+                StringVariant::Pipe,
                 "^\"hello\"$",
                 parsed_text(CaseSensitive, true, "hello", true),
                 "",
@@ -261,7 +261,7 @@ mod tests {
         #[test]
         fn anchors_single_quoted_with_space() {
             check_parse(
-                StringVariant::AngleBracket,
+                StringVariant::Pipe,
                 "^ 'hello' $",
                 parsed_text(CaseSensitive, true, "hello", true),
                 "",
@@ -271,7 +271,7 @@ mod tests {
         #[test]
         fn anchors_unquoted_to_pipe_with_space() {
             check_parse(
-                StringVariant::AngleBracket,
+                StringVariant::Pipe,
                 "^ hello $ there",
                 parsed_text(CaseInsensitive, true, "hello", true),
                 "there",
@@ -281,7 +281,7 @@ mod tests {
         #[test]
         fn anchors_unquoted_to_pipe_no_space() {
             check_parse(
-                StringVariant::AngleBracket,
+                StringVariant::Pipe,
                 "^hello$ there",
                 parsed_text(CaseInsensitive, true, "hello", true),
                 "there",
@@ -294,22 +294,12 @@ mod tests {
 
         #[test]
         fn normal_regex() {
-            check_parse(
-                StringVariant::AngleBracket,
-                "/hello there$/",
-                parsed_regex("hello there$"),
-                "",
-            );
+            check_parse(StringVariant::Pipe, "/hello there$/", parsed_regex("hello there$"), "");
         }
 
         #[test]
         fn regex_with_escaped_slash() {
-            check_parse(
-                StringVariant::AngleBracket,
-                r"/hello\/there/",
-                parsed_regex(r"hello/there"),
-                "",
-            );
+            check_parse(StringVariant::Pipe, r"/hello\/there/", parsed_regex(r"hello/there"), "");
         }
     }
 

--- a/tests/md_cases/bad_queries.toml
+++ b/tests/md_cases/bad_queries.toml
@@ -168,12 +168,12 @@ cli_args = ['# $hello^']
 expect_success = false
 output = ''
 output_err = '''Syntax error in select specifier:
- --> 1:4
+ --> 1:3
   |
 1 | # $hello^
-  |    ^---
+  |   ^---
   |
-  = expected end of input
+  = expected end of input, "*", unquoted string, regex, quoted string, or "^"
 '''
 
 [expect."invalid selector"]
@@ -223,9 +223,9 @@ output_err = '''Syntax error in select specifier:
  --> 1:5
   |
 1 | :-: :-: row
-  |     ^---
+  |     ^
   |
-  = expected explicit "*" or string
+  = table column matcher cannot empty; use an explicit "*"
 '''
 
 [expect."table missing second delimiter"]

--- a/tests/md_cases/select_html.toml
+++ b/tests/md_cases/select_html.toml
@@ -59,7 +59,7 @@ output_err = '''Syntax error in select specifier:
 1 | </> <span>
   |     ^---
   |
-  = expected end of input or string
+  = expected end of input, "*", unquoted string, regex, quoted string, or "^"
 '''
 
 


### PR DESCRIPTION
Use pest's new (as of 2.8.0) `PUSH_LITERAL`. This reduces the number of rules we need in the grammar.

One complication is that the `string` rule now needs to end with `DROP`. So we could either keep the `string` as only non-empty and then add the `DROP` after each `string?`, or we could have it include empty. The latter is simpler, but means we need to then add a check for explicit `*` in the table matcher.