### PR TITLE
remove public exposing of regex::Regex

### DIFF
--- a/src/output/fmt_plain_str.rs
+++ b/src/output/fmt_plain_str.rs
@@ -1,6 +1,7 @@
 use crate::md_elem::elem::*;
 use std::borrow::Borrow;
 
+// TODO this should not be exposed
 pub fn inlines_to_plain_string<N: Borrow<Inline>>(inlines: &[N]) -> String {
     let mut result = String::with_capacity(inlines.len() * 5); // random guess
     build_inlines(&mut result, inlines);

--- a/src/query/matcher_try_from.rs
+++ b/src/query/matcher_try_from.rs
@@ -1,7 +1,6 @@
 use crate::query::strings::{ParsedString, ParsedStringMode};
 use crate::query::{DetachedSpan, Pair, ParseError};
-use crate::select::{AnyVariant, Matcher};
-use regex::Regex;
+use crate::select::{AnyVariant, Matcher, Regex};
 
 impl TryFrom<Option<Pair<'_>>> for Matcher {
     type Error = ParseError;
@@ -34,8 +33,9 @@ impl TryFrom<Option<Pair<'_>>> for Matcher {
                 anchor_end: parsed_string.anchor_end,
             },
             ParsedStringMode::Regex => {
-                let re = Regex::new(&parsed_string.text).map_err(|e| ParseError::Other(span.into(), e.to_string()))?;
-                Self::Regex(re)
+                let re = regex::Regex::new(&parsed_string.text)
+                    .map_err(|e| ParseError::Other(span.into(), e.to_string()))?;
+                Self::Regex(Regex { re })
             }
         };
         Ok(matcher)

--- a/src/query/selector_try_from.rs
+++ b/src/query/selector_try_from.rs
@@ -570,8 +570,8 @@ mod tests {
 
     mod html {
         use super::*;
+        use crate::select::Regex;
         use indoc::indoc;
-        use regex::Regex;
 
         #[test]
         fn html_no_matcher() {
@@ -607,7 +607,9 @@ mod tests {
         fn html_with_regex() {
             find_selector(
                 "</> /<div.*>/",
-                Selector::Html(Matcher::Regex(Regex::new("<div.*>").unwrap())),
+                Selector::Html(Matcher::Regex(Regex {
+                    re: regex::Regex::new("<div.*>").unwrap(),
+                })),
             )
         }
     }

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -75,6 +75,7 @@ adapters! {
     }
 }
 
+// TODO this should not be exposed
 impl SelectorAdapter {
     pub fn find_nodes(&self, ctx: &MdContext, nodes: Vec<MdElem>) -> Vec<MdElem> {
         let mut result = Vec::with_capacity(8); // arbitrary guess

--- a/src/select/matcher.rs
+++ b/src/select/matcher.rs
@@ -1,6 +1,4 @@
-use regex::Regex;
-
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Matcher {
     Text {
         case_sensitive: bool,
@@ -12,34 +10,21 @@ pub enum Matcher {
     Any(AnyVariant),
 }
 
+#[derive(Debug, Clone)]
+pub struct Regex {
+    pub(crate) re: regex::Regex,
+}
+
+impl PartialEq for Regex {
+    fn eq(&self, other: &Self) -> bool {
+        self.re.as_str() == other.re.as_str()
+    }
+}
+
+impl Eq for Regex {}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum AnyVariant {
     Implicit,
     Explicit,
 }
-
-impl PartialEq for Matcher {
-    fn eq(&self, other: &Self) -> bool {
-        match (self, other) {
-            (
-                Self::Text {
-                    case_sensitive: s1,
-                    anchor_start: a1,
-                    text: t1,
-                    anchor_end: e1,
-                },
-                Self::Text {
-                    case_sensitive: s2,
-                    anchor_start: a2,
-                    text: t2,
-                    anchor_end: e2,
-                },
-            ) => s1 == s2 && a1 == a2 && e1 == e2 && t1 == t2,
-            (Self::Regex(r1), Self::Regex(r2)) => r1.as_str() == r2.as_str(),
-            (Self::Any(_), Self::Any(_)) => true,
-            _ => false,
-        }
-    }
-}
-
-impl Eq for Matcher {}

--- a/src/select/string_matcher.rs
+++ b/src/select/string_matcher.rs
@@ -83,7 +83,7 @@ impl From<Matcher> for StringMatcher {
                 anchor_end,
             }
             .to_string_matcher(),
-            Matcher::Regex(re) => Self::regex(re),
+            Matcher::Regex(re) => Self::regex(re.re),
             Matcher::Any(_) => Self::any(),
         }
     }


### PR DESCRIPTION
In service of #307: hide `regex::Regex` from the public API.