### PR TITLE
option to output with or without breaks

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -56,10 +56,7 @@ jobs:
           while read -r line ; do
             echo "::error title=unfinished task::$line"
             exit_status=1
-          done < <(
-            echo "$PR_JSON" | jq -r .body | docker run --rm -i "$DOCKER_RC_TAG" -o plain '- [ ]' | grep -v '^ *-* *$'
-            # note: the grep is to remove the thematic breaks; see https://github.com/yshavit/mdq/issues/270
-          )
+          done < <(echo "$PR_JSON" | jq -r .body | docker run --rm -i "$DOCKER_RC_TAG" -o plain '- [ ]')
           exit "$exit_status"
         env:
           PR_JSON: ${{ steps.pr-info.outputs.json }}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -29,6 +29,25 @@ pub struct Cli {
     #[arg(long, short, default_value_t = OutputFormat::Markdown)]
     pub(crate) output: OutputFormat,
 
+    /// Include breaks between elements in plain and markdown output mode.
+    ///
+    /// For plain, this will add a blank line between elements. For markdown, this will add a thematic break
+    /// ("-----") between elements.
+    ///
+    /// This has no effect in JSON output mode.
+    ///
+    /// This defaults to false for plain output, and true for markdown output.
+    #[arg(long = "[no]-br", action)]
+    pub(crate) br_umbrella: bool,
+
+    /// Negates the --br option.
+    #[arg(long, hide = true)]
+    pub(crate) br: bool,
+
+    /// Negates the --br option.
+    #[arg(long, conflicts_with = "br", hide = true)]
+    pub(crate) no_br: bool,
+
     /// The number of characters to wrap text at. This is only valid when the output format is
     /// markdown.
     ///
@@ -75,6 +94,14 @@ impl Cli {
         }
     }
 
+    pub fn should_add_breaks(&self) -> bool {
+        match self.output {
+            OutputFormat::Json => false,
+            OutputFormat::Markdown | OutputFormat::Md => !self.no_br,
+            OutputFormat::Plain => self.br,
+        }
+    }
+
     pub fn extra_validation(&self) -> bool {
         match self.output {
             OutputFormat::Json => {
@@ -85,14 +112,22 @@ impl Cli {
                             "Can't set text width with JSON output format",
                         )
                         .print();
-                    false
-                } else {
-                    true
+                    return false;
                 }
             }
-            OutputFormat::Markdown | OutputFormat::Md => true,
-            OutputFormat::Plain => true,
+            OutputFormat::Markdown | OutputFormat::Md => {}
+            OutputFormat::Plain => {}
         }
+        if self.br_umbrella {
+            let _ = Cli::command()
+                .error(
+                    ErrorKind::UnknownArgument,
+                    r"invalid argument '--[no]-br'; use '--br' or '--no-br'.",
+                )
+                .print();
+            return false;
+        }
+        true
     }
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -36,7 +36,10 @@ pub struct Cli {
     ///
     /// This has no effect in JSON output mode.
     ///
-    /// This defaults to false for plain output, and true for markdown output.
+    /// This defaults to true for Markdown output, and false for plain text output.
+    // Note: this is a fake arg so we have explicit validation below to ensure it isn't invoked. Clap doesn't let us
+    // add boolean flags with 'no-' to disable, so I'm using this trick to fake that out. Basically, this fake arg is
+    // only for the help text, and then --br and --no-br are fake but hidden args.
     #[arg(long = "[no]-br", action)]
     pub(crate) br_umbrella: bool,
 

--- a/src/fmt_md.rs
+++ b/src/fmt_md.rs
@@ -14,6 +14,7 @@ pub struct MdOptions {
     pub link_reference_placement: ReferencePlacement,
     pub footnote_reference_placement: ReferencePlacement,
     pub inline_options: MdInlinesWriterOptions,
+    pub include_thematic_breaks: bool,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -68,7 +69,7 @@ where
         prev_was_thematic_break: false,
         inlines_writer: &mut MdInlinesWriter::new(ctx, options.inline_options),
     };
-    let nodes_count = writer_state.write_md(out, nodes, true);
+    let nodes_count = writer_state.write_md(out, nodes, options.include_thematic_breaks);
 
     // Always write the pending definitions at the end of the doc. If there were no sections, then BottomOfSection
     // won't have been triggered, but we still want to write them. We'll add a thematic break before the links if there

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,7 @@ where
             link_format: cli.link_format,
             renumber_footnotes: cli.renumber_footnotes,
         },
+        include_thematic_breaks: cli.should_add_breaks(),
     };
 
     let found_any = !pipeline_nodes.is_empty();
@@ -153,7 +154,9 @@ where
                 .unwrap();
             }
             OutputFormat::Plain => {
-                let output_opts = PlainOutputOpts { include_breaks: cli.br };
+                let output_opts = PlainOutputOpts {
+                    include_breaks: cli.should_add_breaks(),
+                };
                 fmt_plain::write_plain(&mut stdout, output_opts, pipeline_nodes.into_iter());
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 use crate::fmt_md::MdOptions;
 use crate::fmt_md_inlines::MdInlinesWriterOptions;
+use crate::fmt_plain::PlainOutputOpts;
 use crate::output::{OutputOpts, Stream};
 use crate::select::{ParseError, SelectorAdapter};
 use crate::tree::{InvalidMd, MdDoc, ReadOptions};
@@ -152,7 +153,8 @@ where
                 .unwrap();
             }
             OutputFormat::Plain => {
-                fmt_plain::write_plain(&mut stdout, pipeline_nodes.into_iter());
+                let output_opts = PlainOutputOpts { include_breaks: cli.br };
+                fmt_plain::write_plain(&mut stdout, output_opts, pipeline_nodes.into_iter());
             }
         }
     }

