### PR TITLE
expose Cli args as RunOptions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use mdq::run::{Error, OsFacade, RunOptions};
+use mdq::run::{CliOptions, Error, OsFacade};
 use std::io;
 use std::io::{stdin, stdout, Read};
 use std::process::ExitCode;
@@ -28,7 +28,7 @@ impl OsFacade for RealOs {
 }
 
 fn main() -> ExitCode {
-    let cli = RunOptions::parse();
+    let cli = CliOptions::parse();
 
     if mdq::run::run(&cli, &mut RealOs) {
         ExitCode::SUCCESS

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use mdq::run::{Cli, Error, OsFacade};
+use mdq::run::{Error, OsFacade, RunOptions};
 use std::io;
 use std::io::{stdin, stdout, Read};
 use std::process::ExitCode;
@@ -28,7 +28,7 @@ impl OsFacade for RealOs {
 }
 
 fn main() -> ExitCode {
-    let cli = Cli::parse();
+    let cli = RunOptions::parse();
 
     if mdq::run::run(&cli, &mut RealOs) {
         ExitCode::SUCCESS

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,7 +30,11 @@ impl OsFacade for RealOs {
 fn main() -> ExitCode {
     let cli = CliOptions::parse();
 
-    if mdq::run::run(&cli, &mut RealOs) {
+    if !cli.extra_validation() {
+        return ExitCode::FAILURE;
+    }
+
+    if mdq::run::run(&cli.into(), &mut RealOs) {
         ExitCode::SUCCESS
     } else {
         ExitCode::FAILURE

--- a/src/run/cli.rs
+++ b/src/run/cli.rs
@@ -108,26 +108,6 @@ macro_rules! create_options_structs {
                 }
             }
         }
-
-        impl From<RunOptions> for CliOptions {
-            fn from(value: RunOptions) -> Self {
-                let (br, no_br) = match value.add_breaks {
-                    None => (false, false),
-                    Some(true) => (true, false),
-                    Some(false) => (false, true),
-                };
-                Self {
-                    $($name: value.$name,)*
-                    br_umbrella: false,
-                    list_selector: None,
-                    selectors: Some(value.selectors),
-                    markdown_file_paths: value.markdown_file_paths,
-                    br,
-                    no_br,
-                }
-            }
-        }
-
     };
 }
 

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -1,7 +1,7 @@
 use crate::md_elem::{InvalidMd, MdDoc, MdElem, ParseOptions};
 use crate::output::MdWriter;
 use crate::query::ParseError;
-use crate::run::cli::{Cli, OutputFormat};
+use crate::run::cli::{OutputFormat, RunOptions};
 use crate::select::{Selector, SelectorAdapter};
 use crate::{md_elem, output, query};
 use pest::error::ErrorVariant;
@@ -130,7 +130,7 @@ pub trait OsFacade {
 
 // TODO: replace with a method that doesn't take OsFacade (that should be defined in main.rs), but instead takes
 //  an FnOnce(MdElem) -> R
-pub fn run(cli: &Cli, os: &mut impl OsFacade) -> bool {
+pub fn run(cli: &RunOptions, os: &mut impl OsFacade) -> bool {
     if !cli.extra_validation() {
         return false;
     }
@@ -143,7 +143,7 @@ pub fn run(cli: &Cli, os: &mut impl OsFacade) -> bool {
     }
 }
 
-fn run_or_error(cli: &Cli, os: &mut impl OsFacade) -> Result<bool, Error> {
+fn run_or_error(cli: &RunOptions, os: &mut impl OsFacade) -> Result<bool, Error> {
     let contents_str = os.read_all(&cli.markdown_file_paths)?;
     let mut options = ParseOptions::gfm();
     options.allow_unknown_markdown = cli.allow_unknown_markdown;

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -1,14 +1,14 @@
 use crate::md_elem::{InvalidMd, MdDoc, MdElem, ParseOptions};
 use crate::output::MdWriter;
 use crate::query::ParseError;
-use crate::run::cli::{CliOptions, OutputFormat};
+use crate::run::cli::OutputFormat;
+use crate::run::RunOptions;
 use crate::select::{Selector, SelectorAdapter};
 use crate::{md_elem, output, query};
 use pest::error::ErrorVariant;
 use pest::Span;
 use std::fmt::{Display, Formatter};
 use std::io::Write;
-use std::ops::Deref;
 use std::{env, io};
 
 #[derive(Debug)]
@@ -130,10 +130,7 @@ pub trait OsFacade {
 
 // TODO: replace with a method that doesn't take OsFacade (that should be defined in main.rs), but instead takes
 //  an FnOnce(MdElem) -> R
-pub fn run(cli: &CliOptions, os: &mut impl OsFacade) -> bool {
-    if !cli.extra_validation() {
-        return false;
-    }
+pub fn run(cli: &RunOptions, os: &mut impl OsFacade) -> bool {
     match run_or_error(cli, os) {
         Ok(ok) => ok,
         Err(err) => {
@@ -143,7 +140,7 @@ pub fn run(cli: &CliOptions, os: &mut impl OsFacade) -> bool {
     }
 }
 
-fn run_or_error(cli: &CliOptions, os: &mut impl OsFacade) -> Result<bool, Error> {
+fn run_or_error(cli: &RunOptions, os: &mut impl OsFacade) -> Result<bool, Error> {
     let contents_str = os.read_all(&cli.markdown_file_paths)?;
     let mut options = ParseOptions::gfm();
     options.allow_unknown_markdown = cli.allow_unknown_markdown;
@@ -154,12 +151,12 @@ fn run_or_error(cli: &CliOptions, os: &mut impl OsFacade) -> Result<bool, Error>
         }
     };
 
-    let selectors_str = cli.selector_string();
-    let selectors: Selector = match selectors_str.deref().try_into() {
+    let selectors_str = &cli.selectors;
+    let selectors: Selector = match selectors_str.try_into() {
         Ok(selectors) => selectors,
         Err(error) => {
             return Err(Error::QueryParse(QueryParseError {
-                query_string: selectors_str.into_owned(),
+                query_string: selectors_str.to_string(),
                 error,
             }));
         }

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -1,7 +1,7 @@
 use crate::md_elem::{InvalidMd, MdDoc, MdElem, ParseOptions};
 use crate::output::MdWriter;
 use crate::query::ParseError;
-use crate::run::cli::{OutputFormat, RunOptions};
+use crate::run::cli::{CliOptions, OutputFormat};
 use crate::select::{Selector, SelectorAdapter};
 use crate::{md_elem, output, query};
 use pest::error::ErrorVariant;
@@ -130,7 +130,7 @@ pub trait OsFacade {
 
 // TODO: replace with a method that doesn't take OsFacade (that should be defined in main.rs), but instead takes
 //  an FnOnce(MdElem) -> R
-pub fn run(cli: &RunOptions, os: &mut impl OsFacade) -> bool {
+pub fn run(cli: &CliOptions, os: &mut impl OsFacade) -> bool {
     if !cli.extra_validation() {
         return false;
     }
@@ -143,7 +143,7 @@ pub fn run(cli: &RunOptions, os: &mut impl OsFacade) -> bool {
     }
 }
 
-fn run_or_error(cli: &RunOptions, os: &mut impl OsFacade) -> Result<bool, Error> {
+fn run_or_error(cli: &CliOptions, os: &mut impl OsFacade) -> Result<bool, Error> {
     let contents_str = os.read_all(&cli.markdown_file_paths)?;
     let mut options = ParseOptions::gfm();
     options.allow_unknown_markdown = cli.allow_unknown_markdown;

--- a/tests/integ_test.rs
+++ b/tests/integ_test.rs
@@ -65,7 +65,7 @@ impl<const N: usize> Case<N> {
 
     fn run(&self) -> (bool, String, String) {
         let all_cli_args = ["cmd"].iter().chain(&self.cli_args);
-        let cli = mdq::run::RunOptions::try_parse_from(all_cli_args).unwrap();
+        let cli = mdq::run::CliOptions::try_parse_from(all_cli_args).unwrap();
         let restore = EnvVarRestore::set_var("MDQ_PORTABLE_ERRORS", "1");
         let mut runner = CaseRunner {
             case: self,

--- a/tests/integ_test.rs
+++ b/tests/integ_test.rs
@@ -72,7 +72,7 @@ impl<const N: usize> Case<N> {
             stdout: vec![],
             stderr: "".to_string(),
         };
-        let result = mdq::run::run(&cli, &mut runner);
+        let result = mdq::run::run(&cli.into(), &mut runner);
 
         let out_str =
             String::from_utf8(runner.stdout).unwrap_or_else(|err| String::from_utf8_lossy(err.as_bytes()).into_owned());

--- a/tests/integ_test.rs
+++ b/tests/integ_test.rs
@@ -65,7 +65,7 @@ impl<const N: usize> Case<N> {
 
     fn run(&self) -> (bool, String, String) {
         let all_cli_args = ["cmd"].iter().chain(&self.cli_args);
-        let cli = mdq::run::Cli::try_parse_from(all_cli_args).unwrap();
+        let cli = mdq::run::RunOptions::try_parse_from(all_cli_args).unwrap();
         let restore = EnvVarRestore::set_var("MDQ_PORTABLE_ERRORS", "1");
         let mut runner = CaseRunner {
             case: self,


### PR DESCRIPTION
- CliOptions still exists, but is hidden
- RunOptions is visible, and that's what people should use
- define the args via a macro, so that they're in sync

This doesn't hide clap from the dependencies, but it does hide it from the public-facing API.

In service of #307.