### PR TITLE
remove public exposing of mdast::AlignKind

### DIFF
--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -320,35 +320,6 @@ pub mod elem {
         Center,
     }
 
-    impl From<std::fmt::Alignment> for ColumnAlignment {
-        fn from(value: std::fmt::Alignment) -> Self {
-            match value {
-                std::fmt::Alignment::Left => Self::Left,
-                std::fmt::Alignment::Right => Self::Right,
-                std::fmt::Alignment::Center => Self::Center,
-            }
-        }
-    }
-
-    impl From<ColumnAlignment> for std::fmt::Alignment {
-        fn from(value: ColumnAlignment) -> Self {
-            match value {
-                ColumnAlignment::Left => Self::Left,
-                ColumnAlignment::Right => Self::Right,
-                ColumnAlignment::Center => Self::Center,
-            }
-        }
-    }
-
-    pub fn convert_alignment(a: mdast::AlignKind) -> Option<ColumnAlignment> {
-        match a {
-            mdast::AlignKind::Left => Some(ColumnAlignment::Left),
-            mdast::AlignKind::Right => Some(ColumnAlignment::Right),
-            mdast::AlignKind::Center => Some(ColumnAlignment::Center),
-            mdast::AlignKind::None => None,
-        }
-    }
-
     #[derive(Debug, PartialEq, Clone)]
     pub struct CodeBlock {
         pub variant: CodeVariant,
@@ -609,7 +580,7 @@ impl MdElem {
                     rows.push(column);
                 }
                 m_node!(MdElem::Table {
-                    alignments: align.into_iter().map(convert_alignment).collect(),
+                    alignments: align.into_iter().map(Self::convert_alignment).collect(),
                     rows,
                 })
             }
@@ -638,6 +609,15 @@ impl MdElem {
             }
         };
         Ok(vec![result])