--- a/src/utils_for_test.rs
+++ b/src/utils_for_test.rs
@@ -31,6 +31,7 @@ mod test_utils {
                     link_format: LinkTransform::default_for_tests(),
                     renumber_footnotes: false,
                 },
+                include_thematic_breaks: true,
             }
         }
 

--- a/tests/md_cases/output_format.toml
+++ b/tests/md_cases/output_format.toml
@@ -6,6 +6,10 @@ Test _one_ [two][1] three.
 some_markdown("rust");
 ```
 
+```bash
+echo 'some bash'
+```
+
 [1]: https://example.com/1
 '''
 
@@ -22,7 +26,39 @@ Test _one_ [two][1] three.
 some_markdown("rust");
 ```
 
+```bash
+echo 'some bash'
+```
+
 [1]: https://example.com/1
+'''
+
+[expect."default codes"]
+cli_args = ['--br=false', '```']
+output = '''
+```rust
+some_markdown("rust");
+```
+
+   -----
+
+```bash
+echo 'some bash'
+```
+'''
+
+
+
+[expect."codes with no breaks"]
+cli_args = ['--br=false', '```']
+output = '''
+```rust
+some_markdown("rust");
+```
+
+```bash
+echo 'some bash'
+```
 '''
 
 
@@ -35,7 +71,39 @@ Test _one_ [two][1] three.
 some_markdown("rust");
 ```
 
+```bash
+echo 'some bash'
+```
+
 [1]: https://example.com/1
+'''
+
+
+[expect."md codes"]
+cli_args = ['--output', 'md', '```']
+output = '''
+```rust
+some_markdown("rust");
+```
+
+   -----
+
+```bash
+echo 'some bash'
+```
+'''
+
+
+[expect."md with no breaks"]
+cli_args = ['--br=false', '--output', 'md', '```']
+output = '''
+```rust
+some_markdown("rust");
+```
+
+```bash
+echo 'some bash'
+```
 '''
 
 
@@ -48,7 +116,38 @@ Test _one_ [two][1] three.
 some_markdown("rust");
 ```
 
+```bash
+echo 'some bash'
+```
+
 [1]: https://example.com/1
+'''
+
+
+[expect."markdown codes"]
+cli_args = ['--output', 'markdown', '```']
+output = '''
+```rust
+some_markdown("rust");
+```
+
+   -----
+
+```bash
+echo 'some bash'
+```
+'''
+
+[expect."markdown with no breaks"]
+cli_args = ['--br=false', '--output', 'markdown', '```']
+output = '''
+```rust
+some_markdown("rust");
+```
+
+```bash
+echo 'some bash'
+```
 '''
 
 
@@ -69,6 +168,13 @@ output = '''
                     "language": "rust",
                     "type": "code"
                   }
+                },
+                {
+                  "code_block": {
+                    "code": "echo 'some bash'",
+                    "language": "bash",
+                    "type": "code"
+                  }
                 }
             ]
         }
@@ -85,6 +191,17 @@ output = '''
 cli_args = ['-o', 'plain']
 output = '''
 Test one two three.
+some_markdown("rust");
+echo 'some bash'
+'''
+
+[expect."plain with breaks"]
+cli_args = ['-o', 'plain', '--no-br']
+output = '''
+Test one two three.
 
 some_markdown("rust");
+
+echo 'some bash'
 '''
+

--- a/tests/md_cases/output_format.toml
+++ b/tests/md_cases/output_format.toml
@@ -34,7 +34,7 @@ echo 'some bash'
 '''
 
 [expect."default codes"]
-cli_args = ['--br=false', '```']
+cli_args = ['```']
 output = '''
 ```rust
 some_markdown("rust");
@@ -50,7 +50,7 @@ echo 'some bash'
 
 
 [expect."codes with no breaks"]
-cli_args = ['--br=false', '```']
+cli_args = ['--no-br', '```']
 output = '''
 ```rust
 some_markdown("rust");
@@ -95,7 +95,7 @@ echo 'some bash'
 
 
 [expect."md with no breaks"]
-cli_args = ['--br=false', '--output', 'md', '```']
+cli_args = ['--no-br', '--output', 'md', '```']
 output = '''
 ```rust
 some_markdown("rust");
@@ -139,7 +139,7 @@ echo 'some bash'
 '''
 
 [expect."markdown with no breaks"]
-cli_args = ['--br=false', '--output', 'markdown', '```']
+cli_args = ['--no-br', '--output', 'markdown', '```']
 output = '''
 ```rust
 some_markdown("rust");
@@ -196,7 +196,7 @@ echo 'some bash'
 '''
 
 [expect."plain with breaks"]
-cli_args = ['-o', 'plain', '--no-br']
+cli_args = ['-o', 'plain', '--br']
 output = '''
 Test one two three.
 


### PR DESCRIPTION
- In markdown output, this controls whether matched elements have thematic break ( `-----` ) between them. The default is yes, and `--no-br` turns that off.
- In plain output, this controls whether matched elements have a newline between them. The default is no, and `--br` turns it on.

This resolvse #270.