### PR TITLE
fix public API for various output-related classes

### DIFF
--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -1,6 +1,6 @@
 use crate::md_elem::elem::*;
 use crate::md_elem::*;
-use crate::output::fmt_md_inlines::{MdInlinesWriter, MdInlinesWriterOptions};
+use crate::output::fmt_md_inlines::{InlineElemOptions, MdInlinesWriter};
 use crate::output::link_transform::LinkLabel;
 use crate::util::output::{Block, Output, SimpleWrite};
 use crate::util::str_utils::{pad_to, CountingWriter};
@@ -12,7 +12,7 @@ use std::ops::Deref;
 pub struct MdOptions {
     pub link_reference_placement: ReferencePlacement,
     pub footnote_reference_placement: ReferencePlacement,
-    pub inline_options: MdInlinesWriterOptions,
+    pub inline_options: InlineElemOptions,
     pub include_thematic_breaks: bool,
 }
 

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -10,11 +10,12 @@ use std::cmp::max;
 use std::ops::Deref;
 
 #[derive(Copy, Clone, Debug)]
-pub struct MdOptions {
+pub struct MdWriterOptions {
     pub link_reference_placement: ReferencePlacement,
     pub footnote_reference_placement: ReferencePlacement,
     pub inline_options: InlineElemOptions,
     pub include_thematic_breaks: bool,
+    pub text_width: Option<usize>,
 }
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
@@ -58,7 +59,7 @@ pub enum ReferencePlacement {
     Doc,
 }
 
-pub(crate) fn write_md<'md, I, W>(options: MdOptions, out: &mut Output<W>, ctx: &'md MdContext, nodes: I)
+pub(crate) fn write_md<'md, I, W>(options: MdWriterOptions, out: &mut Output<W>, ctx: &'md MdContext, nodes: I)
 where
     I: Iterator<Item = &'md MdElem>,
     W: SimpleWrite,
@@ -82,7 +83,7 @@ where
 
 struct MdWriterState<'s, 'md> {
     ctx: &'md MdContext,
-    opts: MdOptions,
+    opts: MdWriterOptions,
     prev_was_thematic_break: bool,
     inlines_writer: &'s mut MdInlinesWriter<'md>,
 }
