### PR TITLE
add end-to-end system tests

### DIFF
--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -35,12 +35,12 @@ jobs:
           set -euo pipefail
 
           test_failures=0
-          
+
           # Run each test toml file
           for test_file in tests/md_cases/*.toml; do
             ./scripts/system_test ./target/debug/mdq "$test_file" || test_failures=$((test_failures + 1))
           done
-          
+
           # Report any failures
           if [ "$test_failures" -ne 0 ]; then
             echo "::error title=failures::$test_failures test(s) failed"

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -9,8 +9,6 @@ on:
 jobs:
   toml-cases:
     runs-on: ubuntu-latest
-    outputs:
-      test-names: ${{ steps.find-tests.outputs.test-names }}
     steps:
 
       - uses: actions/cache@v4
@@ -24,7 +22,7 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Build mdq
         run: cargo build
@@ -35,7 +33,7 @@ jobs:
       - name: Run tests
         run: |
           set -euo pipefail
-          
+
           test_failures=0
           
           # Run each test toml file

--- a/.github/workflows/system-test.yml
+++ b/.github/workflows/system-test.yml
@@ -1,0 +1,50 @@
+name: System tests
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+  workflow_dispatch: { }
+
+jobs:
+  toml-cases:
+    runs-on: ubuntu-latest
+    outputs:
+      test-names: ${{ steps.find-tests.outputs.test-names }}
+    steps:
+
+      - uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Build mdq
+        run: cargo build
+
+      - name: Install toml2json
+        run: command -v toml2json || cargo install toml2json
+
+      - name: Run tests
+        run: |
+          set -euo pipefail
+          
+          test_failures=0
+          
+          # Run each test toml file
+          for test_file in tests/md_cases/*.toml; do
+            ./scripts/system_test ./target/debug/mdq "$test_file" || test_failures=$((test_failures + 1))
+          done
+          
+          # Report any failures
+          if [ "$test_failures" -ne 0 ]; then
+            echo "::error title=failures::$test_failures test(s) failed"
+            exit 1
+          fi

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,10 +1,119 @@
 set -euo pipefail
 
-function msg() {
-  echo >&2 "$@"
+group_level=0
+
+function echo_with_grouping() {
+  for _ in $(seq 1 "$group_level"); do
+    printf '  '
+  done
+  if [[ "${GITHUB_ACTIONS-}" ]]; then
+    echo "$@"
+  else
+    echo >&2 -e "$@"
+  fi
+}
+
+function group() {
+  local title="$1"
+  if [[ "${GITHUB_ACTIONS-}" ]]; then
+    echo "::group::$title"
+  else
+    echo_with_grouping "${title//[^a-zA-Z0-9 _\'\"]/ /}"
+    group_level="$((group_level + 1))"
+  fi
+}
+
+function end_group() {
+  if [[ "${GITHUB_ACTIONS-}" ]]; then
+    echo "::endgroup::"
+  else
+    group_level="$((group_level - 1))"
+  fi
+}
+
+function msg () {
+  case "$#" in
+    1)
+      local level=info
+      local title=''
+      local message="$1"
+      ;;
+    2)
+      local level=info
+      local title="$1"
+      local message="$2"
+      ;;
+    *)
+      local level="$1"
+      local title="$2"
+      local message="$3"
+      ;;
+  esac
+  if [[ "${GITHUB_ACTIONS-}" ]]; then
+    case "$level" in
+      debug)
+        echo "::debug::$title: ${message}"
+        ;;
+      notice|warning|error)
+        echo "::$level title=${title}::${message}"
+        ;;
+      *)
+        if [[ -n "$title" ]]; then
+          echo "$title: ${message}"
+        else
+          echo "${message}"
+        fi
+        ;;
+    esac
+  else
+    local color=''
+    local color_title_end=''
+    local after_title=''
+    case "$level" in
+      debug)
+        color='\e[37m'
+        ;;
+      notice)
+        color='\e[34m'
+        color_title_end='\e[0m'
+        ;;
+      warning)
+        color='\e[33m'
+        color_title_end='\e[0m'
+        ;;
+      error)
+        color='\e[31m'
+        color_title_end='\e[0m'
+        ;;
+      *)
+        color='\e[0m'
+        ;;
+    esac
+    if [[ -n "$title" ]]; then
+      after_title=': '
+    fi
+
+    echo_with_grouping "${color}${title}${color_title_end}${after_title}${message}\e[0m"
+  fi
+}
+
+function msg_debug() {
+  msg debug "$@"
+}
+
+function msg_info() {
+  msg notice "$@"
 }
 
 function err() {
   msg "$@"
   exit 1
 }
+
+function require_tool() {
+  local tool="$1"
+  command -v "$tool" &>/dev/null || {
+    err 'missing software' "$tool"
+  }
+}
+

--- a/scripts/system_test
+++ b/scripts/system_test
@@ -1,0 +1,120 @@
+#!/bin/bash
+set -euo pipefail
+
+source "$(dirname "$0")/common.sh" || exit 1
+
+require_tool jq
+require_tool toml2json
+
+usage_string="Usage: $0 <mdq executable> <path to toml test> [test case grep pattern]"
+if [[ "$#" -lt 2 ]]; then
+  err 'too few args' "$usage_string"
+fi
+if [[ "$#" -gt 3 ]]; then
+  err 'too many args' "$usage_string"
+fi
+
+mdq="$1"
+test_file="$2"
+pattern="${3:-.*}"
+
+msg debug mdq "$mdq"
+msg debug test_file "$test_file"
+msg debug pattern "$pattern"
+
+if [[ -x "$mdq" ]]; then
+  mdq="$(readlink -f "$mdq")"
+  msg debug 'mdq full path' "$mdq"
+  msg debug "mdq version" "$("$mdq" --version)"
+else
+  err 'not executable' "$mdq"
+fi
+
+test_json="$(<"$test_file" toml2json)"
+
+function nice_diff() {
+  local title="$1"
+  local expected="$2"
+  local actual="$3"
+  if diff --strip-trailing-cr "$expected" "$actual" &>/dev/null ; then
+    msg debug "$title" "diff succeeded"
+  else
+    msg error "$title" "diff failed"
+    diff --color=always --strip-trailing-cr -y <(cat <(echo EXPECTED) "$expected") <(cat <(echo ACTUAL) "$actual")
+    return 1
+  fi
+}
+
+format_file_json() {
+  local file="$1"
+  local as_json
+  if as_json="$(jq -S . <(cat "$file"))"; then
+    echo "$as_json" > "$file"
+  fi
+}
+
+function run_test_spec() {
+  local spec="$1"
+  local spec_name
+  spec_name="$(jq -r '.name' <<<"$spec")"
+  full_name="$test_file > $spec_name"
+
+  (
+    local stdin
+    pushd "$(mktemp -d)"
+
+    if jq -e '.expect.ignore' <<<"$spec" &>/dev/null ; then
+      msg warning "$full_name" 'skipping test case'
+      return 0
+    fi
+
+    jq -j '.expect.output' <<<"$spec" >expect_out.txt
+    jq -j '.expect.output_err // ""' <<<"$spec" >expect_err.txt
+    expect_success="$(jq -r '.expect.expect_success | if . == null then true else . end' <<<"$spec")"
+    output_json="$(jq -r '.expect.output_json // false' <<<"$spec")"
+
+    stdin="$(jq -r '.given.md' <<<"$spec")"
+    cli_args=()
+    while read -r cli_arg ; do
+      cli_args+=("$cli_arg")
+    done <<<"$(jq -r '.expect.cli_args[]' <<<"$spec")"
+
+    local actual_success=true
+    set -x
+    "$mdq" <<<"$stdin" "${cli_args[@]}" >actual_out.txt 2>actual_err.txt || actual_success=false
+    set +x
+
+    if [[ "$output_json" == true ]]; then
+      for file in actual_out.txt actual_err.txt expect_out.txt expect_err.txt ; do
+        format_file_json "$file"
+      done
+    fi
+
+    local any_errors=()
+    nice_diff "$full_name: stdout" expect_out.txt actual_out.txt || any_errors+=('stdout')
+    nice_diff "$full_name: stderr" expect_err.txt actual_err.txt || any_errors+=('stderr')
+    [[ "$expect_success" == "$actual_success" ]] || any_errors+=('exit code')
+
+    if [[ "${#any_errors[@]}" -eq 0 ]]; then
+      msg notice "$full_name" 'test passed'
+    else
+      msg error "$full_name" "test failed due to ${any_errors[*]}"
+      exit 1
+    fi
+  )
+}
+
+failures=0
+while read -r test_case ; do
+  if ! grep -qE "$pattern" <<<"$test_case"; then
+    msg debug 'skipping test case' "$test_case"
+    continue
+  fi
+  group "$test_file > $test_case"
+  run_test_spec \
+    "$(jq '{name: $test_case, given: .given, expect: .expect[$test_case]}' <<<"$test_json" --arg test_case "$test_case")" \
+    || failures=$((failures + 1))
+  end_group
+done <<<"$(jq -r '.expect| keys[]' <<<"$test_json")"
+
+[[ "$failures" -eq 0 ]]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -85,7 +85,7 @@ pub fn run_stdio(cli: &Cli) -> bool {
     let mut contents = String::new();
     stdin().read_to_string(&mut contents).expect("invalid input (not utf8)");
     run(&cli, contents, || io::stdout().lock()).unwrap_or_else(|err| {
-        eprintln!("{err}");
+        eprint!("{err}");
         false
     })
 }


### PR DESCRIPTION
These are driven by the same toml files as the in-memory integ tests, but work against a real binary, via shell. This is in preparation for #275, where I'll want to be a bit trickier with inputs.