### PR TITLE
add user-facing docs to API

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,7 @@
+//! This crate is the library behind the [mdq] CLI tool.
+//!
+//! [mdq]: https://github.com/yshavit/mdq
+
 pub mod md_elem;
 pub mod output;
 mod query;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,17 @@
 //! This crate is the library behind the [mdq] CLI tool.
 //!
+//! The general flow is to:
+//!
+//! 1. Parse Markdown into [`md_elem::MdElem`]s via [`md_elem::parse`]
+//! 2. Parse a query via [`select::Selector`'s `TryFrom::<&str>`][selector-parse]
+//! 3. Use [`select::Selector::find_nodes`] to filter the `MdElem`s down
+//! 4. Use [`output`] to write the results
+//!
+//! The [`run`] module implements this workflow using options similar to the CLI's flags and a facade for I/O. You can
+//! also do it yourself.
+//!
 //! [mdq]: https://github.com/yshavit/mdq
+//! [selector-parse]: select::Selector#impl-TryFrom<%26str>-for-Selector
 
 pub mod md_elem;
 pub mod output;

--- a/src/md_elem/mod.rs
+++ b/src/md_elem/mod.rs
@@ -1,4 +1,4 @@
-//! Parsed Markdown nodes
+//! Parsed Markdown nodes (and how to parse them).
 //!
 //! This module provides the AST for a parsed Markdown document. Its main entry point is [parse].
 mod tree;

