### PR TITLE
expose query string errors a bit

### DIFF
--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -33,12 +33,15 @@ impl Display for QueryParse {
                 write!(f, "{err}")
             }
             ParseError::Other(span, message) => {
-                let full_span = Span::new(&self.query_string, span.start, span.end);
+                let Some(full_span) = Span::new(&self.query_string, span.start, span.end) else {
+                    // not expected to happen, but just in case!
+                    return write!(f, "parse error in {:?}: {}", self.query_string, message);
+                };
                 let pest_err = query::Error::new_from_span(
                     ErrorVariant::CustomError {
                         message: message.to_string(),
                     },
-                    full_span.unwrap(),
+                    full_span,
                 );
                 write!(f, "{pest_err}")
             }

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -35,7 +35,11 @@ impl Display for QueryParse {
             ParseError::Other(span, message) => {
                 let Some(full_span) = Span::new(&self.query_string, span.start, span.end) else {
                     // not expected to happen, but just in case!
-                    return write!(f, "parse error in {:?}: {}", self.query_string, message);
+                    return write!(
+                        f,
+                        "parse error at byte {} of {:?}: {}",
+                        span.start, self.query_string, message
+                    );
                 };
                 let pest_err = query::Error::new_from_span(
                     ErrorVariant::CustomError {


### PR DESCRIPTION
Don't actually expose much about them; basically just a Display.

This is in service of #307. That ticket says to hide pest, but actually it was already hidden. The closest we got was in exposing `run::Error::QueryParse { error: ParseError, .. }`, but `ParseError` itself was not pub.

This makes it a bit hard to work with, so this PR actually exposes it a bit _more_. The pest aspect remains hidden, but `QueryParse` is now a pub struct with private fields and a pub `impl Display`.