### PR TITLE
remove SelectorChain struct

### DIFF
--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -373,6 +373,12 @@ pub mod elem {
             MdElem::Inline(Inline::Link(value))
         }
     }
+
+    impl From<Vec<MdElem>> for MdElem {
+        fn from(elems: Vec<MdElem>) -> Self {
+            Self::Doc(elems)
+        }
+    }
 }
 
 /// Defines all the mdx nodes as match arms. This let us easily mark them as ignored, and in particular makes it so that

--- a/src/query/selector_try_from.rs
+++ b/src/query/selector_try_from.rs
@@ -26,7 +26,7 @@ impl TryFrom<Pairs<'_>> for Selector {
             }
         }
         Ok(match selectors.len() {
-            0 => selectors.into_iter().next().unwrap(),
+            1 => selectors.into_iter().next().unwrap(),
             _ => Self::Chain(selectors),
         })
     }

--- a/src/query/selector_try_from.rs
+++ b/src/query/selector_try_from.rs
@@ -222,13 +222,13 @@ mod tests {
         fn useful_chaining() {
             find_selectors(
                 "# | []()",
-                vec![
+                Selector::Chain(vec![
                     Selector::Section(Matcher::Any(AnyVariant::Implicit)),
                     Selector::Link(LinklikeMatcher {
                         display_matcher: Matcher::Any(AnyVariant::Implicit),
                         url_matcher: Matcher::Any(AnyVariant::Implicit),
                     }),
-                ],
+                ]),
             );
         }
 
@@ -236,13 +236,13 @@ mod tests {
         fn empty_intermediate_chains() {
             find_selectors(
                 "# || | []()",
-                vec![
+                Selector::Chain(vec![
                     Selector::Section(Matcher::Any(AnyVariant::Implicit)),
                     Selector::Link(LinklikeMatcher {
                         display_matcher: Matcher::Any(AnyVariant::Implicit),
                         url_matcher: Matcher::Any(AnyVariant::Implicit),
                     }),
-                ],
+                ]),
             );
         }
     }
@@ -731,14 +731,14 @@ mod tests {
     }
 
     fn find_empty_chain(query_text: &str) {
-        find_selectors(query_text, vec![]);
+        find_selectors(query_text, Selector::Chain(Vec::new()));
     }
 
     fn find_selector(query_text: &str, expect: Selector) {
-        find_selectors(query_text, vec![expect])
+        find_selectors(query_text, expect)
     }
 
-    fn find_selectors(query_text: &str, expect: Vec<Selector>) {
+    fn find_selectors(query_text: &str, expect: Selector) {
         let pairs = Query::parse(query_text);
         let pairs = match pairs {
             Ok(pairs) => pairs,
@@ -748,7 +748,7 @@ mod tests {
         };
 
         let result = Selector::try_from(pairs);
-        assert_eq!(result, Ok(Selector::Chain(expect)));
+        assert_eq!(result, Ok(expect));
     }
 
     fn expect_parse_error(query_text: &str, expect: &str) {

--- a/src/query/selector_try_from.rs
+++ b/src/query/selector_try_from.rs
@@ -6,34 +6,36 @@ use crate::query::traversal_composites::{
 };
 use crate::query::{DetachedSpan, Pair, Pairs, ParseError, Query};
 use crate::select::{
-    AnyVariant, CodeBlockMatcher, LinklikeMatcher, ListItemMatcher, ListItemTask, Matcher, Selector, SelectorChain,
-    TableMatcher,
+    AnyVariant, CodeBlockMatcher, LinklikeMatcher, ListItemMatcher, ListItemTask, Matcher, Selector, TableMatcher,
 };
 
-impl TryFrom<Pairs<'_>> for SelectorChain {
+impl TryFrom<Pairs<'_>> for Selector {
     type Error = ParseError;
 
     fn try_from(root: Pairs) -> Result<Self, Self::Error> {
         // Get "all" the selector chains; there should be at most 1.
         let selector_chains = ByRule::new(Rule::selector_chain).find_all_in(root);
-        let mut selectors: Vec<Selector> = Vec::new();
+        let mut selectors: Vec<Self> = Vec::new();
         for chain in selector_chains {
             // within the chain, get the selectors; for each one, get its inners (there should be exactly one) and get
             // its selector.
             let selector_inners = ByRule::new(Rule::selector).find_all_in(chain.into_inner());
             for selector_pair in selector_inners {
-                let selector = Selector::find_selector(selector_pair)?;
+                let selector = Self::find_selector(selector_pair)?;
                 selectors.push(selector);
             }
         }
-        Ok(Self { selectors })
+        Ok(match selectors.len() {
+            0 => selectors.into_iter().next().unwrap(),
+            _ => Self::Chain(selectors),
+        })
     }
 }
 
 impl Selector {
-    pub fn try_parse(value: &'_ str) -> Result<SelectorChain, ParseError> {
+    pub(crate) fn try_parse(value: &'_ str) -> Result<Self, ParseError> {
         let parsed: Pairs = Query::parse(value).map_err(|err| ParseError::from(err))?;
-        let parsed_selectors = SelectorChain::try_from(parsed).map_err(|e| ParseError::from(e))?;
+        let parsed_selectors = Selector::try_from(parsed).map_err(|e| ParseError::from(e))?;
         Ok(parsed_selectors)
     }
 
@@ -745,15 +747,15 @@ mod tests {
             }
         };
 
-        let result = SelectorChain::try_from(pairs);
-        assert_eq!(result, Ok(SelectorChain { selectors: expect }));
+        let result = Selector::try_from(pairs);
+        assert_eq!(result, Ok(Selector::Chain(expect)));
     }
 
     fn expect_parse_error(query_text: &str, expect: &str) {
         let pairs = Query::parse(query_text);
         let err_msg = match pairs {
-            Ok(pairs) => match SelectorChain::try_from(pairs) {
-                Ok(SelectorChain { selectors }) => panic!("{selectors:?}"),
+            Ok(pairs) => match Selector::try_from(pairs) {
+                Ok(selector) => panic!("{selector:?}"),
                 Err(ParseError::Pest(err)) => format!("{err}"),
                 Err(ParseError::Other(span, message)) => {
                     let error = Error::new_from_span(

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -15,7 +15,7 @@ use paste::paste;
 use std::collections::HashSet;
 
 pub trait TrySelector<I: Into<MdElem>> {
-    fn try_select(&self, ctx: &MdContext, item: I) -> Result<MdElem, MdElem>;
+    fn try_select(&self, ctx: &MdContext, item: I) -> Result<Vec<MdElem>, MdElem>;
 }
 
 macro_rules! adapters {
@@ -45,7 +45,7 @@ macro_rules! adapters {
         }
 
         impl SelectorAdapter {
-            fn try_select_node<'md>(&self, ctx: &MdContext, node: MdElem) -> Result<MdElem, MdElem> {
+            fn try_select_node<'md>(&self, ctx: &MdContext, node: MdElem) -> Result<Vec<MdElem>, MdElem> {
                 match (&self, node) {
                     $(
                     (Self::$name(adapter), MdElem::$md_elem(elem)) => adapter.try_select(ctx, elem),
@@ -87,8 +87,7 @@ impl SelectorAdapter {
 
     fn build_output<'md>(&self, out: &mut Vec<MdElem>, ctx: &mut SearchContext<'md>, node: MdElem) {
         match self.try_select_node(&ctx.md_context, node) {
-            Ok(MdElem::Doc(mut multi)) => out.append(&mut multi),
-            Ok(found) => out.push(found),
+            Ok(mut found) => out.append(&mut found),
             Err(not_found) => {
                 for child in Self::find_children(ctx, not_found) {
                     self.build_output(out, ctx, child);

--- a/src/select/match_selector.rs
+++ b/src/select/match_selector.rs
@@ -12,7 +12,7 @@ where
     I: Into<MdElem>,
     M: MatchSelector<I>,
 {
-    fn try_select(&self, item: I) -> Result<MdElem, MdElem> {
+    fn try_select(&self, _: &MdContext, item: I) -> Result<MdElem, MdElem> {
         if self.matches(&item) {
             Ok(item.into())
         } else {

--- a/src/select/match_selector.rs
+++ b/src/select/match_selector.rs
@@ -12,9 +12,9 @@ where
     I: Into<MdElem>,
     M: MatchSelector<I>,
 {
-    fn try_select(&self, _: &MdContext, item: I) -> Result<MdElem, MdElem> {
+    fn try_select(&self, _: &MdContext, item: I) -> Result<Vec<MdElem>, MdElem> {
         if self.matches(&item) {
-            Ok(item.into())
+            Ok(vec![item.into()])
         } else {
             Err(item.into())
         }

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -1,6 +1,7 @@
 mod api;
 mod match_selector;
 mod matcher;
+mod sel_chain;
 mod sel_code_block;
 mod sel_link_like;
 mod sel_list_item;

--- a/src/select/sel_chain.rs
+++ b/src/select/sel_chain.rs
@@ -15,10 +15,16 @@ impl From<Vec<Selector>> for ChainSelector {
 }
 
 impl TrySelector<Vec<MdElem>> for ChainSelector {
-    fn try_select(&self, ctx: &MdContext, mut items: Vec<MdElem>) -> Result<MdElem, MdElem> {
+    fn try_select(&self, ctx: &MdContext, mut items: Vec<MdElem>) -> Result<Vec<MdElem>, MdElem> {
+        if self.chain.is_empty() {
+            // This is a bit of a hack: an empty chain is really a noop, and in this case we assume that the items
+            // aren't actually a stream, but are actually an MdDoc that has been deconstructed into the Vec<MdElem>.
+            // So, just reconstruct it back.
+            return Ok(vec![MdElem::Doc(items)]);
+        }
         for adapter in &self.chain {
             items = adapter.find_nodes(ctx, items);
         }
-        Ok(MdElem::Doc(items))
+        Ok(items)
     }
 }

--- a/src/select/sel_chain.rs
+++ b/src/select/sel_chain.rs
@@ -1,4 +1,4 @@
-use crate::md_elem::MdElem;
+use crate::md_elem::{MdContext, MdElem};
 use crate::select::{Selector, SelectorAdapter, TrySelector};
 
 #[derive(Debug)]
@@ -15,7 +15,10 @@ impl From<Vec<Selector>> for ChainSelector {
 }
 
 impl TrySelector<Vec<MdElem>> for ChainSelector {
-    fn try_select(&self, item: Vec<MdElem>) -> Result<MdElem, MdElem> {
-        todo!("there isn't really any good implementation here")
+    fn try_select(&self, ctx: &MdContext, mut items: Vec<MdElem>) -> Result<MdElem, MdElem> {
+        for adapter in &self.chain {
+            items = adapter.find_nodes(ctx, items);
+        }
+        Ok(MdElem::Doc(items))
     }
 }

--- a/src/select/sel_chain.rs
+++ b/src/select/sel_chain.rs
@@ -1,0 +1,21 @@
+use crate::md_elem::MdElem;
+use crate::select::{Selector, SelectorAdapter, TrySelector};
+
+#[derive(Debug)]
+pub struct ChainSelector {
+    chain: Vec<SelectorAdapter>,
+}
+
+impl From<Vec<Selector>> for ChainSelector {
+    fn from(chain: Vec<Selector>) -> Self {
+        Self {
+            chain: chain.into_iter().map(|s| s.into()).collect(),
+        }
+    }
+}
+
+impl TrySelector<Vec<MdElem>> for ChainSelector {
+    fn try_select(&self, item: Vec<MdElem>) -> Result<MdElem, MdElem> {
+        todo!("there isn't really any good implementation here")
+    }
+}

--- a/src/select/sel_list_item.rs
+++ b/src/select/sel_list_item.rs
@@ -1,5 +1,5 @@
 use crate::md_elem::elem::List;
-use crate::md_elem::MdElem;
+use crate::md_elem::{MdContext, MdElem};
 use crate::select::string_matcher::StringMatcher;
 use crate::select::{ListItemMatcher, ListItemTask, TrySelector};
 
@@ -40,7 +40,7 @@ fn task_matches(matcher: ListItemTask, md_is_checked: Option<bool>) -> bool {
 }
 
 impl TrySelector<List> for ListItemSelector {
-    fn try_select(&self, item: List) -> Result<MdElem, MdElem> {
+    fn try_select(&self, _: &MdContext, item: List) -> Result<MdElem, MdElem> {
         // This one works a bit differently than most:
         // - If the item has a single list, check it; this is essentially a recursive base case.
         // - Otherwise, never match, but return an MdElem::Doc of the list items, each as its own list.

--- a/src/select/sel_list_item.rs
+++ b/src/select/sel_list_item.rs
@@ -40,7 +40,7 @@ fn task_matches(matcher: ListItemTask, md_is_checked: Option<bool>) -> bool {
 }
 
 impl TrySelector<List> for ListItemSelector {
-    fn try_select(&self, _: &MdContext, item: List) -> Result<MdElem, MdElem> {
+    fn try_select(&self, _: &MdContext, item: List) -> Result<Vec<MdElem>, MdElem> {
         // This one works a bit differently than most:
         // - If the item has a single list, check it; this is essentially a recursive base case.
         // - Otherwise, never match, but return an MdElem::Doc of the list items, each as its own list.
@@ -54,7 +54,7 @@ impl TrySelector<List> for ListItemSelector {
                     && self.string_matcher.matches_any(&li.item);
                 let list = MdElem::List(List { starting_index, items });
                 if matched {
-                    Ok(list)
+                    Ok(vec![list])
                 } else {
                     Err(list)
                 }

--- a/src/select/sel_table.rs
+++ b/src/select/sel_table.rs
@@ -10,7 +10,7 @@ pub struct TableSelector {
 }
 
 impl TrySelector<Table> for TableSelector {
-    fn try_select(&self, orig: Table) -> Result<MdElem, MdElem> {
+    fn try_select(&self, _: &MdContext, orig: Table) -> Result<MdElem, MdElem> {
         let mut table = orig.clone();
 
         table.normalize();
@@ -59,7 +59,7 @@ mod tests {
             headers_matcher: ".*".into(),
             rows_matcher: ".*".into(),
         }
-        .try_select(table);
+        .try_select(&MdContext::empty(), table);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
         assert_eq!(
@@ -88,7 +88,7 @@ mod tests {
             headers_matcher: "KEEP".into(),
             rows_matcher: ".*".into(),
         }
-        .try_select(table);
+        .try_select(&MdContext::empty(), table);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
         assert_eq!(table.alignments(), &vec![mdast::AlignKind::Right]);
@@ -109,7 +109,7 @@ mod tests {
             headers_matcher: ".*".into(),
             rows_matcher: "data 2".into(),
         }
-        .try_select(table);
+        .try_select(&MdContext::empty(), table);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
         assert_eq!(
@@ -143,7 +143,7 @@ mod tests {
             headers_matcher: ".*".into(),
             rows_matcher: "data 1".into(),
         }
-        .try_select(table);
+        .try_select(&MdContext::empty(), table);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
         assert_eq!(

--- a/src/select/sel_table.rs
+++ b/src/select/sel_table.rs
@@ -10,7 +10,7 @@ pub struct TableSelector {
 }
 
 impl TrySelector<Table> for TableSelector {
-    fn try_select(&self, _: &MdContext, orig: Table) -> Result<MdElem, MdElem> {
+    fn try_select(&self, _: &MdContext, orig: Table) -> Result<Vec<MdElem>, MdElem> {
         let mut table = orig.clone();
 
         table.normalize();
@@ -24,7 +24,7 @@ impl TrySelector<Table> for TableSelector {
         if table.is_empty() {
             return Err(orig.into());
         }
-        Ok(table.into())
+        Ok(vec![table.into()])
     }
 }
 
@@ -59,7 +59,8 @@ mod tests {
             headers_matcher: ".*".into(),
             rows_matcher: ".*".into(),
         }
-        .try_select(&MdContext::empty(), table);
+        .try_select(&MdContext::empty(), table)
+        .map(get_only);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
         assert_eq!(
@@ -88,7 +89,8 @@ mod tests {
             headers_matcher: "KEEP".into(),
             rows_matcher: ".*".into(),
         }
-        .try_select(&MdContext::empty(), table);
+        .try_select(&MdContext::empty(), table)
+        .map(get_only);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
         assert_eq!(table.alignments(), &vec![mdast::AlignKind::Right]);
@@ -109,7 +111,8 @@ mod tests {
             headers_matcher: ".*".into(),
             rows_matcher: "data 2".into(),
         }
-        .try_select(&MdContext::empty(), table);
+        .try_select(&MdContext::empty(), table)
+        .map(get_only);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
         assert_eq!(
@@ -143,7 +146,8 @@ mod tests {
             headers_matcher: ".*".into(),
             rows_matcher: "data 1".into(),
         }
-        .try_select(&MdContext::empty(), table);
+        .try_select(&MdContext::empty(), table)
+        .map(get_only);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
         assert_eq!(

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -35,13 +35,8 @@ pub struct TableMatcher {
 }
 
 #[derive(Eq, PartialEq, Debug)]
-pub struct SelectorChain {
-    // #315 make this be a Selector variant
-    pub selectors: Vec<Selector>,
-}
-
-#[derive(Eq, PartialEq, Debug)]
 pub enum Selector {
+    Chain(Vec<Self>),
     Section(Matcher),
     ListItem(ListItemMatcher),
     Link(LinklikeMatcher),
@@ -53,7 +48,7 @@ pub enum Selector {
     Table(TableMatcher),
 }
 
-impl TryFrom<&'_ str> for SelectorChain {
+impl TryFrom<&'_ str> for Selector {
     type Error = ParseError;
 
     fn try_from(value: &'_ str) -> Result<Self, Self::Error> {
@@ -61,7 +56,7 @@ impl TryFrom<&'_ str> for SelectorChain {
     }
 }
 
-impl TryFrom<&'_ String> for SelectorChain {
+impl TryFrom<&'_ String> for Selector {
     type Error = ParseError;
 
     fn try_from(value: &'_ String) -> Result<Self, Self::Error> {


### PR DESCRIPTION
Instead of having a separate SelectorChain, create a new variant Selector::Chain.

The SelectorChain struct had a slightly different contract than Selectors: it worked on a stream of MdElem (rather than just a 1:1 mapping), and essentially flatmapped it, with the extra caveat that an empty chain on an MdDoc would not flatmap, but just return the MdDoc directly. This has now been encoded into ChainSelector::try_select.

resolves #315