--- a/src/md_elem/mod.rs
+++ b/src/md_elem/mod.rs
@@ -1,3 +1,6 @@
+//! Parsed Markdown nodes
+//!
+//! This module provides the AST for a parsed Markdown document. Its main entry point is [parse].
 mod tree;
 mod tree_ref;
 

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -202,7 +202,8 @@ pub enum InvalidMd {
     /// Internal error. You shouldn't get this.
     InternalError(UnknownMdParseError),
     /// Internal error. You shouldn't get this.
-    /// Internal error. You shouldn't get this. See [`ParseOptions::allow_unknown_markdown`].
+    ///
+    /// See [`ParseOptions::allow_unknown_markdown`].
     UnknownMarkdown(&'static str),
     /// Internal error. You shouldn't get this.
     ParseError(String),

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -8,7 +8,20 @@ use std::vec::IntoIter;
 use elem::*;
 use markdown::mdast;
 
-// If we ever need any additional document-wide state, we can rename this
+/// Additional context for navigating or parsing a Markdown document.
+///
+/// The main functionality this exposes is [`MdContext::get_footnote`], which lets you look up a footnote's contents by
+/// its id. Footnotes can contain loops, such as:
+///
+/// ```markdown
+/// This is my footnote[^1].
+///
+/// [^1]: Note that it contains a cycle[^2].
+/// [^2]: This cycles back to the first footnote[^1].
+/// ```
+///
+/// That means we can't contain them fully within an MdElem without some external state to hold the links. This is that
+/// state.
 #[derive(Debug, PartialEq)]
 pub struct MdContext {
     footnotes: HashMap<FootnoteId, Vec<MdElem>>,
@@ -32,13 +45,60 @@ impl MdContext {
     }
 }
 
+/// A fully parsed Markdown document.
+///
+/// This comprises the root (top-level) [MdElem]s, as well as the [MdContext] for navigating footnotes.
 pub struct MdDoc {
     pub roots: Vec<MdElem>,
     pub ctx: MdContext,
 }
 
+/// A single node of the parsed Markdown.
+///
+/// These come in three flavors:
+///
+/// - block container nodes, which contain other `MdElem`s within them
+/// - inline container nodes, which contain [`Inline`]s
+/// - leaf nodes, which are scalars and represent the leaf nodes of the tree
 #[derive(Debug, PartialEq, Clone)]
 pub enum MdElem {
+    /// Block container: A full Markdown document, or contiguous section of one.
+    ///
+    /// This is distinct from just a `Vec<MdElem>` in that `Doc` represents a single document, while `Vec<MdElem>`
+    /// represents a stream of elements. For example, if you had:
+    ///
+    /// ```markdown
+    /// # First section
+    ///
+    /// Some text
+    ///
+    /// - a list item
+    /// - another list item
+    ///
+    /// More text.
+    ///
+    /// # Second section
+    ///
+    /// And so on.
+    /// ```
+    ///
+    /// Then that whole thing can be represented by a single `Doc` with two elements (both [`MdElem::Section`]s).
+    /// Additionally, the body of each section is also a `Doc`. The `Doc` for the first section is:
+    ///
+    /// ```markdown
+    /// Some text
+    ///
+    /// - a list item
+    /// - another list item
+    ///
+    /// More text.
+    /// ```
+    ///
+    /// On the other hand, if you select list items containing the word "item", you'll get a `Vec<MdElem>` (_not_ a
+    /// `Doc`) containing two items, one for each list item.
+    ///
+    /// Concretely: When mdq outputs the Markdown, it can (if requested) put thematic breaks or newlines between each
+    /// element of a `Vec<MdElem>`, but it will not do that for the elements within a `Doc`.
     Doc(Vec<MdElem>),
 
     // Container blocks
@@ -50,13 +110,29 @@ pub enum MdElem {
     CodeBlock(CodeBlock),
     Paragraph(Paragraph),
     Table(Table),
+    /// A thematic break:
+    ///
+    /// ```markdown
+    /// -----
+    /// ```
+    ///
+    /// Note that there are several styles of thematic break. mdq unifies them at parse time, which results in some
+    /// information loss; you can't necessarily reconstruct the original Markdown.
     ThematicBreak,
     Inline(Inline),
     BlockHtml(BlockHtml),
 }
 
+/// Options for parsing Markdown.
+///
+/// See: [parse].
 pub struct ParseOptions {
     pub(crate) mdast_options: markdown::ParseOptions,
+    /// Usually only required for debugging. Defaults to `false`.
+    ///
+    /// If mdq encounters an unexpected state coming from the underlying parsing library it uses, it can either ignore
+    /// it or error out. If this field is set to `true`, mdq will ignore the unexpected state. Otherwise, [`parse`] will
+    /// return an `Err` containing [`InvalidMd::UnknownMarkdown`].
     pub allow_unknown_markdown: bool,
 }
 
@@ -69,6 +145,7 @@ impl ParseOptions {
     }
 }
 
+/// Parse some Markdown text.
 pub fn parse(text: &str, options: &ParseOptions) -> Result<MdDoc, InvalidMd> {
     let ast = markdown::to_mdast(text, &options.mdast_options).map_err(|e| InvalidMd::ParseError(format!("{e}")))?;
     let read_options = ReadOptions {
@@ -104,24 +181,45 @@ pub(crate) struct ReadOptions {
     pub allow_unknown_markdown: bool,
 }
 
+/// Various error conditions that can come from trying to parse Markdown.
 #[derive(Debug, PartialEq)]
 pub enum InvalidMd {
+    /// Encountered a Markdown component that mdq doesn't support.
+    ///
+    /// This is typically an extension for a particular Markdown variant which mdq knows about, but does not handle.
     Unsupported(MarkdownPart),
+
+    /// Internal error. You shouldn't get this.
     NonListItemDirectlyUnderList(MarkdownPart),
+    /// Internal error. You shouldn't get this.
     NonRowDirectlyUnderTable(MarkdownPart),
+    /// Internal error. You shouldn't get this.
     NonInlineWhereInlineExpected(MdElem),
+    /// Internal error. You shouldn't get this.
     MissingReferenceDefinition(String),
+    /// Internal error. You shouldn't get this.
     ConflictingReferenceDefinition(String),
+    /// Internal error. You shouldn't get this.
     InternalError(UnknownMdParseError),
+    /// Internal error. You shouldn't get this.
+    /// Internal error. You shouldn't get this. See [`ParseOptions::allow_unknown_markdown`].
     UnknownMarkdown(&'static str),
+    /// Internal error. You shouldn't get this.
     ParseError(String),
 }
 
+/// A portion of unparsable markdown.
+///
+/// This wraps the AST from the underlying library that mdq uses; the only thing you can really do with it is to use its
+/// `Debug`.
 #[derive(Debug, PartialEq, Eq)]
 pub struct MarkdownPart {
     node: mdast::Node,
 }
 
+/// An unknown, internal error.
+///
+/// See [`InvalidMd::InternalError`].
 // A wrapper for [Backtrace] that implements [PartialEq] to always return `true`. This lets us use it in a struct
 // while still letting us use `#[derive(PartialEq)]`
 #[derive(Debug)]
@@ -177,30 +275,108 @@ impl Display for InvalidMd {
     }
 }
 
+/// Inner details of the [MdElem] variants.
 pub mod elem {
     use super::*;
     use std::ops::Deref;
 
+    /// A table row.
+    ///
+    /// This is just a `Vec` of table cells, but the type alias makes it much easier to reason about.
     pub type TableRow = Vec<TableCell>;
+
+    /// A table cell within a row.
+    ///
+    /// This is just a `Vec` of [Inline]s, but the type alias makes it much easier to reason about.
     pub type TableCell = Vec<Inline>;
 
+    /// Different kinds of code blocks.
     #[derive(Debug, PartialEq, Hash, Clone)]
     pub enum CodeVariant {
+        /// A standard code block
+        ///
+        /// ````markdown
+        /// ```
+        /// foo()
+        /// ```
+        /// ````
+        ///
+        /// If the `Option<CodeOpts>` is `None`, this block has no metadata in the opening fence (as in the example
+        /// directly above). Otherwise, the first word directly after the backticks is the language, and the rest of
+        /// the string is the metadata:
+        ///
+        /// ````markdown
+        /// ```rust and some metadata
+        /// foo()
+        /// ```
+        /// ````
         Code(Option<CodeOpts>),
-        Math { metadata: Option<String> },
+        Math {
+            metadata: Option<String>,
+        },
         Toml,
         Yaml,
     }
 
+    /// Some inline text.
     #[derive(Debug, PartialEq, Eq, Hash, Clone)]
     pub enum Inline {
+        /// The marker for a footnote; this is a terminal node in the [MdElem] tree.
+        ///
+        /// ```markdown
+        /// [^1]
+        /// ```
+        ///
+        /// Note that this does not include the content of the footnote. To get that, use [`MdContext::get_footnote`].
         Footnote(FootnoteId),
+
+        /// A span of formatted text (~~deleted~~, _emphasized_, or **strong**).
+        ///
+        /// The span's body is a `Vec<Inline>`, so you can have nested spans, emphasized link text, etc.
         Span(Span),
+
+        /// An image; this is a terminal node in the [MdElem] tree.
+        ///
+        /// ```markdown
+        /// ![alt text](https://example.com/hello-world.png)
+        /// ```
         Image(Image),
+
+        /// A link
+        ///
+        /// ```markdown
+        /// ![display text](https://example.com/hello-world)
+        /// ```
         Link(Link),
+
+        /// Some text; this is a terminal node in the [MdElem] tree.
         Text(Text),
     }
 
+    /// An html block.
+    ///
+    /// These are `<tag>`s that start a line. The exact rules are somewhat involved (see:
+    /// <https://github.github.com/gfm/#html-blocks>), but basically these are non-inlined html tags.
+    ///
+    /// The [`BlockHtml::value`] includes the opening and closing tags, and any text between them:
+    ///
+    /// ```
+    /// use mdq::md_elem::{parse, MdElem, ParseOptions};
+    /// use mdq::md_elem::elem::{BlockHtml, Inline, Paragraph, Text, TextVariant};
+    /// let md_text = r"
+    /// <div>
+    ///
+    /// My div content
+    ///
+    /// </div>
+    /// ";
+    /// let md_elems = parse(md_text, &ParseOptions::gfm()).unwrap();
+    /// assert_eq!(3, md_elems.roots.len());
+    /// let MdElem::BlockHtml(BlockHtml{value}) = &md_elems.roots[0] else { panic!() };
+    /// assert_eq!("<div>", value);
+    /// ```
+    ///
+    /// c.f. [`TextVariant::InlineHtml`]
     #[derive(Debug, PartialEq, Eq, Hash, Clone)]
     pub struct BlockHtml {
         pub value: String,
@@ -212,30 +388,35 @@ pub mod elem {
         }
     }
 
+    /// See [`Inline::Span`]
     #[derive(Debug, PartialEq, Eq, Hash, Clone)]
     pub struct Span {
         pub variant: crate::md_elem::tree::elem::SpanVariant,
         pub children: Vec<crate::md_elem::tree::elem::Inline>,
     }
 
+    /// See [`Inline::Text`]
     #[derive(Debug, PartialEq, Eq, Hash, Clone)]
     pub struct Text {
         pub variant: crate::md_elem::tree::elem::TextVariant,
         pub value: String,
     }
 
+    /// See [`Inline::Link`]
     #[derive(Debug, PartialEq, Eq, Hash, Clone)]
     pub struct Link {
         pub text: Vec<crate::md_elem::tree::elem::Inline>,
         pub link_definition: crate::md_elem::tree::elem::LinkDefinition,
     }
 
+    /// See [`Inline::Image`]
     #[derive(Debug, PartialEq, Eq, Hash, Clone)]
     pub struct Image {
         pub alt: String,
         pub link: crate::md_elem::tree::elem::LinkDefinition,
     }
 
+    /// See [`Inline::Footnote`] and [`MdContext::get_footnote`]
     #[derive(Debug, PartialEq, Eq, Hash, Clone)]
     pub struct FootnoteId {
         pub id: String,
@@ -262,22 +443,34 @@ pub mod elem {
         }
     }
 
+    /// The link in an [`Link`] or [`Image`].
     #[derive(Debug, PartialEq, Eq, Hash, Clone)]
     pub struct LinkDefinition {
+        /// The link's destination.
         pub url: String,
         /// If you have `[1]: https://example.com "my title"`, this is the "my title".
         ///
-        /// See: https://github.github.com/gfm/#link-reference-definitions
+        /// See: <https://github.github.com/gfm/#link-reference-definitions>
         pub title: Option<String>,
+        /// The link's reference style.
         pub reference: LinkReference,
     }
 
+    /// A single list item.
+    ///
+    /// ```markdown
+    /// - hello
+    ///   ^^^^^
+    /// ```
     #[derive(Debug, PartialEq, Clone)]
     pub struct ListItem {
+        /// If `None`, this item is not a task. If `Some`, this is a task, with the bool representing whether it's
+        /// marked as completed.
         pub checked: Option<bool>,
         pub item: Vec<MdElem>,
     }
 
+    /// ~~deleted~~, _emphasized_, or **strong**; see [`Span`]
     #[derive(Debug, PartialEq, Eq, Hash, Clone)]
     pub enum SpanVariant {
         Delete,
@@ -285,14 +478,77 @@ pub mod elem {
         Strong,
     }
 
+    /// See [`Text`]
     #[derive(Debug, PartialEq, Eq, Hash, Clone)]
     pub enum TextVariant {
+        /// Plain text
         Plain,
+
+        /// `inline code`
         Code,
+
+        /// $inline math$
         Math,
-        Html,
+
+        /// inline <span>html</span>
+        ///
+        /// Each tag (and not any text inside matching tags) is its own [`Inline::Text`], and the text's `value`
+        /// includes the angle brackets:
+        ///
+        /// ```
+        /// use mdq::md_elem::{parse, MdElem, ParseOptions};
+        /// use mdq::md_elem::elem::{Inline, Paragraph, Text, TextVariant};
+        /// let md_elems = parse("inline <span>html</span>", &ParseOptions::gfm()).unwrap();
+        /// assert_eq!(1, md_elems.roots.len());
+        /// let MdElem::Paragraph(Paragraph{body}) = &md_elems.roots[0] else { panic!() };
+        /// assert_eq!(4, body.len());
+        /// assert_eq!(&Inline::Text(Text{variant: TextVariant::InlineHtml, value: "<span>".to_string()}), &body[1]);
+        /// ```
+        ///
+        /// c.f. [`BlockHtml`]
+        InlineHtml,
     }
 
+    /// A section title and its body.
+    ///
+    /// ```markdown
+    /// # This is a title with depth 1
+    ///
+    /// This is its body.
+    /// ```
+    ///
+    /// Note that many Markdown parsers treat Markdown as non-hierarchical: the title is a top-level node, and its
+    /// body is another top-level node sibling to it. mdq does not do this: each section's body belongs to the section.
+    ///
+    /// Deeper sections will be contained as [`MdElem::Section`]s within this [`Section::body`]. For example, given:
+    ///
+    /// ```markdown
+    /// # This is a title with depth 1
+    ///
+    /// Hello, world.
+    ///
+    /// ## This is a title with depth 2
+    ///
+    /// Alpha, bravo.
+    ///
+    /// # Back to depth 1
+    ///
+    /// Foo, bar.
+    /// ```
+    ///
+    /// ... the tree would look roughly like:
+    ///
+    /// - This is a title with depth 1
+    ///
+    ///   Hello, world.
+    ///
+    ///   - This is a title with depth 2
+    ///
+    ///     Alpha, bravo
+    ///
+    /// - Back to depth 1
+    ///
+    ///   Foo, bar.
     #[derive(Debug, PartialEq, Clone)]
     pub struct Section {
         pub depth: u8,
@@ -300,28 +556,66 @@ pub mod elem {
         pub body: Vec<MdElem>,
     }
 
+    /// Just a standard paragraph
+    ///
+    /// ```markdown
+    /// Hello, world.
+    /// ```
     #[derive(Debug, PartialEq, Clone)]
     pub struct Paragraph {
         pub body: Vec<Inline>,
     }
 
+    /// A block quote.
+    ///
+    /// ```markdown
+    /// Hello, world.
+    /// ```
     #[derive(Debug, PartialEq, Clone)]
     pub struct BlockQuote {
         pub body: Vec<MdElem>,
     }
 
+    /// A list.
+    ///
+    /// ```markdown
+    /// - hello
+    /// - world
+    /// ```
+    ///
+    /// or
+    ///
+    /// ```markdown
+    /// 1. hello
+    /// 2. world
+    /// ```
+    ///
+    /// If [`List::starting_index`] is `None`, this is an unordered list. If it is `Some`, this is an ordered list,
+    /// starting at the specified index.
     #[derive(Debug, PartialEq, Clone)]
     pub struct List {
         pub starting_index: Option<u32>,
         pub items: Vec<ListItem>,
     }
 
+    /// A table.
+    ///
+    /// Tables will always have at least one row, and the length of [`Table::alignments`] should equal the length of
+    /// that first row's `Vec<TableCell>`.
     #[derive(Debug, PartialEq, Clone)]
     pub struct Table {
         pub alignments: Vec<Option<ColumnAlignment>>,
+        /// The table's rows. Each `TableRow` is a `Vec<TableCell>`, and each `TableCell` is a `Vec<Inline>`. It can
+        /// get confusing to iterate these nested vecs!
+        ///
+        /// The first row is the header row.
         pub rows: Vec<TableRow>,
     }
 
+    /// Left, right, or center for table columns.
+    ///
+    /// This enum does not define "no alignment". It is typically used in an `Option<ColumnAlignment>`, where "no
+    /// alignment" is represented as `None`.
     #[derive(Debug, PartialEq, Clone, Copy)]
     pub enum ColumnAlignment {
         Left,
@@ -329,21 +623,64 @@ pub mod elem {
         Center,
     }
 
+    /// A code block.
+    ///
+    /// ````markdown
+    /// ```
+    /// code block
+    /// ```
+    /// ````
+    ///
+    /// This includes "code-like" blocks like yaml and block-level math, which some variants of Markdown support.
     #[derive(Debug, PartialEq, Clone)]
     pub struct CodeBlock {
+        /// The type of code block
         pub variant: CodeVariant,
+        /// The contents of the code block; everything between the fence lines, or the indented contents.
         pub value: String,
     }
 
-    /// See https://github.github.com/gfm/#link-reference-definitions
+    /// A [LinkDefinition]'s reference style.
+    ///
+    /// See <https://github.github.com/gfm/#link-reference-definitions>
     #[derive(Debug, PartialEq, Eq, Clone, Hash)]
     pub enum LinkReference {
+        /// ```markdown
+        /// [hello](https://example.com/world)
+        /// ```
         Inline,
+
+        /// ```markdown
+        /// [hello][hello-link]
+        ///
+        /// [hello-link]: https://example.com/world
+        /// ```
+        ///
+        /// This includes numbered links:
+        ///
+        /// ```markdown
+        /// [hello][1]
+        ///
+        /// [1]: https://example.com/world
+        /// ```
         Full(String),
+
+        /// ```markdown
+        /// [hello][]
+        ///
+        /// [hello]: https://example.com/world
+        /// ```
         Collapsed,
+
+        /// ```markdown
+        /// [hello]
+        ///
+        /// [hello]: https://example.com/world
+        /// ```
         Shortcut,
     }
 
+    /// See [`CodeVariant::Code`]
     #[derive(Debug, PartialEq, Hash, Clone)]
     pub struct CodeOpts {
         pub language: String,
@@ -753,7 +1090,7 @@ impl MdElem {
             let inline = match child {
                 MdElem::Inline(inline) => inline,
                 MdElem::BlockHtml(html) => Inline::Text(Text {
-                    variant: TextVariant::Html,
+                    variant: TextVariant::InlineHtml,
                     value: html.value,
                 }),
                 _ => return Err(InvalidMd::NonInlineWhereInlineExpected(child)),
@@ -1331,11 +1668,11 @@ mod tests {
                     assert_eq!(body, vec![
                         mdq_inline!("In "),
                         Inline::Text (Text{
-                            variant: TextVariant::Html,
+                            variant: TextVariant::InlineHtml,
                             value: "<em>".to_string()}),
                         mdq_inline!("a paragraph."),
                         Inline::Text (Text{
-                            variant: TextVariant::Html,
+                            variant: TextVariant::InlineHtml,
                             value: "</em>".to_string()}),
                     ])
                 });
@@ -1351,11 +1688,11 @@ mod tests {
                     assert_eq!(body, vec![
                         mdq_inline!("In "),
                         Inline::Text (Text{
-                            variant: TextVariant::Html,
+                            variant: TextVariant::InlineHtml,
                             value: "<em\nnewline  >".to_string()}),
                         mdq_inline!("a paragraph."),
                         Inline::Text (Text{
-                            variant: TextVariant::Html,
+                            variant: TextVariant::InlineHtml,
                             value: "</em>".to_string()}),
                     ])
                 });

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -456,7 +456,7 @@ pub mod elem {
         pub reference: LinkReference,
     }
 
-    /// A single list item.
+    /// An item within a list.
     ///
     /// ```markdown
     /// - hello

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -11,13 +11,48 @@ use std::ops::Deref;
 
 #[derive(Copy, Clone, Debug)]
 pub struct MdWriterOptions {
+    /// Where to put link references (for non-inline links).
     pub link_reference_placement: ReferencePlacement,
+    /// Where to put footnote references.
     pub footnote_reference_placement: ReferencePlacement,
+    /// Inline Markdown options.
     pub inline_options: InlineElemOptions,
+    /// Whether to include thematic breaks between top-level elements.
+    ///
+    /// If `true`, each top-level element will be separated by a thematic break:
+    ///
+    /// ```markdown
+    ///    -----
+    /// ```
+    ///
+    /// Note that "top-level" refers to the nodes you pass into [`MdWriter::write`], not to what might
+    /// otherwise look "top level" to a user. For example, if you were to construct an [`MdElem::Section`] with depth 2,
+    /// and within its body another `Section` with depth 1, only the outer depth-2 `Section` would count as top-level
+    /// for these breaks.
+    ///
+    /// [`MdWriter::write`]: crate::output::MdWriter
     pub include_thematic_breaks: bool,
+    /// Optional text wrapping.
+    ///
+    /// Code blocks will never wrap, and certain inline elements (like URLs) will be treated as atomic: if any part of
+    /// them wraps, the whole thing will wrap, and if it starts a line then it will never wrap.
+    ///
+    /// For example:
+    ///
+    /// <pre>
+    /// ┌────────────────────────────────┐
+    /// │This is a long line that will   │
+    /// │wrap. But                       │
+    /// │[this](https://example.com/will/not/wrap)
+    /// |because it's a URL.             │
+    /// └────────────────────────────────┘
+    /// </pre>
+    ///
+    ///
     pub text_width: Option<usize>,
 }
 
+/// Whether to put link definitions at the end of each section, or at the bottom of the whole document.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum ReferencePlacement {
     /// Show link definitions in the first section that uses the link.

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -247,7 +247,7 @@ impl<'s, 'md> MdWriterState<'s, 'md> {
 
         let mut row_strs = Vec::with_capacity(alignments.len());
 
-        let mut column_widths = [0].repeat(alignments.len());
+        let mut column_widths = vec![0; alignments.len()];
         if !alignments.is_empty() {
             for (idx, alignment) in alignments.iter().enumerate() {
                 let width = match *alignment {

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -509,7 +509,7 @@ pub mod tests {
         Inline(Inline::Text(Text{variant: TextVariant::Plain, ..})),
         Inline(Inline::Text(Text{variant: TextVariant::Code, ..})),
         Inline(Inline::Text(Text{variant: TextVariant::Math, ..})),
-        Inline(Inline::Text(Text{variant: TextVariant::Html, ..})),
+        Inline(Inline::Text(Text{variant: TextVariant::InlineHtml, ..})),
 
         Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..})),
         Inline(Inline::Link(Link{link_definition: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..})),
@@ -1457,7 +1457,7 @@ pub mod tests {
             fn html() {
                 check_render(
                     vec![MdElem::Inline(Inline::Text(Text {
-                        variant: TextVariant::Html,
+                        variant: TextVariant::InlineHtml,
                         value: "<a hello />".to_string(),
                     }))],
                     indoc! {"<a hello />"},
@@ -2353,7 +2353,7 @@ pub mod tests {
                             value: "Hello ".to_string()
                         }),
                         Inline::Text(Text {
-                            variant: TextVariant::Html,
+                            variant: TextVariant::InlineHtml,
                             value: "<span class=\"greeting\">".to_string()
                         }),
                         Inline::Text(Text {
@@ -2361,7 +2361,7 @@ pub mod tests {
                             value: "world".to_string()
                         }),
                         Inline::Text(Text {
-                            variant: TextVariant::Html,
+                            variant: TextVariant::InlineHtml,
                             value: "</span>".to_string()
                         }),
                     ]

--- a/src/output/fmt_md_inlines.rs
+++ b/src/output/fmt_md_inlines.rs
@@ -8,6 +8,7 @@ use std::borrow::Cow;
 use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 
+/// Options for formatting inline elements.
 #[derive(Debug, Copy, Clone)]
 pub struct InlineElemOptions {
     pub link_format: LinkTransform,

--- a/src/output/fmt_md_inlines.rs
+++ b/src/output/fmt_md_inlines.rs
@@ -145,7 +145,7 @@ impl<'md> MdInlinesWriter<'md> {
                 let (surround_ch, surround_space) = match variant {
                     TextVariant::Plain => (Cow::Borrowed(""), false),
                     TextVariant::Math => (Cow::Borrowed("$"), false),
-                    TextVariant::Html => (Cow::Borrowed(""), false),
+                    TextVariant::InlineHtml => (Cow::Borrowed(""), false),
                     TextVariant::Code => {
                         let backticks_info = BackticksInfo::from(value);
                         let surround_ch = if backticks_info.count == 0 {

--- a/src/output/fmt_plain_inline.rs
+++ b/src/output/fmt_plain_inline.rs
@@ -8,19 +8,24 @@ pub struct PlainWriterOptions {
     pub include_breaks: bool,
 }
 
+/// A struct for writing [MdElem]s as plain text (as per `--output plain`)
+///
+/// This generally strips all Markdown-y aspects of from the elements, and leaves only the core text. For example,
+/// `_emphasized text_` will be rendered simply as `"emphasized text"`, and `- a list` will be rendered just as
+/// "`a list"`.
+///
+/// Links and images will have their URLs removed, leaving only the display/alt text.
 pub struct PlainWriter {
     options: PlainWriterOptions,
 }
 
 impl PlainWriter {
+    /// Create a new `PlainWriter` with the given options
     pub fn with_options(options: PlainWriterOptions) -> Self {
         Self { options }
     }
 
-    pub fn options(&mut self) -> &mut PlainWriterOptions {
-        &mut self.options
-    }
-
+    /// Writes the given nodes to the given writer.
     pub fn write<'md, I, W>(&self, nodes: I, out: &mut W)
     where
         I: IntoIterator<Item = &'md MdElem>,

--- a/src/output/fmt_plain_str.rs
+++ b/src/output/fmt_plain_str.rs
@@ -1,8 +1,7 @@
 use crate::md_elem::elem::*;
 use std::borrow::Borrow;
 
-// TODO this should not be exposed
-pub fn inlines_to_plain_string<N: Borrow<Inline>>(inlines: &[N]) -> String {
+pub(crate) fn inlines_to_plain_string<N: Borrow<Inline>>(inlines: &[N]) -> String {
     let mut result = String::with_capacity(inlines.len() * 5); // random guess
     build_inlines(&mut result, inlines);
     result

--- a/src/output/fmt_plain_str.rs
+++ b/src/output/fmt_plain_str.rs
@@ -43,7 +43,7 @@ mod tests {
         Text(Text { variant: TextVariant::Plain, .. }),
         Text(Text { variant: TextVariant::Code, .. }),
         Text(Text { variant: TextVariant::Math, .. }),
-        Text(Text { variant: TextVariant::Html, .. }),
+        Text(Text { variant: TextVariant::InlineHtml, .. }),
         Link { .. },
         Image { .. },
         Footnote(_),

--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -8,6 +8,7 @@ use std::collections::hash_map::Entry;
 use std::collections::HashMap;
 use std::ops::Deref;
 
+/// Whether to render links as inline, reference form, or keep them as they were.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum LinkTransform {
     /// Keep links as they were in the original

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,3 +1,4 @@
+//! Output `md_elem`s to various formats.
 mod fmt_md;
 mod fmt_md_inlines;
 mod fmt_plain_inline;

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -9,10 +9,11 @@ mod link_transform;
 mod output_adapter;
 mod tree_ref_serde;
 
+pub(crate) use crate::output::fmt_plain_str::*;
+
 pub use crate::output::fmt_md::*;
 pub use crate::output::fmt_md_inlines::*;
 pub use crate::output::link_transform::*;
 pub use crate::output::output_adapter::*;
 
 pub use crate::output::fmt_plain_inline::*;
-pub use crate::output::fmt_plain_str::*;

--- a/src/output/output_adapter.rs
+++ b/src/output/output_adapter.rs
@@ -5,15 +5,18 @@ use crate::util::output::{Output, SimpleWrite};
 use serde::Serialize;
 use std::{fmt, io};
 
+/// A struct for writing [MdElem]s as Markdown (as per `--output markdown`).
 pub struct MdWriter {
     options: MdWriterOptions,
 }
 
 impl MdWriter {
+    /// Creates a new [MdWriter] with the given options.
     pub fn with_options(options: MdWriterOptions) -> Self {
         Self { options }
     }
 
+    /// Writes the given nodes to the given writer.
     pub fn write<'md, I, W>(&self, ctx: &'md MdContext, nodes: I, out: &mut W)
     where
         I: IntoIterator<Item = &'md MdElem>,
@@ -28,11 +31,16 @@ impl MdWriter {
     }
 }
 
+/// Utility for translating an [`std::io::Write`] into a [`std::fmt::Write`].
+///
+/// [`std::io::Write`]: io::Write
+/// [`std::fmt::Write`]: fmt::Write
 pub fn io_to_fmt(writer: impl io::Write) -> impl fmt::Write {
     Adapter(writer)
 }
 
-pub fn serializable<'a>(
+/// Transform [`MdElem`]s into a [`Serialize`].
+pub fn md_to_serialize<'a>(
     elems: &'a [MdElem],
     ctx: &'a MdContext,
     inline_options: InlineElemOptions,

--- a/src/query/matcher_try_from.rs
+++ b/src/query/matcher_try_from.rs
@@ -1,23 +1,20 @@
 use crate::query::strings::{ParsedString, ParsedStringMode};
 use crate::query::{DetachedSpan, Pair, ParseError};
-use crate::select::{Any, Matcher, Regex};
+use crate::select::{Matcher, Regex};
 
 impl TryFrom<Option<Pair<'_>>> for Matcher {
     type Error = ParseError;
 
     fn try_from(pair: Option<Pair>) -> Result<Self, Self::Error> {
         let Some(pair) = pair else {
-            return Ok(Self::Any(Any::Implicit));
+            return Ok(Self::Any { explicit: false });
         };
         let span = DetachedSpan::from(&pair);
         let parsed_string: ParsedString = pair.into_inner().try_into()?;
         if parsed_string.is_equivalent_to_asterisk() {
-            let any_variant = if parsed_string.explicit_wildcard {
-                Any::Explicit
-            } else {
-                Any::Implicit
-            };
-            return Ok(Self::Any(any_variant));
+            return Ok(Self::Any {
+                explicit: parsed_string.explicit_wildcard,
+            });
         }
         let matcher = match parsed_string.mode {
             ParsedStringMode::CaseSensitive => Self::Text {

--- a/src/query/selector_try_from.rs
+++ b/src/query/selector_try_from.rs
@@ -122,8 +122,8 @@ impl Selector {
                 }
                 let row_matcher = Matcher::try_from(res.row.take().map_err(to_parse_error)?)?;
                 Ok(Self::Table(TableMatcher {
-                    column: column_matcher,
-                    row: row_matcher,
+                    headers: column_matcher,
+                    rows: row_matcher,
                 }))
             }
             Rule::selector | _ => {
@@ -726,8 +726,8 @@ mod tests {
             find_selector(
                 ":-: * :-:",
                 Selector::Table(TableMatcher {
-                    column: Matcher::Any { explicit: true },
-                    row: Matcher::Any { explicit: false },
+                    headers: Matcher::Any { explicit: true },
+                    rows: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -737,8 +737,8 @@ mod tests {
             find_selector(
                 ":-: Header :-:",
                 Selector::Table(TableMatcher {
-                    column: matcher_text(false, "Header", false),
-                    row: Matcher::Any { explicit: false },
+                    headers: matcher_text(false, "Header", false),
+                    rows: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -748,8 +748,8 @@ mod tests {
             find_selector(
                 ":-: * :-: Data",
                 Selector::Table(TableMatcher {
-                    column: Matcher::Any { explicit: true },
-                    row: matcher_text(false, "Data", false),
+                    headers: Matcher::Any { explicit: true },
+                    rows: matcher_text(false, "Data", false),
                 }),
             )
         }
@@ -759,8 +759,8 @@ mod tests {
             find_selector(
                 ":-: Header :-: Data",
                 Selector::Table(TableMatcher {
-                    column: matcher_text(false, "Header", false),
-                    row: matcher_text(false, "Data", false),
+                    headers: matcher_text(false, "Header", false),
+                    rows: matcher_text(false, "Data", false),
                 }),
             )
         }

--- a/src/query/selector_try_from.rs
+++ b/src/query/selector_try_from.rs
@@ -6,7 +6,7 @@ use crate::query::traversal_composites::{
 };
 use crate::query::{DetachedSpan, Pair, Pairs, ParseError, Query};
 use crate::select::{
-    Any, BlockQuoteMatcher, CodeBlockMatcher, HtmlMatcher, LinklikeMatcher, ListItemMatcher, ListItemTask, Matcher,
+    BlockQuoteMatcher, CodeBlockMatcher, HtmlMatcher, LinklikeMatcher, ListItemMatcher, ListItemTask, Matcher,
     ParagraphMatcher, SectionMatcher, Selector, TableMatcher,
 };
 
@@ -114,7 +114,7 @@ impl Selector {
                     Some(column_matcher_span) => DetachedSpan::from(column_matcher_span),
                 };
                 let column_matcher = Matcher::try_from(column_matcher_span)?;
-                if matches!(column_matcher, Matcher::Any(Any::Implicit)) {
+                if matches!(column_matcher, Matcher::Any { explicit: false }) {
                     return Err(ParseError::Other(
                         detached_span,
                         "table column matcher cannot empty; use an explicit \"*\"".to_string(),
@@ -214,7 +214,7 @@ mod tests {
             find_selector(
                 "| #",
                 Selector::Section(SectionMatcher {
-                    title: Matcher::Any(Any::Implicit),
+                    title: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -224,7 +224,7 @@ mod tests {
             find_selector(
                 "# |",
                 Selector::Section(SectionMatcher {
-                    title: Matcher::Any(Any::Implicit),
+                    title: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -235,11 +235,11 @@ mod tests {
                 "# | []()",
                 Selector::Chain(vec![
                     Selector::Section(SectionMatcher {
-                        title: Matcher::Any(Any::Implicit),
+                        title: Matcher::Any { explicit: false },
                     }),
                     Selector::Link(LinklikeMatcher {
-                        display_matcher: Matcher::Any(Any::Implicit),
-                        url_matcher: Matcher::Any(Any::Implicit),
+                        display_matcher: Matcher::Any { explicit: false },
+                        url_matcher: Matcher::Any { explicit: false },
                     }),
                 ]),
             );
@@ -251,11 +251,11 @@ mod tests {
                 "# || | []()",
                 Selector::Chain(vec![
                     Selector::Section(SectionMatcher {
-                        title: Matcher::Any(Any::Implicit),
+                        title: Matcher::Any { explicit: false },
                     }),
                     Selector::Link(LinklikeMatcher {
-                        display_matcher: Matcher::Any(Any::Implicit),
-                        url_matcher: Matcher::Any(Any::Implicit),
+                        display_matcher: Matcher::Any { explicit: false },
+                        url_matcher: Matcher::Any { explicit: false },
                     }),
                 ]),
             );
@@ -270,7 +270,7 @@ mod tests {
             find_selector(
                 "#",
                 Selector::Section(SectionMatcher {
-                    title: Matcher::Any(Any::Implicit),
+                    title: Matcher::Any { explicit: false },
                 }),
             );
         }
@@ -297,7 +297,7 @@ mod tests {
                 Selector::ListItem(ListItemMatcher {
                     ordered: false,
                     task: ListItemTask::None,
-                    matcher: Matcher::Any(Any::Implicit),
+                    matcher: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -335,7 +335,7 @@ mod tests {
                 Selector::ListItem(ListItemMatcher {
                     ordered: true,
                     task: ListItemTask::None,
-                    matcher: Matcher::Any(Any::Implicit),
+                    matcher: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -371,7 +371,7 @@ mod tests {
                 Selector::ListItem(ListItemMatcher {
                     ordered: false,
                     task: ListItemTask::Unselected,
-                    matcher: Matcher::Any(Any::Implicit),
+                    matcher: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -383,7 +383,7 @@ mod tests {
                 Selector::ListItem(ListItemMatcher {
                     ordered: false,
                     task: ListItemTask::Selected,
-                    matcher: Matcher::Any(Any::Implicit),
+                    matcher: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -395,7 +395,7 @@ mod tests {
                 Selector::ListItem(ListItemMatcher {
                     ordered: false,
                     task: ListItemTask::Either,
-                    matcher: Matcher::Any(Any::Implicit),
+                    matcher: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -447,8 +447,8 @@ mod tests {
             find_selector(
                 "[]()",
                 Selector::Link(LinklikeMatcher {
-                    display_matcher: Matcher::Any(Any::Implicit),
-                    url_matcher: Matcher::Any(Any::Implicit),
+                    display_matcher: Matcher::Any { explicit: false },
+                    url_matcher: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -459,7 +459,7 @@ mod tests {
                 "[hello]()",
                 Selector::Link(LinklikeMatcher {
                     display_matcher: matcher_text(false, "hello", false),
-                    url_matcher: Matcher::Any(Any::Implicit),
+                    url_matcher: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -469,7 +469,7 @@ mod tests {
             find_selector(
                 "[](example.com)",
                 Selector::Link(LinklikeMatcher {
-                    display_matcher: Matcher::Any(Any::Implicit),
+                    display_matcher: Matcher::Any { explicit: false },
                     url_matcher: matcher_text(false, "example.com", false),
                 }),
             )
@@ -491,8 +491,8 @@ mod tests {
             find_selector(
                 "![]()",
                 Selector::Image(LinklikeMatcher {
-                    display_matcher: Matcher::Any(Any::Implicit),
-                    url_matcher: Matcher::Any(Any::Implicit),
+                    display_matcher: Matcher::Any { explicit: false },
+                    url_matcher: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -503,7 +503,7 @@ mod tests {
                 "![alt text]()",
                 Selector::Image(LinklikeMatcher {
                     display_matcher: matcher_text(false, "alt text", false),
-                    url_matcher: Matcher::Any(Any::Implicit),
+                    url_matcher: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -517,7 +517,7 @@ mod tests {
             find_selector(
                 ">",
                 Selector::BlockQuote(BlockQuoteMatcher {
-                    text: Matcher::Any(Any::Implicit),
+                    text: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -551,8 +551,8 @@ mod tests {
             find_selector(
                 "```",
                 Selector::CodeBlock(CodeBlockMatcher {
-                    language: Matcher::Any(Any::Implicit),
-                    contents: Matcher::Any(Any::Implicit),
+                    language: Matcher::Any { explicit: false },
+                    contents: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -563,7 +563,7 @@ mod tests {
                 "```rust",
                 Selector::CodeBlock(CodeBlockMatcher {
                     language: matcher_text(false, "rust", false),
-                    contents: Matcher::Any(Any::Implicit),
+                    contents: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -574,7 +574,7 @@ mod tests {
                 "```rust",
                 Selector::CodeBlock(CodeBlockMatcher {
                     language: matcher_text(false, "rust", false),
-                    contents: Matcher::Any(Any::Implicit),
+                    contents: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -584,7 +584,7 @@ mod tests {
             find_selector(
                 "``` fn main()",
                 Selector::CodeBlock(CodeBlockMatcher {
-                    language: Matcher::Any(Any::Implicit),
+                    language: Matcher::Any { explicit: false },
                     contents: matcher_text(false, "fn main()", false),
                 }),
             )
@@ -612,7 +612,7 @@ mod tests {
             find_selector(
                 "</>",
                 Selector::Html(HtmlMatcher {
-                    html: Matcher::Any(Any::Implicit),
+                    html: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -663,7 +663,7 @@ mod tests {
             find_selector(
                 "P:",
                 Selector::Paragraph(ParagraphMatcher {
-                    text: Matcher::Any(Any::Implicit),
+                    text: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -726,8 +726,8 @@ mod tests {
             find_selector(
                 ":-: * :-:",
                 Selector::Table(TableMatcher {
-                    column: Matcher::Any(Any::Explicit),
-                    row: Matcher::Any(Any::Implicit),
+                    column: Matcher::Any { explicit: true },
+                    row: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -738,7 +738,7 @@ mod tests {
                 ":-: Header :-:",
                 Selector::Table(TableMatcher {
                     column: matcher_text(false, "Header", false),
-                    row: Matcher::Any(Any::Implicit),
+                    row: Matcher::Any { explicit: false },
                 }),
             )
         }
@@ -748,7 +748,7 @@ mod tests {
             find_selector(
                 ":-: * :-: Data",
                 Selector::Table(TableMatcher {
-                    column: Matcher::Any(Any::Explicit),
+                    column: Matcher::Any { explicit: true },
                     row: matcher_text(false, "Data", false),
                 }),
             )

--- a/src/run/cli.rs
+++ b/src/run/cli.rs
@@ -71,6 +71,7 @@ macro_rules! create_options_structs {
             pub(crate) markdown_file_paths: Vec<String>,
         }
 
+        /// Options analogous to the mdq CLI's switches.
         #[derive(Parser, Debug, PartialEq, Eq)]
         pub struct RunOptions {
             $(
@@ -141,7 +142,7 @@ create_options_structs! {
     clap(long, default_value_t = true, action = clap::ArgAction::Set)
     pub renumber_footnotes: bool,
 
-    /// Output the results as a JSON object, instead of as markdown.
+    /// Specifies the output format. Defaults to markdown.
     clap(long, short, default_value_t = OutputFormat::Markdown)
     pub output: OutputFormat,
 
@@ -221,6 +222,7 @@ impl CliOptions {
     }
 }
 
+/// Output formats, analogous to `--output` in the CLI.
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, ValueEnum)]
 pub enum OutputFormat {
     /// Output results as Markdown.

--- a/src/run/mod.rs
+++ b/src/run/mod.rs
@@ -1,3 +1,7 @@
+//! End-to-end runs.
+//!
+//! This module combines the [`crate::md_elem`], [`crate::select`], and [`crate::output`] mods into a single workflow.
+//! It's useful for building functionality like the CLI's, but running it within-process.
 mod cli;
 mod run;
 

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -188,7 +188,7 @@ fn run_or_error(cli: &RunOptions, os: &mut impl OsFacade) -> Result<bool, Error>
             OutputFormat::Json => {
                 serde_json::to_writer(
                     &mut stdout,
-                    &output::serializable(&pipeline_nodes, &ctx, md_options.inline_options),
+                    &output::md_to_serialize(&pipeline_nodes, &ctx, md_options.inline_options),
                 )
                 .unwrap();
             }

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -3,7 +3,7 @@ use crate::output::MdWriter;
 use crate::query::ParseError;
 use crate::run::cli::OutputFormat;
 use crate::run::RunOptions;
-use crate::select::{Selector, SelectorAdapter};
+use crate::select::Selector;
 use crate::{md_elem, output, query};
 use pest::error::ErrorVariant;
 use pest::Span;

--- a/src/run/run.rs
+++ b/src/run/run.rs
@@ -191,8 +191,7 @@ fn run_or_error(cli: &RunOptions, os: &mut impl OsFacade) -> Result<bool, Error>
         }
     };
 
-    let selector_adapter = SelectorAdapter::from(selectors);
-    let pipeline_nodes = selector_adapter.find_nodes(&ctx, vec![MdElem::Doc(roots)]);
+    let pipeline_nodes = selectors.find_nodes(&ctx, vec![MdElem::Doc(roots)]);
 
     // TODO: turn this into an impl From
     let md_options = output::MdWriterOptions {

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -75,9 +75,8 @@ adapters! {
     }
 }
 
-// TODO this should not be exposed
 impl SelectorAdapter {
-    pub fn find_nodes(&self, ctx: &MdContext, nodes: Vec<MdElem>) -> Vec<MdElem> {
+    pub(crate) fn find_nodes(&self, ctx: &MdContext, nodes: Vec<MdElem>) -> Vec<MdElem> {
         let mut result = Vec::with_capacity(8); // arbitrary guess
         let mut search_context = SearchContext::new(ctx);
         for node in nodes {

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -149,7 +149,7 @@ impl SelectorAdapter {
                         Vec::new()
                     }
                 }
-                Inline::Text(Text { variant, value }) if variant == TextVariant::Html => {
+                Inline::Text(Text { variant, value }) if variant == TextVariant::InlineHtml => {
                     vec![MdElem::BlockHtml(value.into())]
                 }
                 Inline::Link(Link { text, .. }) => text.into_iter().map(|child| MdElem::Inline(child)).collect(),

--- a/src/select/matcher.rs
+++ b/src/select/matcher.rs
@@ -1,17 +1,28 @@
+/// A type for matching against expected strings.
+///
+/// Given a selector like `# hello world` (for a section selector), this defines the `hello world` portion.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Matcher {
+    /// Quoted or unquoted text, with optional anchoring.
     Text {
         case_sensitive: bool,
         anchor_start: bool,
         text: String,
         anchor_end: bool,
     },
+    /// A regex match. This will match any substring by default, though you can use `^` and `$` anchors.
+    ///
+    /// The actual regex library is intentionally obscured so that it can change in the future without breaking the API.
     Regex(Regex),
-    Any {
-        explicit: bool,
-    },
+
+    /// Any string. This can be implicit (an empty matcher in a query string, like `# | ...`), or explicit
+    /// (a `*` in a query string, like `# * | ...`).
+    Any { explicit: bool },
 }
 
+/// An opaque wrapper around a regular expression.
+///
+/// The actual regex library is intentionally obscured so that it can change in the future without breaking the API.
 #[derive(Debug, Clone)]
 pub struct Regex {
     pub(crate) re: regex::Regex,

--- a/src/select/matcher.rs
+++ b/src/select/matcher.rs
@@ -7,7 +7,9 @@ pub enum Matcher {
         anchor_end: bool,
     },
     Regex(Regex),
-    Any(Any),
+    Any {
+        explicit: bool,
+    },
 }
 
 #[derive(Debug, Clone)]
@@ -22,9 +24,3 @@ impl PartialEq for Regex {
 }
 
 impl Eq for Regex {}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum Any {
-    Implicit,
-    Explicit,
-}

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -1,3 +1,4 @@
+//! Selector strings. This is the heart of mdq.
 mod api;
 mod match_selector;
 mod matcher;

--- a/src/select/sel_table.rs
+++ b/src/select/sel_table.rs
@@ -31,8 +31,8 @@ impl TrySelector<Table> for TableSelector {
 impl From<TableMatcher> for TableSelector {
     fn from(value: TableMatcher) -> Self {
         Self {
-            headers_matcher: value.column.into(),
-            rows_matcher: value.row.into(),
+            headers_matcher: value.headers.into(),
+            rows_matcher: value.rows.into(),
         }
     }
 }

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -1,71 +1,107 @@
+use crate::md_elem::{MdContext, MdElem};
 use crate::query::ParseError;
-use crate::select::Matcher;
+use crate::select::{Matcher, SelectorAdapter};
 
+/// The completion state that a [`ListItemMatcher`] looks for.
 #[derive(Eq, PartialEq, Debug, Copy, Clone)]
 pub enum ListItemTask {
+    /// `- [x] foo`
     Selected,
+    /// `- [ ] foo`
     Unselected,
+    /// `- [?] foo`
     Either,
+    /// `- foo`
     None,
 }
 
+/// matcher for [`Selector::ListItem`]
 #[derive(Eq, PartialEq, Debug)]
 pub struct ListItemMatcher {
+    /// Whether this matches an ordered list (`1. foo`) or an unordered one (`- foo`).
     pub ordered: bool,
+    /// Whether this matches a task list (`- [ ] foo`), and if so, what completion state matches.
+    ///
+    /// Tasks are typically unordered, but may also be ordered (`1. [ ] foo`).
     pub task: ListItemTask,
     pub matcher: Matcher,
 }
 
+/// matcher for [`Selector::Section`]
 #[derive(Eq, PartialEq, Debug)]
 pub struct SectionMatcher {
     pub title: Matcher,
 }
 
+/// matcher for both [`Selector::Link`] and [`Selector::Image`]
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub struct LinklikeMatcher {
     pub display_matcher: Matcher,
     pub url_matcher: Matcher,
 }
 
+/// matcher for [`Selector::BlockQuote`]
 #[derive(Eq, PartialEq, Debug)]
 pub struct BlockQuoteMatcher {
     pub text: Matcher,
 }
 
+/// matcher for [`Selector::Html`]
 #[derive(Eq, PartialEq, Debug)]
 pub struct HtmlMatcher {
     pub html: Matcher,
 }
 
+/// matcher for [`Selector::Paragraph`]
 #[derive(Eq, PartialEq, Debug)]
 pub struct ParagraphMatcher {
     pub text: Matcher,
 }
 
+/// matcher for [`Selector::CodeBlock`]
 #[derive(Eq, PartialEq, Debug)]
 pub struct CodeBlockMatcher {
     pub language: Matcher,
     pub contents: Matcher,
 }
 
+/// matcher for [`Selector::Table`]
 #[derive(Eq, PartialEq, Debug)]
 pub struct TableMatcher {
-    pub column: Matcher,
-    pub row: Matcher,
+    pub headers: Matcher,
+    pub rows: Matcher,
 }
 
+/// The in-memory equivalent of mdq's selector query string.
 #[derive(Eq, PartialEq, Debug)]
 pub enum Selector {
+    /// `foo | bar`
     Chain(Vec<Self>),
+    /// `# section title`
     Section(SectionMatcher),
+    /// `1. ordered` or `- unordered` lists, or `- [ ] tasks`
     ListItem(ListItemMatcher),
+    /// `[some](https://example.com/url)`
     Link(LinklikeMatcher),
+    /// `![alt](https://example.com/image.png)`
     Image(LinklikeMatcher),
+    /// `> block quote`
     BlockQuote(BlockQuoteMatcher),
+    /// ` ```language contents `
     CodeBlock(CodeBlockMatcher),
+    /// `</> html-tags`
     Html(HtmlMatcher),
+    /// `P: paragraph text`
     Paragraph(ParagraphMatcher),
+    /// `:-: headers :-: rows`
     Table(TableMatcher),
+}
+
+impl Selector {
+    /// Filter and manipulate the provided `MdElem`s according to this selector.
+    pub fn find_nodes(self, ctx: &MdContext, nodes: Vec<MdElem>) -> Vec<MdElem> {
+        SelectorAdapter::from(self).find_nodes(ctx, nodes)
+    }
 }
 
 impl TryFrom<&'_ str> for Selector {

--- a/src/select/string_matcher.rs
+++ b/src/select/string_matcher.rs
@@ -84,7 +84,7 @@ impl From<Matcher> for StringMatcher {
             }
             .to_string_matcher(),
             Matcher::Regex(re) => Self::regex(re.re),
-            Matcher::Any(_) => Self::any(),
+            Matcher::Any { .. } => Self::any(),
         }
     }
 }


### PR DESCRIPTION
Also includes a few small tweaks other than docs:

- remove the `Any` enum, and replace it with just an `explicit: bool` on `Matcher::Any`
- rename `TextVariant::Html` -> `TextVariant::InlineHtml`
- rm `PlainWriter::options(&mut self) -> &mut PlainWriterOptions`, which isn't needed
- make `inlines_to_plain_string` `pub(crate)` instead of `pub`
- rename `Table::column` -> `headers`, and `row` -> `rows`

resolves #335.