+    }
+
+    fn convert_alignment(a: mdast::AlignKind) -> Option<ColumnAlignment> {
+        match a {
+            mdast::AlignKind::Left => Some(ColumnAlignment::Left),
+            mdast::AlignKind::Right => Some(ColumnAlignment::Right),
+            mdast::AlignKind::Center => Some(ColumnAlignment::Center),
+            mdast::AlignKind::None => None,
+        }
     }
 
     fn all(

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -320,6 +320,26 @@ pub mod elem {
         Center,
     }
 
+    impl From<std::fmt::Alignment> for ColumnAlignment {
+        fn from(value: std::fmt::Alignment) -> Self {
+            match value {
+                std::fmt::Alignment::Left => Self::Left,
+                std::fmt::Alignment::Right => Self::Right,
+                std::fmt::Alignment::Center => Self::Center,
+            }
+        }
+    }
+
+    impl From<ColumnAlignment> for std::fmt::Alignment {
+        fn from(value: ColumnAlignment) -> Self {
+            match value {
+                ColumnAlignment::Left => Self::Left,
+                ColumnAlignment::Right => Self::Right,
+                ColumnAlignment::Center => Self::Center,
+            }
+        }
+    }
+
     pub fn convert_alignment(a: mdast::AlignKind) -> Option<ColumnAlignment> {
         match a {
             mdast::AlignKind::Left => Some(ColumnAlignment::Left),

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -309,8 +309,27 @@ pub mod elem {
 
     #[derive(Debug, PartialEq, Clone)]
     pub struct Table {
-        pub alignments: Vec<mdast::AlignKind>,
+        pub alignments: Vec<TableColumnAlignment>,
         pub rows: Vec<TableRow>,
+    }
+
+    #[derive(Debug, PartialEq, Clone, Copy)]
+    pub enum TableColumnAlignment {
+        Left,
+        Right,
+        Center,
+        None,
+    }
+
+    impl From<mdast::AlignKind> for TableColumnAlignment {
+        fn from(value: mdast::AlignKind) -> Self {
+            match value {
+                mdast::AlignKind::Left => Self::Left,
+                mdast::AlignKind::Right => Self::Right,
+                mdast::AlignKind::Center => Self::Center,
+                mdast::AlignKind::None => Self::None,
+            }
+        }
     }
 
     #[derive(Debug, PartialEq, Clone)]
@@ -573,7 +592,7 @@ impl MdElem {
                     rows.push(column);
                 }
                 m_node!(MdElem::Table {
-                    alignments: align,
+                    alignments: align.into_iter().map(|a| a.into()).collect(),
                     rows,
                 })
             }
@@ -1969,7 +1988,7 @@ mod tests {
             );
             assert_eq!(root.children.len(), 1);
             check!(&root.children[0], Node::Table(table_node), lookups => m_node!(MdElem::Table{alignments, rows}) = {
-                assert_eq!(alignments, vec![mdast::AlignKind::Left, mdast::AlignKind::Center, mdast::AlignKind::Right, mdast::AlignKind::None]);
+                assert_eq!(alignments, vec![TableColumnAlignment::Left, TableColumnAlignment::Center, TableColumnAlignment::Right, TableColumnAlignment::None]);
                 assert_eq!(rows,
                     vec![ // rows
                         vec![// Header row
@@ -2009,7 +2028,7 @@ mod tests {
             );
             assert_eq!(root.children.len(), 1);
             check!(&root.children[0], Node::Table(_), lookups => m_node!(MdElem::Table{alignments, rows}) = {
-                assert_eq!(alignments, vec![mdast::AlignKind::Left, mdast::AlignKind::Right]);
+                assert_eq!(alignments, vec![TableColumnAlignment::Left, TableColumnAlignment::Right]);
                 assert_eq!(rows,
                     vec![ // rows
                         vec![// Header row

--- a/src/md_elem/tree_ref.rs
+++ b/src/md_elem/tree_ref.rs
@@ -6,7 +6,7 @@ mod elem_ref {
     use crate::util::vec_utils::IndexKeeper;
 
     impl Table {
-        pub fn alignments(&self) -> &Vec<TableColumnAlignment> {
+        pub fn alignments(&self) -> &[Option<ColumnAlignment>] {
             &self.alignments
         }
 
@@ -32,10 +32,7 @@ mod elem_ref {
             if self.alignments.len() > max_cols {
                 self.alignments.truncate(max_cols);
             } else {
-                let nones = [TableColumnAlignment::None]
-                    .iter()
-                    .cycle()
-                    .take(max_cols - self.alignments.len());
+                let nones = [None].iter().cycle().take(max_cols - self.alignments.len());
                 self.alignments.extend(nones);
             }
         }
@@ -99,7 +96,6 @@ mod tests {
 
     mod tables {
         use super::*;
-        use std::fmt::Alignment;
 
         #[test]
         fn retain_col() {
@@ -112,7 +108,7 @@ mod tests {
 
             // note: "KEEPER" is in the last column, but not in the header; only the header gets
             // matched.
-            assert_eq!(table.alignments, vec![Some(Alignment::Left)]);
+            assert_eq!(table.alignments, vec![Some(ColumnAlignment::Left)]);
             assert_eq!(
                 table.rows,
                 vec![vec![cell("KEEPER a")], vec![cell("data 1 a")], vec![cell("data 2 a")],]
@@ -137,7 +133,7 @@ mod tests {
             // normalization
             assert_eq!(
                 table.alignments,
-                vec![Some(Alignment::Left), Some(Alignment::Right), None]
+                vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right), None]
             );
             assert_eq!(
                 table.rows,
@@ -164,7 +160,11 @@ mod tests {
 
             assert_eq!(
                 table.alignments,
-                vec![Some(Alignment::Left), Some(Alignment::Right), Some(Alignment::Center),]
+                vec![
+                    Some(ColumnAlignment::Left),
+                    Some(ColumnAlignment::Right),
+                    Some(ColumnAlignment::Center),
+                ]
             );
             // note: header row always gets kept
             assert_eq!(
@@ -197,7 +197,7 @@ mod tests {
             // normalization
             assert_eq!(
                 table.alignments,
-                vec![Some(Alignment::Left), Some(Alignment::Right), None]
+                vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right), None]
             );
             assert_eq!(
                 table.rows,
@@ -238,12 +238,16 @@ mod tests {
             };
 
             // for alignments, just cycle [L, R, C].
-            let alignments = [Some(Alignment::Left), Some(Alignment::Right), Some(Alignment::Center)]
-                .iter()
-                .cycle()
-                .take(first_row.len())
-                .map(ToOwned::to_owned)
-                .collect();
+            let alignments = [
+                Some(ColumnAlignment::Left),
+                Some(ColumnAlignment::Right),
+                Some(ColumnAlignment::Center),
+            ]
+            .iter()
+            .cycle()
+            .take(first_row.len())
+            .map(ToOwned::to_owned)
+            .collect();
             let mut rows = Vec::with_capacity(cells.len());
 
             while let Some(row_strings) = rows_iter.next() {

--- a/src/md_elem/tree_ref.rs
+++ b/src/md_elem/tree_ref.rs
@@ -99,6 +99,7 @@ mod tests {
 
     mod tables {
         use super::*;
+        use std::fmt::Alignment;
 
         #[test]
         fn retain_col() {
@@ -111,7 +112,7 @@ mod tests {
 
             // note: "KEEPER" is in the last column, but not in the header; only the header gets
             // matched.
-            assert_eq!(table.alignments, vec![TableColumnAlignment::Left]);
+            assert_eq!(table.alignments, vec![Some(Alignment::Left)]);
             assert_eq!(
                 table.rows,
                 vec![vec![cell("KEEPER a")], vec![cell("data 1 a")], vec![cell("data 2 a")],]
@@ -136,11 +137,7 @@ mod tests {
             // normalization
             assert_eq!(
                 table.alignments,
-                vec![
-                    TableColumnAlignment::Left,
-                    TableColumnAlignment::Right,
-                    TableColumnAlignment::None
-                ]
+                vec![Some(Alignment::Left), Some(Alignment::Right), None]
             );
             assert_eq!(
                 table.rows,
@@ -167,11 +164,7 @@ mod tests {
 
             assert_eq!(
                 table.alignments,
-                vec![
-                    TableColumnAlignment::Left,
-                    TableColumnAlignment::Right,
-                    TableColumnAlignment::Center,
-                ]
+                vec![Some(Alignment::Left), Some(Alignment::Right), Some(Alignment::Center),]
             );
             // note: header row always gets kept
             assert_eq!(
@@ -204,11 +197,7 @@ mod tests {
             // normalization
             assert_eq!(
                 table.alignments,
-                vec![
-                    TableColumnAlignment::Left,
-                    TableColumnAlignment::Right,
-                    TableColumnAlignment::None
-                ]
+                vec![Some(Alignment::Left), Some(Alignment::Right), None]
             );
             assert_eq!(
                 table.rows,
@@ -249,16 +238,12 @@ mod tests {
             };
 
             // for alignments, just cycle [L, R, C].
-            let alignments = [
-                TableColumnAlignment::Left,
-                TableColumnAlignment::Right,
-                TableColumnAlignment::Center,
-            ]
-            .iter()
-            .cycle()
-            .take(first_row.len())
-            .map(ToOwned::to_owned)
-            .collect();
+            let alignments = [Some(Alignment::Left), Some(Alignment::Right), Some(Alignment::Center)]
+                .iter()
+                .cycle()
+                .take(first_row.len())
+                .map(ToOwned::to_owned)
+                .collect();
             let mut rows = Vec::with_capacity(cells.len());
 
             while let Some(row_strings) = rows_iter.next() {

--- a/src/md_elem/tree_ref.rs
+++ b/src/md_elem/tree_ref.rs
@@ -1,13 +1,12 @@
 use crate::md_elem::elem::*;
 use crate::util::vec_utils::ItemRetainer;
-use markdown::mdast;
 
 mod elem_ref {
     use super::*;
     use crate::util::vec_utils::IndexKeeper;
 
     impl Table {
-        pub fn alignments(&self) -> &Vec<mdast::AlignKind> {
+        pub fn alignments(&self) -> &Vec<TableColumnAlignment> {
             &self.alignments
         }
 
@@ -33,7 +32,7 @@ mod elem_ref {
             if self.alignments.len() > max_cols {
                 self.alignments.truncate(max_cols);
             } else {
-                let nones = [mdast::AlignKind::None]
+                let nones = [TableColumnAlignment::None]
                     .iter()
                     .cycle()
                     .take(max_cols - self.alignments.len());
@@ -100,7 +99,6 @@ mod tests {
 
     mod tables {
         use super::*;
-        use markdown::mdast;
 
         #[test]
         fn retain_col() {
@@ -113,7 +111,7 @@ mod tests {
 
             // note: "KEEPER" is in the last column, but not in the header; only the header gets
             // matched.
-            assert_eq!(table.alignments, vec![mdast::AlignKind::Left]);
+            assert_eq!(table.alignments, vec![TableColumnAlignment::Left]);
             assert_eq!(
                 table.rows,
                 vec![vec![cell("KEEPER a")], vec![cell("data 1 a")], vec![cell("data 2 a")],]
@@ -138,7 +136,11 @@ mod tests {
             // normalization
             assert_eq!(
                 table.alignments,
-                vec![mdast::AlignKind::Left, mdast::AlignKind::Right, mdast::AlignKind::None]
+                vec![
+                    TableColumnAlignment::Left,
+                    TableColumnAlignment::Right,
+                    TableColumnAlignment::None
+                ]
             );
             assert_eq!(
                 table.rows,
@@ -166,9 +168,9 @@ mod tests {
             assert_eq!(
                 table.alignments,
                 vec![
-                    mdast::AlignKind::Left,
-                    mdast::AlignKind::Right,
-                    mdast::AlignKind::Center,
+                    TableColumnAlignment::Left,
+                    TableColumnAlignment::Right,
+                    TableColumnAlignment::Center,
                 ]
             );
             // note: header row always gets kept
@@ -202,7 +204,11 @@ mod tests {
             // normalization
             assert_eq!(
                 table.alignments,
-                vec![mdast::AlignKind::Left, mdast::AlignKind::Right, mdast::AlignKind::None]
+                vec![
+                    TableColumnAlignment::Left,
+                    TableColumnAlignment::Right,
+                    TableColumnAlignment::None
+                ]
             );
             assert_eq!(
                 table.rows,
@@ -244,9 +250,9 @@ mod tests {
 
             // for alignments, just cycle [L, R, C].
             let alignments = [
-                mdast::AlignKind::Left,
-                mdast::AlignKind::Right,
-                mdast::AlignKind::Center,
+                TableColumnAlignment::Left,
+                TableColumnAlignment::Right,
+                TableColumnAlignment::Center,
             ]
             .iter()
             .cycle()

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -215,8 +215,8 @@ impl<'s, 'md> MdWriterState<'s, 'md> {
         if !alignments.is_empty() {
             for (idx, alignment) in alignments.iter().enumerate() {
                 let width = match *alignment {
-                    Some(Alignment::Left | Alignment::Right) => 2,
-                    Some(Alignment::Center) => 3,
+                    Some(ColumnAlignment::Left | ColumnAlignment::Right) => 2,
+                    Some(ColumnAlignment::Center) => 3,
                     None => 1,
                 };
                 column_widths[idx] = width;
@@ -283,8 +283,8 @@ impl<'s, 'md> MdWriterState<'s, 'md> {
                 let width = column_widths
                     .get(idx)
                     .unwrap_or_else(|| match align {
-                        Some(Alignment::Left | Alignment::Right) => &2,
-                        Some(Alignment::Center) => &3,
+                        Some(ColumnAlignment::Left | ColumnAlignment::Right) => &2,
+                        Some(ColumnAlignment::Center) => &3,
                         None => &1,
                     })
                     .to_owned();
@@ -956,9 +956,9 @@ pub mod tests {
             check_render(
                 md_elems![Table {
                     alignments: vec![
-                        Some(Alignment::Left),
-                        Some(Alignment::Right),
-                        Some(Alignment::Center),
+                        Some(ColumnAlignment::Left),
+                        Some(ColumnAlignment::Right),
+                        Some(ColumnAlignment::Center),
                         None,
                     ],
                     rows: vec![
@@ -993,9 +993,9 @@ pub mod tests {
             check_render(
                 md_elems![Table {
                     alignments: vec![
-                        Some(Alignment::Left),
-                        Some(Alignment::Right),
-                        Some(Alignment::Center),
+                        Some(ColumnAlignment::Left),
+                        Some(ColumnAlignment::Right),
+                        Some(ColumnAlignment::Center),
                         None,
                     ],
                     rows: vec![
@@ -1030,9 +1030,9 @@ pub mod tests {
             check_render(
                 md_elems![Table {
                     alignments: vec![
-                        Some(Alignment::Left),
-                        Some(Alignment::Right),
-                        Some(Alignment::Center),
+                        Some(ColumnAlignment::Left),
+                        Some(ColumnAlignment::Right),
+                        Some(ColumnAlignment::Center),
                         None,
                     ],
                     rows: vec![
@@ -1066,7 +1066,7 @@ pub mod tests {
             // This is an invalid table, but we should still support it
             check_render(
                 md_elems![Table {
-                    alignments: vec![TableColumnAlignment::None, TableColumnAlignment::None,],
+                    alignments: vec![None, None],
                     rows: vec![
                         // Header row: two values
                         vec![
@@ -1103,7 +1103,7 @@ pub mod tests {
         #[test]
         fn slice() {
             let table = Table {
-                alignments: vec![Some(Alignment::Left), Some(Alignment::Right)],
+                alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
                 rows: vec![
                     // Header row
                     vec![

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -258,7 +258,7 @@ impl<'s, 'md> MdWriterState<'s, 'md> {
                     out,
                     &col,
                     *column_widths.get(idx).unwrap_or(&0) - left_padding_count - 1, // -1 for right padding
-                    alignments.get(idx).map(|i| *i).unwrap_or(None),
+                    alignments.get(idx).copied().flatten(),
                 );
                 out.write_str(" |");
             }

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -949,8 +949,6 @@ pub mod tests {
     }
 
     mod table {
-        use markdown::mdast;
-
         use super::*;
 
         #[test]
@@ -958,10 +956,10 @@ pub mod tests {
             check_render(
                 md_elems![Table {
                     alignments: vec![
-                        mdast::AlignKind::Left,
-                        mdast::AlignKind::Right,
-                        mdast::AlignKind::Center,
-                        mdast::AlignKind::None,
+                        TableColumnAlignment::Left,
+                        TableColumnAlignment::Right,
+                        TableColumnAlignment::Center,
+                        TableColumnAlignment::None,
                     ],
                     rows: vec![
                         // Header row
@@ -995,10 +993,10 @@ pub mod tests {
             check_render(
                 md_elems![Table {
                     alignments: vec![
-                        mdast::AlignKind::Left,
-                        mdast::AlignKind::Right,
-                        mdast::AlignKind::Center,
-                        mdast::AlignKind::None,
+                        TableColumnAlignment::Left,
+                        TableColumnAlignment::Right,
+                        TableColumnAlignment::Center,
+                        TableColumnAlignment::None,
                     ],
                     rows: vec![
                         // Header row
@@ -1032,10 +1030,10 @@ pub mod tests {
             check_render(
                 md_elems![Table {
                     alignments: vec![
-                        mdast::AlignKind::Left,
-                        mdast::AlignKind::Right,
-                        mdast::AlignKind::Center,
-                        mdast::AlignKind::None,
+                        TableColumnAlignment::Left,
+                        TableColumnAlignment::Right,
+                        TableColumnAlignment::Center,
+                        TableColumnAlignment::None,
                     ],
                     rows: vec![
                         // Header row
@@ -1068,7 +1066,7 @@ pub mod tests {
             // This is an invalid table, but we should still support it
             check_render(
                 md_elems![Table {
-                    alignments: vec![mdast::AlignKind::None, mdast::AlignKind::None,],
+                    alignments: vec![TableColumnAlignment::None, TableColumnAlignment::None,],
                     rows: vec![
                         // Header row: two values
                         vec![
@@ -1105,7 +1103,7 @@ pub mod tests {
         #[test]
         fn slice() {
             let table = Table {
-                alignments: vec![mdast::AlignKind::Left, mdast::AlignKind::Right],
+                alignments: vec![TableColumnAlignment::Left, TableColumnAlignment::Right],
                 rows: vec![
                     // Header row
                     vec![

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -3,11 +3,10 @@ use crate::md_elem::*;
 use crate::output::fmt_md_inlines::{MdInlinesWriter, MdInlinesWriterOptions};
 use crate::output::link_transform::LinkLabel;
 use crate::util::output::{Block, Output, SimpleWrite};
-use crate::util::str_utils::{pad_to, standard_align, CountingWriter};
+use crate::util::str_utils::{pad_to, CountingWriter};
 use clap::ValueEnum;
 use std::borrow::Cow;
 use std::cmp::max;
-use std::fmt::Alignment;
 use std::ops::Deref;
 
 pub struct MdOptions {
@@ -288,16 +287,16 @@ impl<'s, 'md> MdWriterState<'s, 'md> {
                         None => &1,
                     })
                     .to_owned();
-                match standard_align(align) {
-                    Some(Alignment::Left) => {
+                match align {
+                    Some(ColumnAlignment::Left) => {
                         out.write_char(':');
                         out.write_str(&"-".repeat(width - 1));
                     }
-                    Some(Alignment::Right) => {
+                    Some(ColumnAlignment::Right) => {
                         out.write_str(&"-".repeat(width - 1));
                         out.write_char(':');
                     }
-                    Some(Alignment::Center) => {
+                    Some(ColumnAlignment::Center) => {
                         out.write_char(':');
                         out.write_str(&"-".repeat(width - 2));
                         out.write_char(':');

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -214,7 +214,7 @@ impl<'s, 'md> MdWriterState<'s, 'md> {
         let mut column_widths = [0].repeat(alignments.len());
         if !alignments.is_empty() {
             for (idx, alignment) in alignments.iter().enumerate() {
-                let width = match standard_align(*alignment) {
+                let width = match *alignment {
                     Some(Alignment::Left | Alignment::Right) => 2,
                     Some(Alignment::Center) => 3,
                     None => 1,
@@ -259,7 +259,7 @@ impl<'s, 'md> MdWriterState<'s, 'md> {
                     out,
                     &col,
                     *column_widths.get(idx).unwrap_or(&0) - left_padding_count - 1, // -1 for right padding
-                    alignments.get(idx),
+                    alignments.get(idx).map(|i| *i).unwrap_or(None),
                 );
                 out.write_str(" |");
             }
@@ -282,7 +282,7 @@ impl<'s, 'md> MdWriterState<'s, 'md> {
             for (idx, &align) in alignments.iter().enumerate() {
                 let width = column_widths
                     .get(idx)
-                    .unwrap_or_else(|| match standard_align(align) {
+                    .unwrap_or_else(|| match align {
                         Some(Alignment::Left | Alignment::Right) => &2,
                         Some(Alignment::Center) => &3,
                         None => &1,
@@ -956,10 +956,10 @@ pub mod tests {
             check_render(
                 md_elems![Table {
                     alignments: vec![
-                        TableColumnAlignment::Left,
-                        TableColumnAlignment::Right,
-                        TableColumnAlignment::Center,
-                        TableColumnAlignment::None,
+                        Some(Alignment::Left),
+                        Some(Alignment::Right),
+                        Some(Alignment::Center),
+                        None,
                     ],
                     rows: vec![
                         // Header row
@@ -993,10 +993,10 @@ pub mod tests {
             check_render(
                 md_elems![Table {
                     alignments: vec![
-                        TableColumnAlignment::Left,
-                        TableColumnAlignment::Right,
-                        TableColumnAlignment::Center,
-                        TableColumnAlignment::None,
+                        Some(Alignment::Left),
+                        Some(Alignment::Right),
+                        Some(Alignment::Center),
+                        None,
                     ],
                     rows: vec![
                         // Header row
@@ -1030,10 +1030,10 @@ pub mod tests {
             check_render(
                 md_elems![Table {
                     alignments: vec![
-                        TableColumnAlignment::Left,
-                        TableColumnAlignment::Right,
-                        TableColumnAlignment::Center,
-                        TableColumnAlignment::None,
+                        Some(Alignment::Left),
+                        Some(Alignment::Right),
+                        Some(Alignment::Center),
+                        None,
                     ],
                     rows: vec![
                         // Header row
@@ -1103,7 +1103,7 @@ pub mod tests {
         #[test]
         fn slice() {
             let table = Table {
-                alignments: vec![TableColumnAlignment::Left, TableColumnAlignment::Right],
+                alignments: vec![Some(Alignment::Left), Some(Alignment::Right)],
                 rows: vec![
                     // Header row
                     vec![

--- a/src/output/fmt_plain_inline.rs
+++ b/src/output/fmt_plain_inline.rs
@@ -148,6 +148,7 @@ mod test {
     use super::*;
     use crate::util::utils_for_test::*;
     use indoc::indoc;
+    use std::fmt::Alignment;
 
     variants_checker!(VARIANTS_CHECKER = MdElem {
         Doc(_),
@@ -345,7 +346,7 @@ mod test {
     #[test]
     fn table() {
         let md_elem = md_elem!(Table {
-            alignments: vec![TableColumnAlignment::None, TableColumnAlignment::Center],
+            alignments: vec![None, Some(Alignment::Center)],
             rows: vec![
                 vec![vec![mdq_inline!("1A")], vec![mdq_inline!("1B")]],
                 vec![vec![mdq_inline!("2A")], vec![mdq_inline!("2B")]],
@@ -363,7 +364,7 @@ mod test {
     #[test]
     fn table_with_empty_cells() {
         let md_elem = md_elem!(Table {
-            alignments: vec![TableColumnAlignment::None, TableColumnAlignment::Center],
+            alignments: vec![None, Some(Alignment::Center)],
             rows: vec![
                 vec![cell(["a"]), cell(["b"]), cell(["c"])],
                 vec![cell(["a"]), cell([]), cell(["c"])],
@@ -481,7 +482,7 @@ mod test {
     #[test]
     fn table_slice() {
         let table = Table {
-            alignments: vec![TableColumnAlignment::None, TableColumnAlignment::Center],
+            alignments: vec![None, Some(Alignment::Center)],
             rows: vec![
                 vec![vec![mdq_inline!("1A")], vec![mdq_inline!("1B")]],
                 vec![vec![mdq_inline!("2A")], vec![mdq_inline!("2B")]],

--- a/src/output/fmt_plain_inline.rs
+++ b/src/output/fmt_plain_inline.rs
@@ -148,7 +148,6 @@ mod test {
     use super::*;
     use crate::util::utils_for_test::*;
     use indoc::indoc;
-    use markdown::mdast;
 
     variants_checker!(VARIANTS_CHECKER = MdElem {
         Doc(_),
@@ -346,7 +345,7 @@ mod test {
     #[test]
     fn table() {
         let md_elem = md_elem!(Table {
-            alignments: vec![mdast::AlignKind::None, mdast::AlignKind::Center],
+            alignments: vec![TableColumnAlignment::None, TableColumnAlignment::Center],
             rows: vec![
                 vec![vec![mdq_inline!("1A")], vec![mdq_inline!("1B")]],
                 vec![vec![mdq_inline!("2A")], vec![mdq_inline!("2B")]],
@@ -364,7 +363,7 @@ mod test {
     #[test]
     fn table_with_empty_cells() {
         let md_elem = md_elem!(Table {
-            alignments: vec![mdast::AlignKind::None, mdast::AlignKind::Center],
+            alignments: vec![TableColumnAlignment::None, TableColumnAlignment::Center],
             rows: vec![
                 vec![cell(["a"]), cell(["b"]), cell(["c"])],
                 vec![cell(["a"]), cell([]), cell(["c"])],
@@ -482,7 +481,7 @@ mod test {
     #[test]
     fn table_slice() {
         let table = Table {
-            alignments: vec![mdast::AlignKind::None, mdast::AlignKind::Center],
+            alignments: vec![TableColumnAlignment::None, TableColumnAlignment::Center],
             rows: vec![
                 vec![vec![mdq_inline!("1A")], vec![mdq_inline!("1B")]],
                 vec![vec![mdq_inline!("2A")], vec![mdq_inline!("2B")]],

--- a/src/output/fmt_plain_inline.rs
+++ b/src/output/fmt_plain_inline.rs
@@ -55,7 +55,7 @@ where
         MdElem::Doc(doc) => write_plain_result(out, doc.iter()),
         MdElem::BlockQuote(block) => write_plain_result(out, block.body.iter()),
         MdElem::CodeBlock(block) => {
-            if !(block.value.is_empty()) {
+            if !block.value.is_empty() {
                 writeln!(out, "{}", block.value)?;
                 writeln!(out)?;
             }
@@ -148,7 +148,6 @@ mod test {
     use super::*;
     use crate::util::utils_for_test::*;
     use indoc::indoc;
-    use std::fmt::Alignment;
 
     variants_checker!(VARIANTS_CHECKER = MdElem {
         Doc(_),
@@ -346,7 +345,7 @@ mod test {
     #[test]
     fn table() {
         let md_elem = md_elem!(Table {
-            alignments: vec![None, Some(Alignment::Center)],
+            alignments: vec![None, Some(ColumnAlignment::Center)],
             rows: vec![
                 vec![vec![mdq_inline!("1A")], vec![mdq_inline!("1B")]],
                 vec![vec![mdq_inline!("2A")], vec![mdq_inline!("2B")]],
@@ -364,7 +363,7 @@ mod test {
     #[test]
     fn table_with_empty_cells() {
         let md_elem = md_elem!(Table {
-            alignments: vec![None, Some(Alignment::Center)],
+            alignments: vec![None, Some(ColumnAlignment::Center)],
             rows: vec![
                 vec![cell(["a"]), cell(["b"]), cell(["c"])],
                 vec![cell(["a"]), cell([]), cell(["c"])],
@@ -482,7 +481,7 @@ mod test {
     #[test]
     fn table_slice() {
         let table = Table {
-            alignments: vec![None, Some(Alignment::Center)],
+            alignments: vec![None, Some(ColumnAlignment::Center)],
             rows: vec![
                 vec![vec![mdq_inline!("1A")], vec![mdq_inline!("1B")]],
                 vec![vec![mdq_inline!("2A")], vec![mdq_inline!("2B")]],

--- a/src/output/tree_ref_serde.rs
+++ b/src/output/tree_ref_serde.rs
@@ -6,7 +6,6 @@ use crate::util::output::Output;
 use serde::{Serialize, Serializer};
 use std::borrow::{Borrow, Cow};
 use std::collections::HashMap;
-use std::fmt::Alignment;
 
 #[derive(Serialize)]
 pub struct MdSerde<'md> {
@@ -109,12 +108,12 @@ pub enum AlignSerde {
     None,
 }
 
-impl From<TableColumnAlignment> for AlignSerde {
-    fn from(value: TableColumnAlignment) -> Self {
+impl From<Option<ColumnAlignment>> for AlignSerde {
+    fn from(value: Option<ColumnAlignment>) -> Self {
         match value {
-            Some(Alignment::Left) => Self::Left,
-            Some(Alignment::Right) => Self::Right,
-            Some(Alignment::Center) => Self::Center,
+            Some(ColumnAlignment::Left) => Self::Left,
+            Some(ColumnAlignment::Right) => Self::Right,
+            Some(ColumnAlignment::Center) => Self::Center,
             None => Self::None,
         }
     }
@@ -570,7 +569,7 @@ mod tests {
     fn table() {
         check(
             md_elem!(Table {
-                alignments: vec![Some(Alignment::Left), None],
+                alignments: vec![Some(ColumnAlignment::Left), None],
                 rows: vec![
                     vec![vec![mdq_inline!("R1C1")], vec![mdq_inline!("R1C2")]],
                     vec![vec![mdq_inline!("R2C1")], vec![mdq_inline!("R2C2")]],
@@ -593,7 +592,7 @@ mod tests {
     #[test]
     fn table_slice() {
         let table = Table {
-            alignments: vec![Some(Alignment::Left), None],
+            alignments: vec![Some(ColumnAlignment::Left), None],
             rows: vec![
                 vec![vec![mdq_inline!("R1C1")], vec![mdq_inline!("R1C2")]],
                 vec![vec![mdq_inline!("R2C1")], vec![mdq_inline!("R2C2")]],

--- a/src/output/tree_ref_serde.rs
+++ b/src/output/tree_ref_serde.rs
@@ -266,7 +266,7 @@ impl<'md> SerdeElem<'md> {
                     rendered_rows.push(rendered_cells);
                 }
                 Self::Table {
-                    alignments: table.alignments().iter().map(|a| (*a).into()).collect(),
+                    alignments: table.alignments.iter().copied().map(Into::into).collect(),
                     rows: rendered_rows,
                 }
             }

--- a/src/output/tree_ref_serde.rs
+++ b/src/output/tree_ref_serde.rs
@@ -6,6 +6,7 @@ use crate::util::output::Output;
 use serde::{Serialize, Serializer};
 use std::borrow::{Borrow, Cow};
 use std::collections::HashMap;
+use std::fmt::Alignment;
 
 #[derive(Serialize)]
 pub struct MdSerde<'md> {
@@ -111,10 +112,10 @@ pub enum AlignSerde {
 impl From<TableColumnAlignment> for AlignSerde {
     fn from(value: TableColumnAlignment) -> Self {
         match value {
-            TableColumnAlignment::Left => Self::Left,
-            TableColumnAlignment::Right => Self::Right,
-            TableColumnAlignment::Center => Self::Center,
-            TableColumnAlignment::None => Self::None,
+            Some(Alignment::Left) => Self::Left,
+            Some(Alignment::Right) => Self::Right,
+            Some(Alignment::Center) => Self::Center,
+            None => Self::None,
         }
     }
 }
@@ -569,7 +570,7 @@ mod tests {
     fn table() {
         check(
             md_elem!(Table {
-                alignments: vec![TableColumnAlignment::Left, TableColumnAlignment::None],
+                alignments: vec![Some(Alignment::Left), None],
                 rows: vec![
                     vec![vec![mdq_inline!("R1C1")], vec![mdq_inline!("R1C2")]],
                     vec![vec![mdq_inline!("R2C1")], vec![mdq_inline!("R2C2")]],
@@ -592,7 +593,7 @@ mod tests {
     #[test]
     fn table_slice() {
         let table = Table {
-            alignments: vec![TableColumnAlignment::Left, TableColumnAlignment::None],
+            alignments: vec![Some(Alignment::Left), None],
             rows: vec![
                 vec![vec![mdq_inline!("R1C1")], vec![mdq_inline!("R1C2")]],
                 vec![vec![mdq_inline!("R2C1")], vec![mdq_inline!("R2C2")]],

--- a/src/output/tree_ref_serde.rs
+++ b/src/output/tree_ref_serde.rs
@@ -3,7 +3,6 @@ use crate::md_elem::*;
 use crate::output::fmt_md_inlines::{MdInlinesWriter, MdInlinesWriterOptions, UrlAndTitle};
 use crate::output::link_transform::LinkLabel;
 use crate::util::output::Output;
-use markdown::mdast::AlignKind;
 use serde::{Serialize, Serializer};
 use std::borrow::{Borrow, Cow};
 use std::collections::HashMap;
@@ -109,13 +108,13 @@ pub enum AlignSerde {
     None,
 }
 
-impl From<&AlignKind> for AlignSerde {
-    fn from(value: &AlignKind) -> Self {
+impl From<TableColumnAlignment> for AlignSerde {
+    fn from(value: TableColumnAlignment) -> Self {
         match value {
-            AlignKind::Left => Self::Left,
-            AlignKind::Right => Self::Right,
-            AlignKind::Center => Self::Center,
-            AlignKind::None => Self::None,
+            TableColumnAlignment::Left => Self::Left,
+            TableColumnAlignment::Right => Self::Right,
+            TableColumnAlignment::Center => Self::Center,
+            TableColumnAlignment::None => Self::None,
         }
     }
 }
@@ -267,7 +266,7 @@ impl<'md> SerdeElem<'md> {
                     rendered_rows.push(rendered_cells);
                 }
                 Self::Table {
-                    alignments: table.alignments().iter().map(|a| a.into()).collect(),
+                    alignments: table.alignments().iter().map(|a| (*a).into()).collect(),
                     rows: rendered_rows,
                 }
             }
@@ -570,7 +569,7 @@ mod tests {
     fn table() {
         check(
             md_elem!(Table {
-                alignments: vec![AlignKind::Left, AlignKind::None],
+                alignments: vec![TableColumnAlignment::Left, TableColumnAlignment::None],
                 rows: vec![
                     vec![vec![mdq_inline!("R1C1")], vec![mdq_inline!("R1C2")]],
                     vec![vec![mdq_inline!("R2C1")], vec![mdq_inline!("R2C2")]],
@@ -593,7 +592,7 @@ mod tests {
     #[test]
     fn table_slice() {
         let table = Table {
-            alignments: vec![AlignKind::Left, AlignKind::None],
+            alignments: vec![TableColumnAlignment::Left, TableColumnAlignment::None],
             rows: vec![
                 vec![vec![mdq_inline!("R1C1")], vec![mdq_inline!("R1C2")]],
                 vec![vec![mdq_inline!("R2C1")], vec![mdq_inline!("R2C2")]],

--- a/src/select/sel_table.rs
+++ b/src/select/sel_table.rs
@@ -40,7 +40,6 @@ impl From<TableMatcher> for TableSelector {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::fmt::Alignment;
 
     use crate::md_elem::elem::*;
     use crate::select::TrySelector;
@@ -49,7 +48,7 @@ mod tests {
     #[test]
     fn select_all_on_normalized_table() {
         let table: Table = Table {
-            alignments: vec![Some(Alignment::Left), Some(Alignment::Right)],
+            alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
             rows: vec![
                 vec![cell("header a"), cell("header b")],
                 vec![cell("data 1 a"), cell("data 1 b")],
@@ -63,7 +62,10 @@ mod tests {
         .map(get_only);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
-        assert_eq!(table.alignments(), &vec![Some(Alignment::Left), Some(Alignment::Right)]);
+        assert_eq!(
+            table.alignments(),
+            &vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)]
+        );
         assert_eq!(
             table.rows(),
             &vec![
@@ -76,7 +78,7 @@ mod tests {
     #[test]
     fn select_columns_on_normalized_table() {
         let table: Table = Table {
-            alignments: vec![Some(Alignment::Left), Some(Alignment::Right)],
+            alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
             rows: vec![
                 vec![cell("header a"), cell("KEEP b")],
                 vec![cell("data 1 a"), cell("data 1 b")],
@@ -90,14 +92,14 @@ mod tests {
         .map(get_only);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
-        assert_eq!(table.alignments(), &vec![Some(Alignment::Right)]);
+        assert_eq!(table.alignments(), &vec![Some(ColumnAlignment::Right)]);
         assert_eq!(table.rows(), &vec![vec![cell("KEEP b")], vec![cell("data 1 b")],]);
     }
 
     #[test]
     fn select_rows_on_normalized_table() {
         let table: Table = Table {
-            alignments: vec![Some(Alignment::Left), Some(Alignment::Right)],
+            alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
             rows: vec![
                 vec![cell("header a"), cell("header b")],
                 vec![cell("data 1 a"), cell("data 1 b")],
@@ -112,7 +114,10 @@ mod tests {
         .map(get_only);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
-        assert_eq!(table.alignments(), &vec![Some(Alignment::Left), Some(Alignment::Right)]);
+        assert_eq!(
+            table.alignments(),
+            &vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)]
+        );
         assert_eq!(
             table.rows(),
             &vec![
@@ -129,7 +134,7 @@ mod tests {
     fn jagged_table() {
         let table: Table = Table {
             // only 1 align; rest will be filled with None
-            alignments: vec![Some(Alignment::Left)],
+            alignments: vec![Some(ColumnAlignment::Left)],
             rows: vec![
                 vec![cell("header a")],
                 vec![cell("data 1 a"), cell("data 1 b")],
@@ -144,7 +149,7 @@ mod tests {
         .map(get_only);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
-        assert_eq!(table.alignments(), &vec![Some(Alignment::Left), None, None]);
+        assert_eq!(table.alignments(), &vec![Some(ColumnAlignment::Left), None, None]);
         assert_eq!(
             table.rows(),
             &vec![

--- a/src/select/sel_table.rs
+++ b/src/select/sel_table.rs
@@ -44,12 +44,11 @@ mod tests {
     use crate::md_elem::elem::*;
     use crate::select::TrySelector;
     use crate::util::utils_for_test::*;
-    use markdown::mdast;
 
     #[test]
     fn select_all_on_normalized_table() {
         let table: Table = Table {
-            alignments: vec![mdast::AlignKind::Left, mdast::AlignKind::Right],
+            alignments: vec![TableColumnAlignment::Left, TableColumnAlignment::Right],
             rows: vec![
                 vec![cell("header a"), cell("header b")],
                 vec![cell("data 1 a"), cell("data 1 b")],
@@ -65,7 +64,7 @@ mod tests {
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
         assert_eq!(
             table.alignments(),
-            &vec![mdast::AlignKind::Left, mdast::AlignKind::Right]
+            &vec![TableColumnAlignment::Left, TableColumnAlignment::Right]
         );
         assert_eq!(
             table.rows(),
@@ -79,7 +78,7 @@ mod tests {
     #[test]
     fn select_columns_on_normalized_table() {
         let table: Table = Table {
-            alignments: vec![mdast::AlignKind::Left, mdast::AlignKind::Right],
+            alignments: vec![TableColumnAlignment::Left, TableColumnAlignment::Right],
             rows: vec![
                 vec![cell("header a"), cell("KEEP b")],
                 vec![cell("data 1 a"), cell("data 1 b")],
@@ -93,14 +92,14 @@ mod tests {
         .map(get_only);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
-        assert_eq!(table.alignments(), &vec![mdast::AlignKind::Right]);
+        assert_eq!(table.alignments(), &vec![TableColumnAlignment::Right]);
         assert_eq!(table.rows(), &vec![vec![cell("KEEP b")], vec![cell("data 1 b")],]);
     }
 
     #[test]
     fn select_rows_on_normalized_table() {
         let table: Table = Table {
-            alignments: vec![mdast::AlignKind::Left, mdast::AlignKind::Right],
+            alignments: vec![TableColumnAlignment::Left, TableColumnAlignment::Right],
             rows: vec![
                 vec![cell("header a"), cell("header b")],
                 vec![cell("data 1 a"), cell("data 1 b")],
@@ -117,7 +116,7 @@ mod tests {
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
         assert_eq!(
             table.alignments(),
-            &vec![mdast::AlignKind::Left, mdast::AlignKind::Right]
+            &vec![TableColumnAlignment::Left, TableColumnAlignment::Right]
         );
         assert_eq!(
             table.rows(),
@@ -135,7 +134,7 @@ mod tests {
     fn jagged_table() {
         let table: Table = Table {
             // only 1 align; rest will be filled with None
-            alignments: vec![mdast::AlignKind::Left],
+            alignments: vec![TableColumnAlignment::Left],
             rows: vec![
                 vec![cell("header a")],
                 vec![cell("data 1 a"), cell("data 1 b")],
@@ -152,7 +151,11 @@ mod tests {
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
         assert_eq!(
             table.alignments(),
-            &vec![mdast::AlignKind::Left, mdast::AlignKind::None, mdast::AlignKind::None]
+            &vec![
+                TableColumnAlignment::Left,
+                TableColumnAlignment::None,
+                TableColumnAlignment::None
+            ]
         );
         assert_eq!(
             table.rows(),

--- a/src/select/sel_table.rs
+++ b/src/select/sel_table.rs
@@ -40,6 +40,7 @@ impl From<TableMatcher> for TableSelector {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::fmt::Alignment;
 
     use crate::md_elem::elem::*;
     use crate::select::TrySelector;
@@ -48,7 +49,7 @@ mod tests {
     #[test]
     fn select_all_on_normalized_table() {
         let table: Table = Table {
-            alignments: vec![TableColumnAlignment::Left, TableColumnAlignment::Right],
+            alignments: vec![Some(Alignment::Left), Some(Alignment::Right)],
             rows: vec![
                 vec![cell("header a"), cell("header b")],
                 vec![cell("data 1 a"), cell("data 1 b")],
@@ -62,10 +63,7 @@ mod tests {
         .map(get_only);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
-        assert_eq!(
-            table.alignments(),
-            &vec![TableColumnAlignment::Left, TableColumnAlignment::Right]
-        );
+        assert_eq!(table.alignments(), &vec![Some(Alignment::Left), Some(Alignment::Right)]);
         assert_eq!(
             table.rows(),
             &vec![
@@ -78,7 +76,7 @@ mod tests {
     #[test]
     fn select_columns_on_normalized_table() {
         let table: Table = Table {
-            alignments: vec![TableColumnAlignment::Left, TableColumnAlignment::Right],
+            alignments: vec![Some(Alignment::Left), Some(Alignment::Right)],
             rows: vec![
                 vec![cell("header a"), cell("KEEP b")],
                 vec![cell("data 1 a"), cell("data 1 b")],
@@ -92,14 +90,14 @@ mod tests {
         .map(get_only);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
-        assert_eq!(table.alignments(), &vec![TableColumnAlignment::Right]);
+        assert_eq!(table.alignments(), &vec![Some(Alignment::Right)]);
         assert_eq!(table.rows(), &vec![vec![cell("KEEP b")], vec![cell("data 1 b")],]);
     }
 
     #[test]
     fn select_rows_on_normalized_table() {
         let table: Table = Table {
-            alignments: vec![TableColumnAlignment::Left, TableColumnAlignment::Right],
+            alignments: vec![Some(Alignment::Left), Some(Alignment::Right)],
             rows: vec![
                 vec![cell("header a"), cell("header b")],
                 vec![cell("data 1 a"), cell("data 1 b")],
@@ -114,10 +112,7 @@ mod tests {
         .map(get_only);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
-        assert_eq!(
-            table.alignments(),
-            &vec![TableColumnAlignment::Left, TableColumnAlignment::Right]
-        );
+        assert_eq!(table.alignments(), &vec![Some(Alignment::Left), Some(Alignment::Right)]);
         assert_eq!(
             table.rows(),
             &vec![
@@ -134,7 +129,7 @@ mod tests {
     fn jagged_table() {
         let table: Table = Table {
             // only 1 align; rest will be filled with None
-            alignments: vec![TableColumnAlignment::Left],
+            alignments: vec![Some(Alignment::Left)],
             rows: vec![
                 vec![cell("header a")],
                 vec![cell("data 1 a"), cell("data 1 b")],
@@ -149,14 +144,7 @@ mod tests {
         .map(get_only);
 
         unwrap!(maybe_selected, Ok(MdElem::Table(table)));
-        assert_eq!(
-            table.alignments(),
-            &vec![
-                TableColumnAlignment::Left,
-                TableColumnAlignment::None,
-                TableColumnAlignment::None
-            ]
-        );
+        assert_eq!(table.alignments(), &vec![Some(Alignment::Left), None, None]);
         assert_eq!(
             table.rows(),
             &vec![

--- a/src/util/str_utils.rs
+++ b/src/util/str_utils.rs
@@ -1,7 +1,8 @@
+use crate::md_elem::elem::ColumnAlignment;
 use crate::util::output::{Output, SimpleWrite};
 use std::fmt::Alignment;
 
-pub fn pad_to<W>(output: &mut Output<W>, input: &str, min_width: usize, alignment: Option<Alignment>)
+pub fn pad_to<W>(output: &mut Output<W>, input: &str, min_width: usize, alignment: Option<ColumnAlignment>)
 where
     W: SimpleWrite,
 {
@@ -12,26 +13,30 @@ where
     let padding = min_width - input.len();
 
     match alignment {
-        Some(Alignment::Left) | None => {
+        Some(ColumnAlignment::Left) | None => {
             output.write_str(input);
             (0..padding).for_each(|_| output.write_char(' '));
         }
-        Some(Alignment::Center) => {
+        Some(ColumnAlignment::Center) => {
             let left_pad = padding / 2; // round down
             let right_pad = padding - left_pad;
             (0..left_pad).for_each(|_| output.write_char(' '));
             output.write_str(input);
             (0..right_pad).for_each(|_| output.write_char(' '));
         }
-        Some(Alignment::Right) => {
+        Some(ColumnAlignment::Right) => {
             (0..padding).for_each(|_| output.write_char(' '));
             output.write_str(input);
         }
     }
 }
 
-pub fn standard_align(a: Option<Alignment>) -> Option<Alignment> {
-    a
+pub fn standard_align(a: Option<ColumnAlignment>) -> Option<Alignment> {
+    a.map(|a| match a {
+        ColumnAlignment::Left => Alignment::Left,
+        ColumnAlignment::Right => Alignment::Right,
+        ColumnAlignment::Center => Alignment::Center,
+    })
 }
 
 pub struct CountingWriter<'a, W> {
@@ -82,7 +87,7 @@ mod test {
     fn left_pad() {
         assert_eq!(
             "a    ",
-            output_and_get(|out| pad_to(out, "a", 5, Some(Alignment::Left)))
+            output_and_get(|out| pad_to(out, "a", 5, Some(ColumnAlignment::Left)))
         );
     }
 
@@ -90,7 +95,7 @@ mod test {
     fn right_pad() {
         assert_eq!(
             "    a",
-            output_and_get(|out| pad_to(out, "a", 5, Some(Alignment::Right)))
+            output_and_get(|out| pad_to(out, "a", 5, Some(ColumnAlignment::Right)))
         );
     }
 
@@ -99,7 +104,7 @@ mod test {
     fn center_pad_even() {
         assert_eq!(
             "  a  ",
-            output_and_get(|out| pad_to(out, "a", 5, Some(Alignment::Center)))
+            output_and_get(|out| pad_to(out, "a", 5, Some(ColumnAlignment::Center)))
         );
     }
 
@@ -108,20 +113,20 @@ mod test {
     fn center_pad_uneven() {
         assert_eq!(
             " ab  ",
-            output_and_get(|out| pad_to(out, "ab", 5, Some(Alignment::Center)))
+            output_and_get(|out| pad_to(out, "ab", 5, Some(ColumnAlignment::Center)))
         );
     }
 
     #[test]
     fn string_already_right_size() {
-        for align in [Alignment::Left, Alignment::Center, Alignment::Right] {
+        for align in [ColumnAlignment::Left, ColumnAlignment::Center, ColumnAlignment::Right] {
             assert_eq!("abcde", output_and_get(|out| pad_to(out, "abcde", 5, Some(align))));
         }
     }
 
     #[test]
     fn string_already_too_big() {
-        for align in [Alignment::Left, Alignment::Center, Alignment::Right] {
+        for align in [ColumnAlignment::Left, ColumnAlignment::Center, ColumnAlignment::Right] {
             assert_eq!("abcdef", output_and_get(|out| pad_to(out, "abcdef", 3, Some(align))));
         }
     }

--- a/src/util/str_utils.rs
+++ b/src/util/str_utils.rs
@@ -1,9 +1,7 @@
+use crate::md_elem::elem::TableColumnAlignment;
+use crate::util::output::{Output, SimpleWrite};
 use std::borrow::Borrow;
 use std::fmt::Alignment;
-
-use markdown::mdast::AlignKind;
-
-use crate::util::output::{Output, SimpleWrite};
 
 pub fn pad_to<A, W>(output: &mut Output<W>, input: &str, min_width: usize, alignment: A)
 where
@@ -52,18 +50,18 @@ impl ToAlignment for Alignment {
     }
 }
 
-impl ToAlignment for AlignKind {
+impl ToAlignment for TableColumnAlignment {
     fn to_alignment(self) -> Option<Alignment> {
         match self {
-            AlignKind::Left => Some(Alignment::Left),
-            AlignKind::Right => Some(Alignment::Right),
-            AlignKind::Center => Some(Alignment::Center),
-            AlignKind::None => None,
+            TableColumnAlignment::Left => Some(Alignment::Left),
+            TableColumnAlignment::Right => Some(Alignment::Right),
+            TableColumnAlignment::Center => Some(Alignment::Center),
+            TableColumnAlignment::None => None,
         }
     }
 }
 
-impl<A: Borrow<AlignKind>> ToAlignment for Option<A> {
+impl<A: Borrow<TableColumnAlignment>> ToAlignment for Option<A> {
     fn to_alignment(self) -> Option<Alignment> {
         match self {
             Some(a) => a.borrow().to_alignment(),

--- a/src/util/str_utils.rs
+++ b/src/util/str_utils.rs
@@ -1,6 +1,5 @@
 use crate::md_elem::elem::ColumnAlignment;
 use crate::util::output::{Output, SimpleWrite};
-use std::fmt::Alignment;
 
 pub fn pad_to<W>(output: &mut Output<W>, input: &str, min_width: usize, alignment: Option<ColumnAlignment>)
 where
@@ -29,14 +28,6 @@ where
             output.write_str(input);
         }
     }
-}
-
-pub fn standard_align(a: Option<ColumnAlignment>) -> Option<Alignment> {
-    a.map(|a| match a {
-        ColumnAlignment::Left => Alignment::Left,
-        ColumnAlignment::Right => Alignment::Right,
-        ColumnAlignment::Center => Alignment::Center,
-    })
 }
 
 pub struct CountingWriter<'a, W> {


### PR DESCRIPTION
In service of #307: hide `mdast::AlignKind` from the public API.