@@ -489,7 +490,7 @@ pub mod tests {
     use indoc::indoc;
 
     use super::*;
-    use crate::output::fmt_md::MdOptions;
+    use crate::output::fmt_md::MdWriterOptions;
     use crate::output::link_transform::LinkTransform;
     use crate::util::output::Output;
     use crate::util::utils_for_test::*;
@@ -675,7 +676,7 @@ pub mod tests {
 
         #[test]
         fn two_paragraphs_no_thematic_break() {
-            let mut options = MdOptions::default_for_tests();
+            let mut options = MdWriterOptions::default_for_tests();
             options.include_thematic_breaks = false;
             check_render_with(
                 options,
@@ -915,7 +916,7 @@ pub mod tests {
                 checked: Some(true),
                 item: md_elems!("second item"),
             };
-            let mut options = MdOptions::default_for_tests();
+            let mut options = MdWriterOptions::default_for_tests();
             options.include_thematic_breaks = false;
             check_render_refs_with(
                 options,
@@ -1317,7 +1318,7 @@ pub mod tests {
 
         #[test]
         fn two_blocks_no_thematic_break() {
-            let mut options = MdOptions::default_for_tests();
+            let mut options = MdWriterOptions::default_for_tests();
             options.include_thematic_breaks = false;
             check_render_with(
                 options,
@@ -1404,7 +1405,7 @@ pub mod tests {
 
             #[test]
             fn no_thematic_break() {
-                let mut options = MdOptions::default_for_tests();
+                let mut options = MdWriterOptions::default_for_tests();
                 options.include_thematic_breaks = false;
                 check_render_with(
                     options,
@@ -1850,7 +1851,7 @@ pub mod tests {
 
         #[test]
         fn two_links_inline_no_thematic_break() {
-            let mut options = MdOptions::default_for_tests();
+            let mut options = MdWriterOptions::default_for_tests();
             options.include_thematic_breaks = false;
             check_render_refs_with(
                 options,
@@ -1880,7 +1881,7 @@ pub mod tests {
 
         #[test]
         fn two_links_doc_pos_no_thematic_break() {
-            let mut options = MdOptions::default_for_tests();
+            let mut options = MdWriterOptions::default_for_tests();
             options.include_thematic_breaks = false;
             options.inline_options.link_format = LinkTransform::Reference;
             options.link_reference_placement = ReferencePlacement::Doc;
@@ -1917,7 +1918,7 @@ pub mod tests {
         #[test]
         fn reference_transform_smoke_test() {
             check_render_refs_with(
-                MdOptions::new_with(|mdo| mdo.inline_options.link_format = LinkTransform::Reference),
+                MdWriterOptions::new_with(|mdo| mdo.inline_options.link_format = LinkTransform::Reference),
                 vec![link_elem(Link {
                     text: vec![mdq_inline!("link text")],
                     link_definition: LinkDefinition {
@@ -1997,7 +1998,7 @@ pub mod tests {
         #[test]
         fn reference_transform_smoke_test() {
             check_render_refs_with(
-                MdOptions::new_with(|mdo| mdo.inline_options.link_format = LinkTransform::Reference),
+                MdWriterOptions::new_with(|mdo| mdo.inline_options.link_format = LinkTransform::Reference),
                 vec![image_elem(Image {
                     alt: "alt text".to_string(),
                     link: LinkDefinition {
@@ -2024,7 +2025,7 @@ pub mod tests {
         #[test]
         fn single_line() {
             check_render_with_ctx(
-                MdOptions::default_for_tests(),
+                MdWriterOptions::default_for_tests(),
                 (
                     MdContext::empty().with("a", md_elems!["Hello, world."]),
                     vec![
@@ -2044,7 +2045,7 @@ pub mod tests {
         #[test]
         fn two_lines() {
             check_render_with_ctx(
-                MdOptions::default_for_tests(),
+                MdWriterOptions::default_for_tests(),
                 (
                     MdContext::empty().with("a", md_elems!["Hello,\nworld."]),
                     vec![
@@ -2067,7 +2068,7 @@ pub mod tests {
         fn footnote_transform_smoke_test() {
             let (ctx, graf) = footnote_a_in_paragraph();
             check_render_refs_with_ctx(
-                MdOptions::new_with(|mdo| mdo.inline_options.renumber_footnotes = true),
+                MdWriterOptions::new_with(|mdo| mdo.inline_options.renumber_footnotes = true),
                 (ctx, vec![MdElem::Paragraph(graf)]),
                 indoc! {r#"
                     [^1]
@@ -2080,7 +2081,7 @@ pub mod tests {
         fn footnote_no_transform_smoke_test() {
             let (ctx, graf) = footnote_a_in_paragraph();
             check_render_refs_with_ctx(
-                MdOptions::new_with(|mdo| mdo.inline_options.renumber_footnotes = false),
+                MdWriterOptions::new_with(|mdo| mdo.inline_options.renumber_footnotes = false),
                 (ctx, vec![MdElem::Paragraph(graf)]),
                 indoc! {r#"
                     [^a]
@@ -2106,7 +2107,7 @@ pub mod tests {
         #[test]
         fn link_and_footnote() {
             check_render_with_ctx(
-                MdOptions::default_for_tests(),
+                MdWriterOptions::default_for_tests(),
                 (
                     MdContext::empty().with("a", md_elems!["this is my note"]),
                     md_elems![Paragraph {
@@ -2137,7 +2138,7 @@ pub mod tests {
         #[test]
         fn both_in_sections() {
             check_render_with_ctx(
-                MdOptions::new_with(|mdo| {
+                MdWriterOptions::new_with(|mdo| {
                     mdo.link_reference_placement = ReferencePlacement::Section;
                     mdo.footnote_reference_placement = ReferencePlacement::Section;
                 }),
@@ -2161,7 +2162,7 @@ pub mod tests {
         #[test]
         fn only_link_in_section() {
             check_render_with_ctx(
-                MdOptions::new_with(|mdo| {
+                MdWriterOptions::new_with(|mdo| {
                     mdo.link_reference_placement = ReferencePlacement::Section;
                     mdo.footnote_reference_placement = ReferencePlacement::Doc;
                 }),
@@ -2188,7 +2189,7 @@ pub mod tests {
         #[test]
         fn no_sections_but_writing_to_sections() {
             check_render_with(
-                MdOptions::new_with(|mdo| {
+                MdWriterOptions::new_with(|mdo| {
                     mdo.link_reference_placement = ReferencePlacement::Section;
                     mdo.footnote_reference_placement = ReferencePlacement::Section;
                 }),
@@ -2212,7 +2213,7 @@ pub mod tests {
         #[test]
         fn only_footnote_in_section() {
             check_render_with_ctx(
-                MdOptions::new_with(|mdo| {
+                MdWriterOptions::new_with(|mdo| {
                     mdo.link_reference_placement = ReferencePlacement::Doc;
                     mdo.footnote_reference_placement = ReferencePlacement::Section;
                 }),
@@ -2239,7 +2240,7 @@ pub mod tests {
         #[test]
         fn both_bottom_of_doc() {
             check_render_with_ctx(
-                MdOptions::new_with(|mdo| {
+                MdWriterOptions::new_with(|mdo| {
                     mdo.link_reference_placement = ReferencePlacement::Doc;
                     mdo.footnote_reference_placement = ReferencePlacement::Doc;
                 }),
@@ -2265,7 +2266,7 @@ pub mod tests {
         #[test]
         fn ordering() {
             check_render_with_ctx(
-                MdOptions::new_with(|mdo| {
+                MdWriterOptions::new_with(|mdo| {
                     mdo.link_reference_placement = ReferencePlacement::Doc;
                     mdo.footnote_reference_placement = ReferencePlacement::Doc;
                 }),
@@ -2387,14 +2388,14 @@ pub mod tests {
     }
 
     fn check_render(nodes: Vec<MdElem>, expect: &str) {
-        check_render_with(MdOptions::default_for_tests(), nodes, expect);
+        check_render_with(MdWriterOptions::default_for_tests(), nodes, expect);
     }
 
-    fn check_render_with(options: MdOptions, nodes: Vec<MdElem>, expect: &str) {
+    fn check_render_with(options: MdWriterOptions, nodes: Vec<MdElem>, expect: &str) {
         check_render_with_ctx(options, (MdContext::empty(), nodes), expect)
     }
 
-    fn check_render_with_ctx(options: MdOptions, inputs: (MdContext, Vec<MdElem>), expect: &str) {
+    fn check_render_with_ctx(options: MdWriterOptions, inputs: (MdContext, Vec<MdElem>), expect: &str) {
         let (ctx, nodes) = inputs;
         let mut wrapped = Vec::with_capacity(nodes.len());
         for node in nodes {
@@ -2404,14 +2405,14 @@ pub mod tests {
     }
 
     fn check_render_refs(nodes: Vec<MdElem>, expect: &str) {
-        check_render_refs_with(MdOptions::default_for_tests(), nodes, expect)
+        check_render_refs_with(MdWriterOptions::default_for_tests(), nodes, expect)
     }
 
-    fn check_render_refs_with(options: MdOptions, nodes: Vec<MdElem>, expect: &str) {
+    fn check_render_refs_with(options: MdWriterOptions, nodes: Vec<MdElem>, expect: &str) {
         check_render_refs_with_ctx(options, (MdContext::empty(), nodes), expect)
     }
 
-    fn check_render_refs_with_ctx(options: MdOptions, inputs: (MdContext, Vec<MdElem>), expect: &str) {
+    fn check_render_refs_with_ctx(options: MdWriterOptions, inputs: (MdContext, Vec<MdElem>), expect: &str) {
         let (ctx, nodes) = inputs;
         nodes.iter().for_each(|n| VARIANTS_CHECKER.see(n));
 

--- a/src/output/fmt_md_inlines.rs
+++ b/src/output/fmt_md_inlines.rs
@@ -38,19 +38,19 @@ impl<'md> PendingReferences<'md> {
 }
 
 #[derive(Serialize, Debug, PartialEq, Eq, Copy, Clone, Hash)]
-pub struct UrlAndTitle<'md> {
+pub(crate) struct UrlAndTitle<'md> {
     pub url: &'md String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub title: &'md Option<String>,
 }
 
 #[derive(Debug, Copy, Clone)]
-pub enum LinkLikeType {
+pub(crate) enum LinkLikeType {
     Link,
     Image,
 }
 
-pub trait LinkLike<'md> {
+pub(crate) trait LinkLike<'md> {
     fn link_info(&self) -> (LinkLikeType, LinkLabel<'md>, &'md LinkDefinition);
 }
 

--- a/src/output/fmt_md_inlines.rs
+++ b/src/output/fmt_md_inlines.rs
@@ -456,7 +456,7 @@ impl TitleQuote {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::output::{Output, OutputOpts};
+    use crate::util::output::{Output, OutputOptions};
     use crate::util::utils_for_test::*;
 
     mod title_quoting {
@@ -715,7 +715,7 @@ mod tests {
         text_width: Option<usize>,
         expected: impl ToString,
     ) {
-        let mut output = Output::new(String::new(), OutputOpts { text_width });
+        let mut output = Output::new(String::new(), OutputOptions { text_width });
         let ctx = MdContext::empty();
         let mut writer = MdInlinesWriter::new(
             &ctx,

--- a/src/output/fmt_md_inlines.rs
+++ b/src/output/fmt_md_inlines.rs
@@ -9,7 +9,7 @@ use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Copy, Clone)]
-pub struct MdInlinesWriterOptions {
+pub struct InlineElemOptions {
     pub link_format: LinkTransform,
     pub renumber_footnotes: bool,
 }
@@ -71,7 +71,7 @@ impl<'md> LinkLike<'md> for &'md Image {
 }
 
 impl<'md> MdInlinesWriter<'md> {
-    pub fn new(ctx: &'md MdContext, options: MdInlinesWriterOptions) -> Self {
+    pub fn new(ctx: &'md MdContext, options: InlineElemOptions) -> Self {
         let pending_refs_capacity = 8; // arbitrary guess
         Self {
             ctx,
@@ -663,7 +663,7 @@ mod tests {
             let ctx = MdContext::empty();
             let mut writer = MdInlinesWriter::new(
                 &ctx,
-                MdInlinesWriterOptions {
+                InlineElemOptions {
                     link_format: LinkTransform::Keep,
                     renumber_footnotes: false,
                 },
@@ -692,7 +692,7 @@ mod tests {
         let ctx = MdContext::empty();
         let mut writer = MdInlinesWriter::new(
             &ctx,
-            MdInlinesWriterOptions {
+            InlineElemOptions {
                 link_format: LinkTransform::Keep,
                 renumber_footnotes: false,
             },
@@ -719,7 +719,7 @@ mod tests {
         let ctx = MdContext::empty();
         let mut writer = MdInlinesWriter::new(
             &ctx,
-            MdInlinesWriterOptions {
+            InlineElemOptions {
                 link_format: LinkTransform::Keep,
                 renumber_footnotes: false,
             },

--- a/src/output/fmt_md_inlines.rs
+++ b/src/output/fmt_md_inlines.rs
@@ -456,7 +456,7 @@ impl TitleQuote {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::util::output::{Output, OutputOptions};
+    use crate::util::output::Output;
     use crate::util::utils_for_test::*;
 
     mod title_quoting {
@@ -715,7 +715,7 @@ mod tests {
         text_width: Option<usize>,
         expected: impl ToString,
     ) {
-        let mut output = Output::new(String::new(), OutputOptions { text_width });
+        let mut output = Output::new(String::new(), text_width);
         let ctx = MdContext::empty();
         let mut writer = MdInlinesWriter::new(
             &ctx,

--- a/src/output/fmt_plain_inline.rs
+++ b/src/output/fmt_plain_inline.rs
@@ -13,7 +13,7 @@ pub struct PlainWriter {
 }
 
 impl PlainWriter {
-    pub fn new(options: PlainWriterOptions) -> Self {
+    pub fn with_options(options: PlainWriterOptions) -> Self {
         Self { options }
     }
 

--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -1,6 +1,6 @@
 use crate::md_elem::elem::*;
 use crate::md_elem::*;
-use crate::output::fmt_md_inlines::{LinkLike, MdInlinesWriter, MdInlinesWriterOptions};
+use crate::output::fmt_md_inlines::{InlineElemOptions, LinkLike, MdInlinesWriter};
 use crate::util::output::Output;
 use clap::ValueEnum;
 use std::borrow::Cow;
@@ -41,7 +41,7 @@ impl<'md> LinkLabel<'md> {
             LinkLabel::Inline(inlines) => {
                 let mut inline_writer = MdInlinesWriter::new(
                     ctx,
-                    MdInlinesWriterOptions {
+                    InlineElemOptions {
                         link_format: LinkTransform::Keep,
                         renumber_footnotes: false,
                     },
@@ -422,7 +422,7 @@ mod tests {
         let ctx = MdContext::empty();
         let mut iw = MdInlinesWriter::new(
             &ctx,
-            MdInlinesWriterOptions {
+            InlineElemOptions {
                 link_format: LinkTransform::Keep,
                 renumber_footnotes: false,
             },
@@ -513,7 +513,7 @@ mod tests {
             let ctx = MdContext::empty();
             let mut iw = MdInlinesWriter::new(
                 &ctx,
-                MdInlinesWriterOptions {
+                InlineElemOptions {
                     link_format: LinkTransform::Keep,
                     renumber_footnotes: false,
                 },

--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -23,7 +23,7 @@ pub enum LinkTransform {
     Reference,
 }
 
-pub struct LinkTransformer {
+pub(crate) struct LinkTransformer {
     delegate: LinkTransformState,
 }
 

--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -119,7 +119,7 @@ impl<'md> LinkTransformation<'md> {
     // We could in principle return a Cow<'md, LinkReference>, and save some clones in the assigner.
     // To do that, fmt_md_inlines.rs would need to adjust to hold Cows instead of LinkLabels directly. For now, not
     // a high priority.
-    pub fn apply(self, transformer: &mut LinkTransformer, link: &'md LinkReference) -> LinkReference {
+    pub(crate) fn apply(self, transformer: &mut LinkTransformer, link: &'md LinkReference) -> LinkReference {
         match &mut transformer.delegate {
             LinkTransformState::Keep => Cow::Borrowed(link),
             LinkTransformState::Inline => Cow::Owned(LinkReference::Inline),

--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -28,7 +28,7 @@ pub struct LinkTransformer {
 }
 
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
-pub enum LinkLabel<'md> {
+pub(crate) enum LinkLabel<'md> {
     Text(Cow<'md, str>),
     Inline(&'md Vec<Inline>),
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -15,10 +15,8 @@ pub use crate::output::fmt_md::*;
 pub use crate::output::fmt_md_inlines::*;
 pub use crate::output::link_transform::*;
 
-pub mod plain {
-    pub use crate::output::fmt_plain_inline::*;
-    pub use crate::output::fmt_plain_str::*;
-}
+pub use crate::output::fmt_plain_inline::*;
+pub use crate::output::fmt_plain_str::*;
 
 pub fn serializable<'a>(
     elems: &'a [MdElem],

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -16,6 +16,7 @@ pub use crate::output::fmt_md::*;
 pub use crate::output::fmt_md_inlines::*;
 pub use crate::output::link_transform::*;
 pub use crate::output::output_adapter::*;
+pub use crate::util::output::OutputOptions;
 
 pub use crate::output::fmt_plain_inline::*;
 pub use crate::output::fmt_plain_str::*;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -16,7 +16,6 @@ pub use crate::output::fmt_md::*;
 pub use crate::output::fmt_md_inlines::*;
 pub use crate::output::link_transform::*;
 pub use crate::output::output_adapter::*;
-pub use crate::util::output::OutputOptions;
 
 pub use crate::output::fmt_plain_inline::*;
 pub use crate::output::fmt_plain_str::*;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,6 +1,6 @@
 mod fmt_md;
 mod fmt_md_inlines;
-pub mod fmt_plain_inline;
+mod fmt_plain_inline;
 mod fmt_plain_str;
 mod fmt_plain_writer;
 mod footnote_transform;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -5,6 +5,7 @@ mod fmt_plain_str;
 mod fmt_plain_writer;
 mod footnote_transform;
 mod link_transform;
+mod output_adapter;
 mod tree_ref_serde;
 
 use crate::md_elem::{MdContext, MdElem};
@@ -21,7 +22,7 @@ pub use crate::output::fmt_plain_str::*;
 pub fn serializable<'a>(
     elems: &'a [MdElem],
     ctx: &'a MdContext,
-    inline_options: MdInlinesWriterOptions,
+    inline_options: InlineElemOptions,
 ) -> impl Serialize + 'a {
     MdSerde::new(&elems, &ctx, inline_options)
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -8,8 +8,6 @@ mod link_transform;
 mod output_adapter;
 mod tree_ref_serde;
 
-use serde::Serialize;
-
 pub use crate::output::fmt_md::*;
 pub use crate::output::fmt_md_inlines::*;
 pub use crate::output::link_transform::*;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -7,15 +7,23 @@ mod footnote_transform;
 mod link_transform;
 mod tree_ref_serde;
 
-pub mod md {
-    pub use crate::output::fmt_md::*;
-    pub use crate::output::fmt_md_inlines::*;
-    pub use crate::output::link_transform::*;
-}
+use crate::md_elem::{MdContext, MdElem};
+use crate::output::tree_ref_serde::MdSerde;
+use serde::Serialize;
+
+pub use crate::output::fmt_md::*;
+pub use crate::output::fmt_md_inlines::*;
+pub use crate::output::link_transform::*;
+
 pub mod plain {
     pub use crate::output::fmt_plain_inline::*;
     pub use crate::output::fmt_plain_str::*;
 }
-pub mod serde {
-    pub use crate::output::tree_ref_serde::*;
+
+pub fn serializable<'a>(
+    elems: &'a [MdElem],
+    ctx: &'a MdContext,
+    inline_options: MdInlinesWriterOptions,
+) -> impl Serialize + 'a {
+    MdSerde::new(&elems, &ctx, inline_options)
 }

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -15,6 +15,7 @@ use serde::Serialize;
 pub use crate::output::fmt_md::*;
 pub use crate::output::fmt_md_inlines::*;
 pub use crate::output::link_transform::*;
+pub use crate::output::output_adapter::*;
 
 pub use crate::output::fmt_plain_inline::*;
 pub use crate::output::fmt_plain_str::*;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -8,8 +8,6 @@ mod link_transform;
 mod output_adapter;
 mod tree_ref_serde;
 
-use crate::md_elem::{MdContext, MdElem};
-use crate::output::tree_ref_serde::MdSerde;
 use serde::Serialize;
 
 pub use crate::output::fmt_md::*;
@@ -19,11 +17,3 @@ pub use crate::output::output_adapter::*;
 
 pub use crate::output::fmt_plain_inline::*;
 pub use crate::output::fmt_plain_str::*;
-
-pub fn serializable<'a>(
-    elems: &'a [MdElem],
-    ctx: &'a MdContext,
-    inline_options: InlineElemOptions,
-) -> impl Serialize + 'a {
-    MdSerde::new(&elems, &ctx, inline_options)
-}

--- a/src/output/output_adapter.rs
+++ b/src/output/output_adapter.rs
@@ -46,7 +46,7 @@ impl<W: fmt::Write> SimpleWrite for Adapter<W> {
     fn write_char(&mut self, ch: char) -> io::Result<()> {
         self.0
             .write_char(ch)
-            .map_err(|_| io::Error::new(io::ErrorKind::Other, "while writing char"))
+            .map_err(|err| io::Error::new(io::ErrorKind::Other, format!("while writing char: {}", err)))
     }
 
     fn flush(&mut self) -> io::Result<()> {

--- a/src/output/output_adapter.rs
+++ b/src/output/output_adapter.rs
@@ -1,19 +1,15 @@
 use crate::md_elem::{MdContext, MdElem};
-use crate::output::{write_md, MdOptions};
-use crate::util::output::{Output, OutputOptions, SimpleWrite};
+use crate::output::{write_md, MdWriterOptions};
+use crate::util::output::{Output, SimpleWrite};
 use std::{fmt, io};
 
 pub struct MdWriter {
-    md_options: MdOptions,
-    output_options: OutputOptions,
+    options: MdWriterOptions,
 }
 
 impl MdWriter {
-    pub fn with_options(md: MdOptions, output: OutputOptions) -> Self {
-        Self {
-            md_options: md,
-            output_options: output,
-        }
+    pub fn with_options(options: MdWriterOptions) -> Self {
+        Self { options }
     }
 
     pub fn write<'md, I, W>(&self, ctx: &'md MdContext, nodes: I, out: &mut W)
@@ -22,8 +18,8 @@ impl MdWriter {
         W: fmt::Write,
     {
         write_md(
-            self.md_options,
-            &mut Output::new(Adapter(out), self.output_options),
+            self.options,
+            &mut Output::new(Adapter(out), self.options.text_width),
             ctx,
             nodes.into_iter(),
         )

--- a/src/output/output_adapter.rs
+++ b/src/output/output_adapter.rs
@@ -16,7 +16,7 @@ impl MdWriter {
         }
     }
 
-    pub fn write_md_to_fmt<'md, I, W>(&self, ctx: &'md MdContext, nodes: I, out: W)
+    pub fn write_md_to_fmt<'md, I, W>(&self, ctx: &'md MdContext, nodes: I, out: &mut W)
     where
         I: IntoIterator<Item = &'md MdElem>,
         W: fmt::Write,
@@ -29,7 +29,7 @@ impl MdWriter {
         )
     }
 
-    pub fn write_md_to_io<'md, I, W>(&self, ctx: &'md MdContext, nodes: I, out: W)
+    pub fn write_md_to_io<'md, I, W>(&self, ctx: &'md MdContext, nodes: I, out: &mut W)
     where
         I: IntoIterator<Item = &'md MdElem>,
         W: io::Write,

--- a/src/output/output_adapter.rs
+++ b/src/output/output_adapter.rs
@@ -1,6 +1,8 @@
 use crate::md_elem::{MdContext, MdElem};
-use crate::output::{write_md, MdWriterOptions};
+use crate::output::tree_ref_serde::MdSerde;
+use crate::output::{write_md, InlineElemOptions, MdWriterOptions};
 use crate::util::output::{Output, SimpleWrite};
+use serde::Serialize;
 use std::{fmt, io};
 
 pub struct MdWriter {
@@ -28,6 +30,14 @@ impl MdWriter {
 
 pub fn io_to_fmt(writer: impl io::Write) -> impl fmt::Write {
     Adapter(writer)
+}
+
+pub fn serializable<'a>(
+    elems: &'a [MdElem],
+    ctx: &'a MdContext,
+    inline_options: InlineElemOptions,
+) -> impl Serialize + 'a {
+    MdSerde::new(&elems, &ctx, inline_options)
 }
 
 struct Adapter<W>(W);

--- a/src/output/output_adapter.rs
+++ b/src/output/output_adapter.rs
@@ -1,0 +1,58 @@
+use crate::md_elem::{MdContext, MdElem};
+use crate::output::{write_md, MdOptions};
+use crate::util::output::{Output, OutputOptions, SimpleWrite, Stream};
+use std::{fmt, io};
+
+pub struct MdWriter {
+    md_options: MdOptions,
+    output_options: OutputOptions,
+}
+
+impl MdWriter {
+    pub fn with_options(md: MdOptions, output: OutputOptions) -> Self {
+        Self {
+            md_options: md,
+            output_options: output,
+        }
+    }
+
+    pub fn write_md_to_fmt<'md, I, W>(&self, ctx: &'md MdContext, nodes: I, out: W)
+    where
+        I: IntoIterator<Item = &'md MdElem>,
+        W: fmt::Write,
+    {
+        write_md(
+            self.md_options,
+            &mut Output::new(Adapter(out), self.output_options),
+            ctx,
+            nodes.into_iter(),
+        )
+    }
+
+    pub fn write_md_to_io<'md, I, W>(&self, ctx: &'md MdContext, nodes: I, out: W)
+    where
+        I: IntoIterator<Item = &'md MdElem>,
+        W: io::Write,
+    {
+        write_md(
+            self.md_options,
+            &mut Output::new(Stream(out), self.output_options),
+            ctx,
+            nodes.into_iter(),
+        )
+    }
+}
+
+struct Adapter<W>(W);
+
+impl<W: fmt::Write> SimpleWrite for Adapter<W> {
+    fn write_char(&mut self, ch: char) -> io::Result<()> {
+        self.0
+            .write_char(ch)
+            .map_err(|_| io::Error::new(io::ErrorKind::Other, "while writing char"))
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}

--- a/src/output/tree_ref_serde.rs
+++ b/src/output/tree_ref_serde.rs
@@ -45,7 +45,6 @@ pub enum SerdeElem<'md> {
         link: LinkSerde<'md>,
     },
     List(Vec<LiSerde<'md>>),
-    ListItem(LiSerde<'md>),
     Section {
         depth: u8,
         title: String,

--- a/src/output/tree_ref_serde.rs
+++ b/src/output/tree_ref_serde.rs
@@ -1,6 +1,6 @@
 use crate::md_elem::elem::*;
 use crate::md_elem::*;
-use crate::output::fmt_md_inlines::{MdInlinesWriter, MdInlinesWriterOptions, UrlAndTitle};
+use crate::output::fmt_md_inlines::{InlineElemOptions, MdInlinesWriter, UrlAndTitle};
 use crate::output::link_transform::LinkLabel;
 use crate::util::output::Output;
 use serde::{Serialize, Serializer};
@@ -146,7 +146,7 @@ pub enum CodeBlockType {
 }
 
 impl<'md> MdSerde<'md> {
-    pub fn new(elems: &'md [MdElem], ctx: &'md MdContext, opts: MdInlinesWriterOptions) -> Self {
+    pub fn new(elems: &'md [MdElem], ctx: &'md MdContext, opts: InlineElemOptions) -> Self {
         let mut inlines_writer = MdInlinesWriter::new(ctx, opts);
         const DEFAULT_CAPACITY: usize = 16; // we could compute these, but it's not really worth it
         let mut result = MdSerde {
@@ -287,7 +287,7 @@ where
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::output::fmt_md_inlines::MdInlinesWriterOptions;
+    use crate::output::fmt_md_inlines::InlineElemOptions;
     use crate::output::link_transform::LinkTransform;
     use crate::util::utils_for_test::*;
 
@@ -629,7 +629,7 @@ mod tests {
     }
 
     fn check(given: MdElem, expect: &str) {
-        let opts = MdInlinesWriterOptions {
+        let opts = InlineElemOptions {
             link_format: LinkTransform::Keep,
             renumber_footnotes: false,
         };
@@ -637,14 +637,14 @@ mod tests {
     }
 
     fn check_md_ref(given: MdElem, expect: &str) {
-        let opts = MdInlinesWriterOptions {
+        let opts = InlineElemOptions {
             link_format: LinkTransform::Keep,
             renumber_footnotes: false,
         };
         check_with(opts, given, expect);
     }
 
-    fn check_with(opts: MdInlinesWriterOptions, elem_ref: MdElem, expect: &str) {
+    fn check_with(opts: InlineElemOptions, elem_ref: MdElem, expect: &str) {
         CHECKER.see(&elem_ref);
         let mut actual_bytes = Vec::with_capacity(32);
         serde_json::to_writer(&mut actual_bytes, &MdSerde::new(&[elem_ref], &MdContext::empty(), opts)).unwrap();

--- a/src/run/cli.rs
+++ b/src/run/cli.rs
@@ -1,4 +1,4 @@
-use crate::output::md::{LinkTransform, ReferencePlacement};
+use crate::output::{LinkTransform, ReferencePlacement};
 use clap::error::ErrorKind;
 use clap::{CommandFactory, Parser, ValueEnum};
 use std::borrow::Cow;

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -13,18 +13,18 @@ use std::{env, io};
 
 #[derive(Debug)]
 pub enum Error {
-    QueryParse(QueryParse),
+    QueryParse(QueryParseError),
     MarkdownParse(InvalidMd),
     FileReadError(Input, io::Error),
 }
 
 #[derive(Debug)]
-pub struct QueryParse {
+pub struct QueryParseError {
     query_string: String,
     error: ParseError,
 }
 
-impl Display for QueryParse {
+impl Display for QueryParseError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match &self.error {
             ParseError::Pest(err) => {
@@ -158,7 +158,7 @@ fn run_or_error(cli: &Cli, os: &mut impl OsFacade) -> Result<bool, Error> {
     let selectors: Selector = match selectors_str.deref().try_into() {
         Ok(selectors) => selectors,
         Err(error) => {
-            return Err(Error::QueryParse(QueryParse {
+            return Err(Error::QueryParse(QueryParseError {
                 query_string: selectors_str.into_owned(),
                 error,
             }));

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -199,10 +199,10 @@ fn run_or_error(cli: &Cli, os: &mut impl OsFacade) -> Result<bool, Error> {
                 .unwrap();
             }
             OutputFormat::Plain => {
-                let output_opts = output::plain::PlainOutputOpts {
+                let output_opts = output::PlainOutputOpts {
                     include_breaks: cli.should_add_breaks(),
                 };
-                output::plain::write_plain(&mut stdout, output_opts, pipeline_nodes.iter());
+                output::write_plain(&mut stdout, output_opts, pipeline_nodes.iter());
             }
         }
     }

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -172,7 +172,7 @@ fn run_or_error(cli: &Cli, os: &mut impl OsFacade) -> Result<bool, Error> {
     let md_options = output::MdOptions {
         link_reference_placement: cli.link_pos,
         footnote_reference_placement: cli.footnote_pos.unwrap_or(cli.link_pos),
-        inline_options: output::MdInlinesWriterOptions {
+        inline_options: output::InlineElemOptions {
             link_format: cli.link_format,
             renumber_footnotes: cli.renumber_footnotes,
         },

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -192,7 +192,7 @@ fn run_or_error(cli: &Cli, os: &mut impl OsFacade) -> Result<bool, Error> {
                         text_width: cli.wrap_width,
                     },
                 );
-                writer.write_md_to_io(&ctx, &pipeline_nodes, &mut stdout);
+                writer.write(&ctx, &pipeline_nodes, &mut output::io_to_fmt(&mut stdout));
             }
             OutputFormat::Json => {
                 serde_json::to_writer(

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -1,5 +1,4 @@
 use crate::md_elem::{InvalidMd, MdDoc, MdElem, ParseOptions};
-use crate::output::serde::MdSerde;
 use crate::query::ParseError;
 use crate::run::cli::{Cli, OutputFormat};
 use crate::select::{Selector, SelectorAdapter};
@@ -170,10 +169,10 @@ fn run_or_error(cli: &Cli, os: &mut impl OsFacade) -> Result<bool, Error> {
     let selector_adapter = SelectorAdapter::from(selectors);
     let pipeline_nodes = selector_adapter.find_nodes(&ctx, vec![MdElem::Doc(roots)]);
 
-    let md_options = output::md::MdOptions {
+    let md_options = output::MdOptions {
         link_reference_placement: cli.link_pos,
         footnote_reference_placement: cli.footnote_pos.unwrap_or(cli.link_pos),
-        inline_options: output::md::MdInlinesWriterOptions {
+        inline_options: output::MdInlinesWriterOptions {
             link_format: cli.link_format,
             renumber_footnotes: cli.renumber_footnotes,
         },
@@ -190,12 +189,12 @@ fn run_or_error(cli: &Cli, os: &mut impl OsFacade) -> Result<bool, Error> {
                     text_width: cli.wrap_width,
                 };
                 let mut out = Output::new(Stream(&mut stdout), output_opts);
-                output::md::write_md(&md_options, &mut out, &ctx, pipeline_nodes.iter());
+                output::write_md(&md_options, &mut out, &ctx, pipeline_nodes.iter());
             }
             OutputFormat::Json => {
                 serde_json::to_writer(
                     &mut stdout,
-                    &MdSerde::new(&pipeline_nodes, &ctx, md_options.inline_options),
+                    &output::serializable(&pipeline_nodes, &ctx, md_options.inline_options),
                 )
                 .unwrap();
             }

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -192,7 +192,7 @@ fn run_or_error(cli: &Cli, os: &mut impl OsFacade) -> Result<bool, Error> {
                         text_width: cli.wrap_width,
                     },
                 );
-                writer.write_md_to_io(&ctx, pipeline_nodes, stdout);
+                writer.write_md_to_io(&ctx, &pipeline_nodes, &mut stdout);
             }
             OutputFormat::Json => {
                 serde_json::to_writer(
@@ -202,10 +202,10 @@ fn run_or_error(cli: &Cli, os: &mut impl OsFacade) -> Result<bool, Error> {
                 .unwrap();
             }
             OutputFormat::Plain => {
-                let output_opts = output::PlainOutputOpts {
+                let writer = output::PlainWriter::new(output::PlainWriterOptions {
                     include_breaks: cli.should_add_breaks(),
-                };
-                output::write_plain(&mut stdout, output_opts, pipeline_nodes.iter());
+                });
+                writer.write(&pipeline_nodes, &mut stdout);
             }
         }
     }

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -22,7 +22,7 @@ macro_rules! adapters {
     { $($name:ident => $md_elem:ident),+ , <inlines> { $($inline:ident),+ , } } => {
 
         #[derive(Debug)]
-        pub enum SelectorAdapter {
+        pub(crate) enum SelectorAdapter {
             $(
             $name( paste!{[<$name Selector>]} ),
             )+

--- a/src/select/string_matcher.rs
+++ b/src/select/string_matcher.rs
@@ -1,6 +1,6 @@
 use crate::md_elem::elem::*;
 use crate::md_elem::*;
-use crate::output::plain::inlines_to_plain_string;
+use crate::output::inlines_to_plain_string;
 use crate::select::Matcher;
 use regex::Regex;
 use std::borrow::Borrow;

--- a/src/util/output.rs
+++ b/src/util/output.rs
@@ -31,8 +31,8 @@ impl<W: std::io::Write> SimpleWrite for Stream<W> {
     }
 }
 
-#[derive(Debug)]
-pub struct OutputOpts {
+#[derive(Debug, Copy, Clone)]
+pub struct OutputOptions {
     pub text_width: Option<usize>,
 }
 
@@ -105,7 +105,7 @@ enum WriteAction {
 }
 
 impl<W: SimpleWrite> Output<W> {
-    pub fn new(to: W, opts: OutputOpts) -> Self {
+    pub fn new(to: W, opts: OutputOptions) -> Self {
         Self {
             stream: to,
             indenter: IndentHandler::new(),
@@ -117,7 +117,7 @@ impl<W: SimpleWrite> Output<W> {
     }
 
     pub fn without_text_wrapping(to: W) -> Self {
-        Self::new(to, OutputOpts { text_width: None })
+        Self::new(to, OutputOptions { text_width: None })
     }
 
     pub fn replace_underlying(&mut self, new: W) -> std::io::Result<W> {
@@ -1051,7 +1051,7 @@ mod tests {
         }
 
         fn out_to_str_wrapped(wrap: usize, action: impl FnOnce(&mut Output<String>)) -> String {
-            let opts = OutputOpts { text_width: Some(wrap) };
+            let opts = OutputOptions { text_width: Some(wrap) };
             let mut out = Output::new(String::new(), opts);
             action(&mut out);
             out.take_underlying().unwrap()

--- a/src/util/utils_for_test.rs
+++ b/src/util/utils_for_test.rs
@@ -5,9 +5,9 @@ pub(crate) use test_utils::*;
 // export its contents.
 #[cfg(test)]
 mod test_utils {
-    use crate::output::md::LinkTransform;
-    use crate::output::md::MdInlinesWriterOptions;
-    use crate::output::md::{MdOptions, ReferencePlacement};
+    use crate::output::LinkTransform;
+    use crate::output::MdInlinesWriterOptions;
+    use crate::output::{MdOptions, ReferencePlacement};
     use std::fmt::Debug;
 
     impl LinkTransform {

--- a/src/util/utils_for_test.rs
+++ b/src/util/utils_for_test.rs
@@ -5,8 +5,8 @@ pub(crate) use test_utils::*;
 // export its contents.
 #[cfg(test)]
 mod test_utils {
+    use crate::output::InlineElemOptions;
     use crate::output::LinkTransform;
-    use crate::output::MdInlinesWriterOptions;
     use crate::output::{MdOptions, ReferencePlacement};
     use std::fmt::Debug;
 
@@ -27,7 +27,7 @@ mod test_utils {
             Self {
                 link_reference_placement: ReferencePlacement::default_for_tests(),
                 footnote_reference_placement: ReferencePlacement::default_for_tests(),
-                inline_options: MdInlinesWriterOptions {
+                inline_options: InlineElemOptions {
                     link_format: LinkTransform::default_for_tests(),
                     renumber_footnotes: false,
                 },

--- a/src/util/utils_for_test.rs
+++ b/src/util/utils_for_test.rs
@@ -7,7 +7,7 @@ pub(crate) use test_utils::*;
 mod test_utils {
     use crate::output::InlineElemOptions;
     use crate::output::LinkTransform;
-    use crate::output::{MdOptions, ReferencePlacement};
+    use crate::output::{MdWriterOptions, ReferencePlacement};
     use std::fmt::Debug;
 
     impl LinkTransform {
@@ -22,7 +22,7 @@ mod test_utils {
         }
     }
 
-    impl MdOptions {
+    impl MdWriterOptions {
         pub fn default_for_tests() -> Self {
             Self {
                 link_reference_placement: ReferencePlacement::default_for_tests(),
@@ -32,12 +32,13 @@ mod test_utils {
                     renumber_footnotes: false,
                 },
                 include_thematic_breaks: true,
+                text_width: None,
             }
         }
 
         pub fn new_with<F>(init: F) -> Self
         where
-            F: FnOnce(&mut MdOptions),
+            F: FnOnce(&mut MdWriterOptions),
         {
             let mut mdo = Self::default_for_tests();
             init(&mut mdo);


### PR DESCRIPTION
In service of #213. This basically cleans up the `output::` mod, and presents a nicer interface to it. I wanted to keep the existing code more or less in place, so a lot of this is just setting up appropriate facades, and `pub use`ing those instead of the underlying.