### PR TITLE
unify the two IO implementations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -133,7 +133,7 @@ pub trait OsFacade {
     }
 }
 
-pub fn run_generic(cli: &Cli, os: &mut impl OsFacade) -> bool {
+pub fn run(cli: &Cli, os: &mut impl OsFacade) -> bool {
     if !cli.extra_validation() {
         return false;
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,7 @@ impl OsFacade for RealOs {
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    if mdq::run_generic(&cli, &mut RealOs) {
+    if mdq::run(&cli, &mut RealOs) {
         ExitCode::SUCCESS
     } else {
         ExitCode::FAILURE

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,8 @@
 use clap::Parser;
 use mdq::cli::Cli;
-use mdq::{run_stdio, OsFacade};
+use mdq::{Error, OsFacade};
 use std::io;
-use std::io::{stdin, Read};
+use std::io::{stdin, stdout, Read};
 use std::process::ExitCode;
 
 struct RealOs;
@@ -17,12 +17,20 @@ impl OsFacade for RealOs {
     fn read_file(&self, path: &str) -> io::Result<String> {
         std::fs::read_to_string(path)
     }
+
+    fn get_stdout(&mut self) -> impl io::Write {
+        stdout().lock()
+    }
+
+    fn write_error(&mut self, err: Error) {
+        eprint!("{err}")
+    }
 }
 
 fn main() -> ExitCode {
     let cli = Cli::parse();
 
-    if run_stdio(&cli, RealOs) {
+    if mdq::run_generic(&cli, &mut RealOs) {
         ExitCode::SUCCESS
     } else {
         ExitCode::FAILURE

--- a/tests/integ_test.rs
+++ b/tests/integ_test.rs
@@ -72,7 +72,7 @@ impl<const N: usize> Case<N> {
             stdout: vec![],
             stderr: "".to_string(),
         };
-        let result = mdq::run_generic(&cli, &mut runner);
+        let result = mdq::run(&cli, &mut runner);
 
         let out_str =
             String::from_utf8(runner.stdout).unwrap_or_else(|err| String::from_utf8_lossy(err.as_bytes()).into_owned());


### PR DESCRIPTION
Add stdout and Error handling to OsFacade. This lets us unify the two previous implementations (`run_stdio` and `run_in_memory`).

In service of #213.