### PR TITLE
add support for front matter

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The filter syntax is designed to mirror Markdown syntax. You can select...
 | Raw HTML         | `</> html_tag`                   |
 | Plain paragraphs | `P: paragraph text `             |
 | Tables           | `:-: header text :-: row text`   |
+| Front matter     | `+++variant front matter text`   |
 
 (Tables selection differs from other selections in that you can actually select only certain headers and rows, such that
 the resulting element is of a different shape than the original. See the example below, or the wiki for more detail.)

--- a/README.md
+++ b/README.md
@@ -106,22 +106,22 @@ cat example.md | mdq '# usage | -'
 
 The filter syntax is designed to mirror Markdown syntax. You can select...
 
-| Element          | Syntax                           |
-|------------------|----------------------------------|
-| Sections         | `# title text`                   |
-| Lists            | `- unordered list item text`     |
-| "                | `1. ordered list item text`      |
-| "                | `- [ ] uncompleted task`         |
-| "                | `- [x] completed task`           |
-| "                | `- [?] any task`                 |
-| Links            | `[display text](url)`            |
-| Images           | `![alt text](url)`               |
-| Block quotes     | `> block quote text`             |
-| Code blocks      | ` ```language <code block text>` |
-| Raw HTML         | `</> html_tag`                   |
-| Plain paragraphs | `P: paragraph text `             |
-| Tables           | `:-: header text :-: row text`   |
-| Front matter     | `+++variant front matter text`   |
+| Element          | Syntax                              |
+|------------------|-------------------------------------|
+| Sections         | `# title text`                      |
+| Lists            | `- unordered list item text`        |
+| "                | `1. ordered list item text`         |
+| "                | `- [ ] uncompleted task`            |
+| "                | `- [x] completed task`              |
+| "                | `- [?] any task`                    |
+| Links            | `[display text](url)`               |
+| Images           | `![alt text](url)`                  |
+| Block quotes     | `> block quote text`                |
+| Code blocks      | ` ```language <code block text>`    |
+| Raw HTML         | `</> html_tag`                      |
+| Plain paragraphs | `P: paragraph text `                |
+| Tables           | `:-: header text :-: row text`      |
+| Front matter     | `+++[toml\|yaml] front matter text` |
 
 (Tables selection differs from other selections in that you can actually select only certain headers and rows, such that
 the resulting element is of a different shape than the original. See the example below, or the wiki for more detail.)

--- a/examples/hello.md
+++ b/examples/hello.md
@@ -1,3 +1,7 @@
+---
+title: My example
+---
+
 # Greetings
 
 ![welcome image](https://example.com/welcome.png)

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -1,4 +1,5 @@
 use crate::md_elem::concatenate::Concatenate;
+use crate::util::str_utils::trim_leading_empty_lines;
 use std::backtrace::Backtrace;
 use std::collections::hash_map::Entry;
 use std::collections::HashMap;
@@ -1322,7 +1323,6 @@ macro_rules! m_node {
         $head::$next( m_node!($next $(:: $($tail)::*)? $({ $($args)* })?) )
     };
 }
-use crate::util::str_utils::trim_leading_empty_lines;
 pub(crate) use m_node;
 
 impl MdDoc {

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -376,8 +376,6 @@ pub mod elem {
         Math {
             metadata: Option<String>,
         },
-        Toml, // TODO rm this!
-        Yaml,
     }
 
     /// Some inline text.

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -517,10 +517,10 @@ pub mod elem {
         /// ```
         /// use mdq::md_elem::elem::FrontMatterVariant;
         ///
-        /// assert_eq!(FrontMatterVariant::Toml.as_separator(), "+++");
-        /// assert_eq!(FrontMatterVariant::Yaml.as_separator(), "---");
+        /// assert_eq!(FrontMatterVariant::Toml.separator(), "+++");
+        /// assert_eq!(FrontMatterVariant::Yaml.separator(), "---");
         /// ```
-        pub fn as_separator(self) -> &'static str {
+        pub fn separator(self) -> &'static str {
             match self {
                 FrontMatterVariant::Toml => "+++",
                 FrontMatterVariant::Yaml => "---",

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -480,12 +480,6 @@ pub mod elem {
         pub value: String,
     }
 
-    impl Display for BlockHtml {
-        fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.value)
-        }
-    }
-
     #[derive(Clone, Debug, PartialEq, Eq, Hash)]
     pub struct FrontMatter {
         pub variant: FrontMatterVariant,

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -376,7 +376,7 @@ pub mod elem {
         Math {
             metadata: Option<String>,
         },
-        Toml,
+        Toml, // TODO rm this!
         Yaml,
     }
 
@@ -497,6 +497,38 @@ pub mod elem {
     pub enum FrontMatterVariant {
         Yaml,
         Toml,
+    }
+
+    impl FrontMatterVariant {
+        /// Gets the written-out name of this variant.
+        ///
+        /// ```
+        /// use mdq::md_elem::elem::FrontMatterVariant;
+        ///
+        /// assert_eq!(FrontMatterVariant::Toml.name(), "toml");
+        /// assert_eq!(FrontMatterVariant::Yaml.name(), "yaml");
+        /// ```
+        pub fn name(self) -> &'static str {
+            match self {
+                FrontMatterVariant::Toml => "toml",
+                FrontMatterVariant::Yaml => "yaml",
+            }
+        }
+
+        /// Gets the separator that's used in front matter syntax to specify this variant.
+        ///
+        /// ```
+        /// use mdq::md_elem::elem::FrontMatterVariant;
+        ///
+        /// assert_eq!(FrontMatterVariant::Toml.as_separator(), "+++");
+        /// assert_eq!(FrontMatterVariant::Yaml.as_separator(), "---");
+        /// ```
+        pub fn as_separator(self) -> &'static str {
+            match self {
+                FrontMatterVariant::Toml => "+++",
+                FrontMatterVariant::Yaml => "---",
+            }
+        }
     }
 
     /// Inline markdown representing formatted text (~~deleted~~, _emphasized_, or **strong**).

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -128,6 +128,7 @@ pub enum MdElem {
 
     // Leaf blocks
     CodeBlock(CodeBlock),
+    FrontMatter(FrontMatter),
     Paragraph(Paragraph),
     Table(Table),
     /// A thematic break:
@@ -146,7 +147,7 @@ pub enum MdElem {
 /// Options for parsing Markdown.
 ///
 /// See: [`MdDoc::parse`].
-#[derive(Default, Debug)]
+#[derive(Debug)]
 pub struct ParseOptions {
     pub(crate) mdast_options: markdown::ParseOptions,
     /// Usually only required for debugging. Defaults to `false`.
@@ -155,6 +156,14 @@ pub struct ParseOptions {
     /// it or error out. If this field is set to `true`, mdq will ignore the unexpected state. Otherwise,
     /// [`MdDoc::parse`] will return an `Err` containing [`InvalidMd::UnknownMarkdown`].
     pub allow_unknown_markdown: bool,
+}
+
+impl Default for ParseOptions {
+    fn default() -> Self {
+        let mut me = Self::gfm();
+        me.mdast_options.constructs.frontmatter = true;
+        me
+    }
 }
 
 impl ParseOptions {
@@ -473,6 +482,18 @@ pub mod elem {
         fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
             write!(f, "{}", self.value)
         }
+    }
+
+    #[derive(Clone, Debug, PartialEq, Eq, Hash)]
+    pub struct FrontMatter {
+        pub variant: FrontMatterVariant,
+        pub body: String,
+    }
+
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    pub enum FrontMatterVariant {
+        Yaml,
+        Toml,
     }
 
     /// Inline markdown representing formatted text (~~deleted~~, _emphasized_, or **strong**).
@@ -1438,13 +1459,13 @@ impl MdElem {
             mdast::Node::Paragraph(node) => m_node!(MdElem::Paragraph {
                 body: Self::inlines(node.children, lookups, ctx)?,
             }),
-            mdast::Node::Toml(node) => m_node!(MdElem::CodeBlock {
-                variant: CodeVariant::Toml,
-                value: node.value,
+            mdast::Node::Toml(node) => m_node!(MdElem::FrontMatter {
+                variant: FrontMatterVariant::Toml,
+                body: node.value,
             }),
-            mdast::Node::Yaml(node) => m_node!(MdElem::CodeBlock {
-                variant: CodeVariant::Yaml,
-                value: node.value,
+            mdast::Node::Yaml(node) => m_node!(MdElem::FrontMatter {
+                variant: FrontMatterVariant::Yaml,
+                body: node.value,
             }),
             mdast::Node::Html(node) => m_node!(MdElem::BlockHtml { value: node.value }),
             mdx_nodes! {} => {
@@ -2724,9 +2745,9 @@ mod tests {
                 my: toml
                 +++"#},
             );
-            check!(&root.children[0], Node::Toml(_), lookups => m_node!(MdElem::CodeBlock{variant, value}) = {
-                assert_eq!(variant, CodeVariant::Toml);
-                assert_eq!(value, r#"my: toml"#);
+            check!(&root.children[0], Node::Toml(_), lookups => m_node!(MdElem::FrontMatter{variant, body}) = {
+                assert_eq!(variant, FrontMatterVariant::Toml);
+                assert_eq!(body, r#"my: toml"#);
             })
         }
 
@@ -2738,12 +2759,12 @@ mod tests {
                 &opts,
                 indoc! {r#"
                 ---
-                my: toml
+                my: yaml
                 ---"#},
             );
-            check!(&root.children[0], Node::Yaml(_), lookups => m_node!(MdElem::CodeBlock{variant, value}) = {
-                assert_eq!(variant, CodeVariant::Yaml);
-                assert_eq!(value, r#"my: toml"#);
+            check!(&root.children[0], Node::Yaml(_), lookups => m_node!(MdElem::FrontMatter{variant, body}) = {
+                assert_eq!(variant, FrontMatterVariant::Yaml);
+                assert_eq!(body, r#"my: yaml"#);
             })
         }
 

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -177,6 +177,9 @@ impl ParseOptions {
 
 /// Parse some Markdown text.
 fn parse0(text: &str, options: &ParseOptions) -> Result<MdDoc, InvalidMd> {
+    // mdast requires front matter to be literally the first char. We'll be more forgiving.
+    let text = trim_leading_empty_lines(text);
+
     let ast = markdown::to_mdast(text, &options.mdast_options).map_err(|e| InvalidMd::ParseError(format!("{e}")))?;
     let read_options = ReadOptions {
         validate_no_conflicting_links: false,
@@ -1216,6 +1219,7 @@ pub mod elem {
     from_for_md_elem! { List }
     from_for_md_elem! { Section }
     from_for_md_elem! { CodeBlock }
+    from_for_md_elem! { FrontMatter }
     from_for_md_elem! { Paragraph }
     from_for_md_elem! { Table }
     from_for_md_elem! { Inline }
@@ -1288,6 +1292,7 @@ macro_rules! m_node {
         $head::$next( m_node!($next $(:: $($tail)::*)? $({ $($args)* })?) )
     };
 }
+use crate::util::str_utils::trim_leading_empty_lines;
 pub(crate) use m_node;
 
 impl MdDoc {

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -73,7 +73,7 @@ impl MdDoc {
         // mdast requires front matter to be literally the first char. We'll be more forgiving.
         let trimmed = TrimmedEmptyLines::from(text);
         let mut result = parse0(trimmed.remaining, options);
-        if matches!(result, Err(_)) && !trimmed.trimmed.is_empty() {
+        if result.is_err() && !trimmed.trimmed.is_empty() {
             // re-parse on the original text, so that we get the correct offsets
             result = parse0(text, options);
         }

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -490,10 +490,10 @@ pub mod elem {
         pub body: String,
     }
 
-    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+    #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord)]
     pub enum FrontMatterVariant {
-        Yaml,
         Toml,
+        Yaml,
     }
 
     impl FrontMatterVariant {

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -403,16 +403,12 @@ impl<'md> MdWriterState<'_, 'md> {
     }
 
     fn write_front_matter<W: SimpleWrite>(&mut self, out: &mut Output<W>, front_matter: &'md FrontMatter) {
-        let front_matter_line = match front_matter.variant {
-            FrontMatterVariant::Yaml => "---",
-            FrontMatterVariant::Toml => "+++",
-        };
         out.with_pre_block(|out| {
-            out.write_str(front_matter_line);
+            out.write_str(front_matter.variant.as_separator());
             out.write_char('\n');
             out.write_str(&front_matter.body);
             out.write_char('\n');
-            out.write_str(front_matter_line);
+            out.write_str(front_matter.variant.as_separator());
         })
     }
 

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -386,8 +386,6 @@ impl<'md> MdWriterState<'_, 'md> {
                 };
                 (Cow::Borrowed("$$"), meta)
             }
-            CodeVariant::Toml => (Cow::Borrowed("+++"), None),
-            CodeVariant::Yaml => (Cow::Borrowed("---"), None),
         };
 
         out.with_pre_block(|out| {
@@ -581,8 +579,6 @@ pub mod tests {
         CodeBlock(CodeBlock{variant: CodeVariant::Code(Some(CodeOpts{metadata: Some(_), ..})), ..}),
         CodeBlock(CodeBlock{variant: CodeVariant::Math{metadata: None}, ..}),
         CodeBlock(CodeBlock{variant: CodeVariant::Math{metadata: Some(_)}, ..}),
-        CodeBlock(CodeBlock{variant: CodeVariant::Toml, ..}),
-        CodeBlock(CodeBlock{variant: CodeVariant::Yaml, ..}),
         FrontMatter(FrontMatter{variant: FrontMatterVariant::Toml, ..}),
         FrontMatter(FrontMatter{variant: FrontMatterVariant::Yaml, ..}),
         Paragraph(_),
@@ -1286,36 +1282,6 @@ pub mod tests {
                 one
                 two
                 $$"#},
-            );
-        }
-
-        #[test]
-        fn toml() {
-            check_render(
-                md_elems![CodeBlock {
-                    variant: CodeVariant::Toml,
-                    value: "one\ntwo".to_string(),
-                }],
-                indoc! {r#"
-                +++
-                one
-                two
-                +++"#},
-            );
-        }
-
-        #[test]
-        fn yaml() {
-            check_render(
-                md_elems![CodeBlock {
-                    variant: CodeVariant::Yaml,
-                    value: "one\ntwo".to_string(),
-                }],
-                indoc! {r#"
-                ---
-                one
-                two
-                ---"#},
             );
         }
 

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -402,11 +402,11 @@ impl<'md> MdWriterState<'_, 'md> {
 
     fn write_front_matter<W: SimpleWrite>(&mut self, out: &mut Output<W>, front_matter: &'md FrontMatter) {
         out.with_pre_block(|out| {
-            out.write_str(front_matter.variant.as_separator());
+            out.write_str(front_matter.variant.separator());
             out.write_char('\n');
             out.write_str(&front_matter.body);
             out.write_char('\n');
-            out.write_str(front_matter.variant.as_separator());
+            out.write_str(front_matter.variant.separator());
         })
     }
 

--- a/src/output/fmt_md_inlines.rs
+++ b/src/output/fmt_md_inlines.rs
@@ -222,7 +222,7 @@ impl<'md> MdInlinesWriter<'md> {
                 MdElem::Inline(inline) => {
                     self.find_references_in_footnote_inlines([inline]);
                 }
-                MdElem::CodeBlock(_) | MdElem::BlockHtml(_) | MdElem::ThematicBreak => {
+                MdElem::CodeBlock(_) | MdElem::FrontMatter(_) | MdElem::BlockHtml(_) | MdElem::ThematicBreak => {
                     // nothing
                 }
             }

--- a/src/output/fmt_plain_inline.rs
+++ b/src/output/fmt_plain_inline.rs
@@ -591,7 +591,7 @@ mod test {
                 body: md_elems!("block quote paragraph 1", "block quote paragraph 2"),
             }),
             md_elem!(CodeBlock {
-                variant: CodeVariant::Toml,
+                variant: CodeVariant::Code(None),
                 value: "code block 1 line 1\ncode block 1 line 2".to_string()
             }),
             MdElem::BlockHtml("<hr>".into()),

--- a/src/output/fmt_plain_inline.rs
+++ b/src/output/fmt_plain_inline.rs
@@ -119,7 +119,7 @@ where
             Ok(())
         }
         MdElem::BlockHtml(h) => {
-            writeln!(out, "{}", h)?;
+            writeln!(out, "{}", h.value)?;
             writeln!(out)
         }
         MdElem::ThematicBreak => Ok(()),

--- a/src/output/fmt_plain_inline.rs
+++ b/src/output/fmt_plain_inline.rs
@@ -82,9 +82,9 @@ where
     match node {
         MdElem::Doc(doc) => write_plain_result(out, doc.iter()),
         MdElem::BlockQuote(block) => write_plain_result(out, block.body.iter()),
-        MdElem::CodeBlock(block) => {
-            if !block.value.is_empty() {
-                writeln!(out, "{}", block.value)?;
+        MdElem::CodeBlock(CodeBlock { value: body, .. }) | MdElem::FrontMatter(FrontMatter { body, .. }) => {
+            if !body.is_empty() {
+                writeln!(out, "{}", body)?;
                 writeln!(out)?;
             }
             Ok(())
@@ -181,6 +181,7 @@ mod test {
         Doc(_),
         BlockQuote(_),
         CodeBlock(_),
+        FrontMatter(_),
         Inline(_),
         List(_),
         Paragraph(_),
@@ -265,6 +266,36 @@ mod test {
         });
         check_plain(
             match_or_panic!(md_elem => MdElem::CodeBlock(_)),
+            Expect {
+                with_breaks: "hello, world\n",
+                no_breaks: "hello, world\n",
+            },
+        )
+    }
+
+    #[test]
+    fn front_matter_empty() {
+        let md_elem = md_elem!(FrontMatter {
+            variant: FrontMatterVariant::Yaml,
+            body: "".to_string()
+        });
+        check_plain(
+            match_or_panic!(md_elem => MdElem::FrontMatter(_)),
+            Expect {
+                with_breaks: "",
+                no_breaks: "",
+            },
+        )
+    }
+
+    #[test]
+    fn front_matter_not_empty() {
+        let md_elem = md_elem!(FrontMatter {
+            variant: FrontMatterVariant::Yaml,
+            body: "hello, world".to_string()
+        });
+        check_plain(
+            match_or_panic!(md_elem => MdElem::FrontMatter(_)),
             Expect {
                 with_breaks: "hello, world\n",
                 no_breaks: "hello, world\n",

--- a/src/output/tree_ref_serde.rs
+++ b/src/output/tree_ref_serde.rs
@@ -446,7 +446,7 @@ mod tests {
         check(
             MdElem::FrontMatter(FrontMatter {
                 variant: FrontMatterVariant::Yaml,
-                body: "my front_matter".to_string(),
+                body: "my front matter".to_string(),
             }),
             json_str!(
                 {"items": [

--- a/src/output/tree_ref_serde.rs
+++ b/src/output/tree_ref_serde.rs
@@ -146,8 +146,6 @@ pub(crate) enum LinkCollapseStyle {
 pub(crate) enum CodeBlockType {
     Code,
     Math,
-    Toml,
-    Yaml,
 }
 
 impl<'md> SerializableMd<'md> {
@@ -206,8 +204,6 @@ impl<'md> SerdeElem<'md> {
                         Some(&code_opts.language),
                     ),
                     CodeVariant::Math { metadata } => (CodeBlockType::Math, metadata.as_ref(), None),
-                    CodeVariant::Toml => (CodeBlockType::Toml, None, None),
-                    CodeVariant::Yaml => (CodeBlockType::Yaml, None, None),
                 };
                 Self::CodeBlock {
                     code: value,

--- a/src/query/grammar.pest
+++ b/src/query/grammar.pest
@@ -10,7 +10,7 @@ selector = {
   | select_link
   | select_block_quote
   | select_code_block
-  | front_matter
+  | select_front_matter
   | select_html
   | select_paragraph
   | select_table
@@ -41,8 +41,8 @@ select_block_quote_start = @{ ">" ~ selector_delim }
 select_code_block =  { code_block_start ~ PUSH_LITERAL("|") ~ #text = string }
 code_block_start  = ${ "```" ~ PUSH_LITERAL(" ") ~ #language = string ~ selector_delim }
 
-front_matter =  { front_matter_start ~ PUSH_LITERAL("|") ~ #text = string }
-front_matter_start = @{ "+++" ~ selector_delim }
+select_front_matter =  { front_matter_start ~ PUSH_LITERAL("|") ~ #text = string }
+front_matter_start  = ${ "+++" ~ PUSH_LITERAL(" ") ~ #variant = string ~ selector_delim }
 
 select_html =  { html_start ~ PUSH_LITERAL("|") ~ #text = string }
 html_start  = @{ "</>" ~ selector_delim }

--- a/src/query/grammar.pest
+++ b/src/query/grammar.pest
@@ -10,6 +10,7 @@ selector = {
   | select_link
   | select_block_quote
   | select_code_block
+  | front_matter
   | select_html
   | select_paragraph
   | select_table
@@ -39,6 +40,9 @@ select_block_quote_start = @{ ">" ~ selector_delim }
 
 select_code_block =  { code_block_start ~ PUSH_LITERAL("|") ~ #text = string }
 code_block_start  = ${ "```" ~ PUSH_LITERAL(" ") ~ #language = string ~ selector_delim }
+
+front_matter =  { front_matter_start ~ PUSH_LITERAL("|") ~ #text = string }
+front_matter_start = @{ "+++" ~ selector_delim }
 
 select_html =  { html_start ~ PUSH_LITERAL("|") ~ #text = string }
 html_start  = @{ "</>" ~ selector_delim }

--- a/src/query/pest.rs
+++ b/src/query/pest.rs
@@ -76,7 +76,7 @@ impl Query {
                 Rule::image_start => "_![_",
                 Rule::select_block_quote | Rule::select_block_quote_start => "_>_",
                 Rule::select_code_block | Rule::code_block_start => "_```_",
-                Rule::front_matter | Rule::front_matter_start => "_+++_",
+                Rule::select_front_matter | Rule::front_matter_start => "_+++_",
                 Rule::select_html | Rule::html_start => "_</>_",
                 Rule::select_paragraph | Rule::select_paragraph_start => "_P:_",
                 Rule::select_table | Rule::table_start => "_:-:_",

--- a/src/query/pest.rs
+++ b/src/query/pest.rs
@@ -76,6 +76,7 @@ impl Query {
                 Rule::image_start => "_![_",
                 Rule::select_block_quote | Rule::select_block_quote_start => "_>_",
                 Rule::select_code_block | Rule::code_block_start => "_```_",
+                Rule::front_matter | Rule::front_matter_start => "_+++_",
                 Rule::select_html | Rule::html_start => "_</>_",
                 Rule::select_paragraph | Rule::select_paragraph_start => "_P:_",
                 Rule::select_table | Rule::table_start => "_:-:_",

--- a/src/query/selector_try_from.rs
+++ b/src/query/selector_try_from.rs
@@ -1,12 +1,12 @@
 use crate::query::pest::Rule;
 use crate::query::traversal::{ByRule, OneOf, PairMatcher};
 use crate::query::traversal_composites::{
-    BlockQuoteTraverser, CodeBlockTraverser, HtmlTraverser, LinkTraverser, ListItemTraverser, ParagraphTraverser,
-    SectionResults, SectionTraverser, TableTraverser,
+    BlockQuoteTraverser, CodeBlockTraverser, FrontMatterTraverser, HtmlTraverser, LinkTraverser, ListItemTraverser,
+    ParagraphTraverser, SectionResults, SectionTraverser, TableTraverser,
 };
 use crate::query::{DetachedSpan, InnerParseError, Pair, Pairs, Query};
 use crate::select::{
-    BlockQuoteMatcher, CodeBlockMatcher, HtmlMatcher, LinklikeMatcher, ListItemMatcher, ListItemTask, Matcher,
+    BlockQuoteMatcher, CodeBlockMatcher, FrontMatterMatcher, HtmlMatcher, LinklikeMatcher, ListItemMatcher, ListItemTask, Matcher,
     ParagraphMatcher, SectionMatcher, Selector, TableMatcher,
 };
 
@@ -93,6 +93,11 @@ impl Selector {
                     language: language_matcher,
                     contents: contents_matcher,
                 }))
+            }
+            Rule::front_matter => {
+                let res = FrontMatterTraverser::traverse(children);
+                let body_matcher = Matcher::try_from(res.text.take().map_err(to_parse_error)?)?;
+                Ok(Self::FrontMatter(FrontMatterMatcher { body: body_matcher }))
             }
             Rule::select_html => {
                 let res = HtmlTraverser::traverse(children);

--- a/src/query/selector_try_from.rs
+++ b/src/query/selector_try_from.rs
@@ -6,8 +6,8 @@ use crate::query::traversal_composites::{
 };
 use crate::query::{DetachedSpan, InnerParseError, Pair, Pairs, Query};
 use crate::select::{
-    BlockQuoteMatcher, CodeBlockMatcher, FrontMatterMatcher, HtmlMatcher, LinklikeMatcher, ListItemMatcher, ListItemTask, Matcher,
-    ParagraphMatcher, SectionMatcher, Selector, TableMatcher,
+    BlockQuoteMatcher, CodeBlockMatcher, FrontMatterMatcher, HtmlMatcher, LinklikeMatcher, ListItemMatcher,
+    ListItemTask, Matcher, ParagraphMatcher, SectionMatcher, Selector, TableMatcher,
 };
 
 impl Selector {
@@ -94,10 +94,14 @@ impl Selector {
                     contents: contents_matcher,
                 }))
             }
-            Rule::front_matter => {
+            Rule::select_front_matter => {
                 let res = FrontMatterTraverser::traverse(children);
+                let variant_matcher = Matcher::try_from(res.variant.take().map_err(to_parse_error)?)?;
                 let body_matcher = Matcher::try_from(res.text.take().map_err(to_parse_error)?)?;
-                Ok(Self::FrontMatter(FrontMatterMatcher { body: body_matcher }))
+                Ok(Self::FrontMatter(FrontMatterMatcher {
+                    variant: variant_matcher,
+                    text: body_matcher,
+                }))
             }
             Rule::select_html => {
                 let res = HtmlTraverser::traverse(children);

--- a/src/query/traversal_composites.rs
+++ b/src/query/traversal_composites.rs
@@ -101,6 +101,7 @@ composite_finder! { CodeBlock {
 }}
 
 composite_finder! { FrontMatter {
+    variant OnePair<'a>: ByTag,
     text OnePair<'a>: ByTag,
 }}
 

--- a/src/query/traversal_composites.rs
+++ b/src/query/traversal_composites.rs
@@ -100,6 +100,10 @@ composite_finder! { CodeBlock {
     text OnePair<'a>: ByTag,
 }}
 
+composite_finder! { FrontMatter {
+    text OnePair<'a>: ByTag,
+}}
+
 composite_finder! { Html {
     text OnePair<'a>: ByTag,
 }}

--- a/src/run/run_main.rs
+++ b/src/run/run_main.rs
@@ -169,7 +169,7 @@ pub fn run(cli: &RunOptions, os: &mut impl OsFacade) -> bool {
 
 fn run_or_error(cli: &RunOptions, os: &mut impl OsFacade) -> Result<bool, Error> {
     let contents_str = os.read_all(&cli.markdown_file_paths)?;
-    let mut options = ParseOptions::gfm();
+    let mut options = ParseOptions::default();
     options.allow_unknown_markdown = cli.allow_unknown_markdown;
     let md_doc = md_elem::MdDoc::parse(&contents_str, &options).map_err(Error::MarkdownParse)?;
 

--- a/src/run/run_main.rs
+++ b/src/run/run_main.rs
@@ -169,8 +169,11 @@ pub fn run(cli: &RunOptions, os: &mut impl OsFacade) -> bool {
 
 fn run_or_error(cli: &RunOptions, os: &mut impl OsFacade) -> Result<bool, Error> {
     let contents_str = os.read_all(&cli.markdown_file_paths)?;
-    let mut options = ParseOptions::default();
-    options.allow_unknown_markdown = cli.allow_unknown_markdown;
+    let options = ParseOptions::default();
+    let options = ParseOptions {
+        allow_unknown_markdown: cli.allow_unknown_markdown,
+        ..options
+    };
     let md_doc = md_elem::MdDoc::parse(&contents_str, &options).map_err(Error::MarkdownParse)?;
 
     let selectors_str = &cli.selectors;

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -135,7 +135,6 @@ impl SelectorAdapter {
                 }
                 result
             }
-            MdElem::ThematicBreak | MdElem::CodeBlock(_) => Vec::new(),
             MdElem::Inline(inline) => match inline {
                 Inline::Span(Span { children, .. }) => children.into_iter().map(MdElem::Inline).collect(),
                 Inline::Footnote(footnote) => {
@@ -155,7 +154,7 @@ impl SelectorAdapter {
                 Inline::Link(Link { display: text, .. }) => text.into_iter().map(MdElem::Inline).collect(),
                 Inline::Text(_) | Inline::Image(_) => Vec::new(),
             },
-            MdElem::BlockHtml(_) => Vec::new(),
+            MdElem::ThematicBreak | MdElem::CodeBlock(_) | MdElem::FrontMatter(_) | MdElem::BlockHtml(_) => Vec::new(),
         }
     }
 }

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -7,6 +7,7 @@ use crate::select::sel_link_like::LinkSelector;
 use crate::select::sel_list_item::ListItemSelector;
 use crate::select::sel_section::SectionSelector;
 use crate::select::sel_single_matcher::BlockQuoteSelector;
+use crate::select::sel_single_matcher::FrontMatterSelector;
 use crate::select::sel_single_matcher::HtmlSelector;
 use crate::select::sel_single_matcher::ParagraphSelector;
 use crate::select::sel_table::TableSelector;
@@ -66,6 +67,7 @@ adapters! {
     ListItem => List,
     BlockQuote => BlockQuote,
     CodeBlock => CodeBlock,
+    FrontMatter => FrontMatter,
     Html => BlockHtml,
     Paragraph => Paragraph,
     Table => Table,

--- a/src/select/sel_code_block.rs
+++ b/src/select/sel_code_block.rs
@@ -28,7 +28,7 @@ impl MatchSelector<CodeBlock> for CodeBlockSelector {
                 };
                 self.lang_matcher.matches(actual_lang)
             }
-            CodeVariant::Math { .. } | CodeVariant::Toml | CodeVariant::Yaml => false,
+            CodeVariant::Math { .. } => false,
         };
         lang_matches && self.contents_matcher.matches(&code_block.value)
     }

--- a/src/select/sel_single_matcher.rs
+++ b/src/select/sel_single_matcher.rs
@@ -59,7 +59,7 @@ pub struct FrontMatterSelector {
 impl From<FrontMatterMatcher> for FrontMatterSelector {
     fn from(value: FrontMatterMatcher) -> Self {
         Self {
-            variant: value.variant.into(),
+            variant: value.variant,
             text: value.text.into(),
         }
     }

--- a/src/select/sel_single_matcher.rs
+++ b/src/select/sel_single_matcher.rs
@@ -67,6 +67,6 @@ impl From<FrontMatterMatcher> for FrontMatterSelector {
 
 impl MatchSelector<FrontMatter> for FrontMatterSelector {
     fn matches(&self, front_matter: &FrontMatter) -> bool {
-        self.variant.matches(&front_matter.variant.name()) && self.text.matches(&front_matter.body)
+        self.variant.matches(front_matter.variant.name()) && self.text.matches(&front_matter.body)
     }
 }

--- a/src/select/sel_single_matcher.rs
+++ b/src/select/sel_single_matcher.rs
@@ -52,7 +52,7 @@ impl MatchSelector<BlockHtml> for HtmlSelector {
 
 #[derive(Debug, PartialEq)]
 pub struct FrontMatterSelector {
-    variant: StringMatcher,
+    variant: Option<FrontMatterVariant>,
     text: StringMatcher,
 }
 
@@ -67,6 +67,10 @@ impl From<FrontMatterMatcher> for FrontMatterSelector {
 
 impl MatchSelector<FrontMatter> for FrontMatterSelector {
     fn matches(&self, front_matter: &FrontMatter) -> bool {
-        self.variant.matches(front_matter.variant.name()) && self.text.matches(&front_matter.body)
+        let variant_selected = self
+            .variant
+            .map(|selected| selected == front_matter.variant)
+            .unwrap_or(true);
+        variant_selected && self.text.matches(&front_matter.body)
     }
 }

--- a/src/select/sel_single_matcher.rs
+++ b/src/select/sel_single_matcher.rs
@@ -1,7 +1,7 @@
 use crate::md_elem::elem::*;
 use crate::select::match_selector::MatchSelector;
 use crate::select::string_matcher::StringMatcher;
-use crate::select::{BlockQuoteMatcher, HtmlMatcher, ParagraphMatcher, SectionMatcher};
+use crate::select::{BlockQuoteMatcher, FrontMatterMatcher, HtmlMatcher, ParagraphMatcher, SectionMatcher};
 use paste::paste;
 
 macro_rules! single_matcher_adapter {
@@ -47,5 +47,24 @@ impl From<HtmlMatcher> for HtmlSelector {
 impl MatchSelector<BlockHtml> for HtmlSelector {
     fn matches(&self, html: &BlockHtml) -> bool {
         self.matcher.matches(&html.value)
+    }
+}
+
+#[derive(Debug, PartialEq)]
+pub struct FrontMatterSelector {
+    matcher: StringMatcher,
+}
+
+impl From<FrontMatterMatcher> for FrontMatterSelector {
+    fn from(value: FrontMatterMatcher) -> Self {
+        Self {
+            matcher: value.body.into(),
+        }
+    }
+}
+
+impl MatchSelector<FrontMatter> for FrontMatterSelector {
+    fn matches(&self, front_matter: &FrontMatter) -> bool {
+        self.matcher.matches(&front_matter.body)
     }
 }

--- a/src/select/sel_single_matcher.rs
+++ b/src/select/sel_single_matcher.rs
@@ -67,8 +67,6 @@ impl From<FrontMatterMatcher> for FrontMatterSelector {
 
 impl MatchSelector<FrontMatter> for FrontMatterSelector {
     fn matches(&self, front_matter: &FrontMatter) -> bool {
-        let variant_disp = format!("{:?}", self.variant);
-        println!("variant_disp: {}", variant_disp);
         self.variant.matches(&front_matter.variant.name()) && self.text.matches(&front_matter.body)
     }
 }

--- a/src/select/sel_single_matcher.rs
+++ b/src/select/sel_single_matcher.rs
@@ -52,19 +52,23 @@ impl MatchSelector<BlockHtml> for HtmlSelector {
 
 #[derive(Debug, PartialEq)]
 pub struct FrontMatterSelector {
-    matcher: StringMatcher,
+    variant: StringMatcher,
+    text: StringMatcher,
 }
 
 impl From<FrontMatterMatcher> for FrontMatterSelector {
     fn from(value: FrontMatterMatcher) -> Self {
         Self {
-            matcher: value.body.into(),
+            variant: value.variant.into(),
+            text: value.text.into(),
         }
     }
 }
 
 impl MatchSelector<FrontMatter> for FrontMatterSelector {
     fn matches(&self, front_matter: &FrontMatter) -> bool {
-        self.matcher.matches(&front_matter.body)
+        let variant_disp = format!("{:?}", self.variant);
+        println!("variant_disp: {}", variant_disp);
+        self.variant.matches(&front_matter.variant.name()) && self.text.matches(&front_matter.body)
     }
 }

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -65,6 +65,12 @@ pub struct CodeBlockMatcher {
     pub contents: Matcher,
 }
 
+/// matcher for [`Selector::FrontMatter`]
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct FrontMatterMatcher {
+    pub body: Matcher,
+}
+
 /// matcher for [`Selector::Table`]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TableMatcher {
@@ -90,6 +96,8 @@ pub enum Selector {
     BlockQuote(BlockQuoteMatcher),
     /// ` ```language contents `
     CodeBlock(CodeBlockMatcher),
+    /// `+++ front matter`
+    FrontMatter(FrontMatterMatcher),
     /// `</> html-tags`
     Html(HtmlMatcher),
     /// `P: paragraph text`

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -68,7 +68,8 @@ pub struct CodeBlockMatcher {
 /// matcher for [`Selector::FrontMatter`]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FrontMatterMatcher {
-    pub body: Matcher,
+    pub variant: Matcher,
+    pub text: Matcher,
 }
 
 /// matcher for [`Selector::Table`]

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -1,3 +1,4 @@
+use crate::md_elem::elem::FrontMatterVariant;
 use crate::md_elem::{MdContext, MdDoc, MdElem};
 use crate::query::ParseError;
 use crate::select::{Matcher, SelectorAdapter};
@@ -68,7 +69,7 @@ pub struct CodeBlockMatcher {
 /// matcher for [`Selector::FrontMatter`]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FrontMatterMatcher {
-    pub variant: Matcher,
+    pub variant: Option<FrontMatterVariant>,
     pub text: Matcher,
 }
 

--- a/src/select/string_matcher.rs
+++ b/src/select/string_matcher.rs
@@ -33,7 +33,6 @@ impl StringMatcher {
         match node {
             MdElem::Doc(elems) => self.matches_any(elems),
             MdElem::Paragraph(p) => self.matches_inlines(&p.body),
-            MdElem::ThematicBreak | MdElem::CodeBlock(_) => false,
             MdElem::Table(table) => {
                 for row in &table.rows {
                     for cell in row {
@@ -54,6 +53,9 @@ impl StringMatcher {
             }
             MdElem::BlockHtml(html) => self.matches(&html.value),
             MdElem::Inline(inline) => self.matches_inlines(&[inline]),
+            // Base cases: these don't recurse, so we say the StringMatcher doesn't match them. A Selector still may,
+            // but that's Selector-specific logic, not StringMatcher logic.
+            MdElem::ThematicBreak | MdElem::CodeBlock(_) | MdElem::FrontMatter(_) => false,
         }
     }
 

--- a/src/util/str_utils.rs
+++ b/src/util/str_utils.rs
@@ -70,6 +70,25 @@ impl<W: SimpleWrite> std::fmt::Write for CountingWriter<'_, W> {
     }
 }
 
+/// Trims leading empty lines from a string slice.
+///
+/// An "empty line" is defined as a line that consists of zero or more whitespace characters,
+/// and nothing else.
+pub fn trim_leading_empty_lines(s: &str) -> &str {
+    let mut start = 0;
+    // using split_inclusive() instead of just split() because we need to count \r\n as 2 chars; so we can't just take
+    // the split()s, and assume a one-char newline for each one.
+    let mut lines = s.split_inclusive(|c| c == '\n');
+    while let Some(line) = lines.next() {
+        if line.chars().all(|c| c.is_whitespace()) {
+            start += line.len();
+        } else {
+            break;
+        }
+    }
+    &s[start..]
+}
+
 #[cfg(test)]
 mod test {
     use super::*;
@@ -119,6 +138,54 @@ mod test {
     fn string_already_too_big() {
         for align in [ColumnAlignment::Left, ColumnAlignment::Center, ColumnAlignment::Right] {
             assert_eq!("abcdef", output_and_get(|out| pad_to(out, "abcdef", 3, Some(align))));
+        }
+    }
+
+    mod trim_leading_empty_lines {
+        use super::*;
+
+        #[test]
+        fn starts_with_newline() {
+            check("\nhello\nworld", "hello\nworld");
+        }
+
+        #[test]
+        fn starts_with_space_then_newline() {
+            check("  \nhello\nworld", "hello\nworld");
+        }
+
+        #[test]
+        fn starts_with_space_then_char() {
+            check("  a\nhello\nworld", "  a\nhello\nworld");
+        }
+
+        #[test]
+        fn starts_with_char() {
+            check("hello world", "hello world");
+        }
+
+        #[test]
+        fn empty() {
+            check("", "");
+        }
+
+        #[test]
+        fn all_newlines() {
+            check("\n\n\n", "");
+        }
+
+        #[test]
+        fn crlf() {
+            check("\r\n\r\nhello", "hello");
+        }
+
+        #[test]
+        fn just_cr() {
+            check("\rhello", "\rhello");
+        }
+
+        fn check(given: &str, expected: &str) {
+            assert_eq!(trim_leading_empty_lines(given), expected);
         }
     }
 

--- a/src/util/str_utils.rs
+++ b/src/util/str_utils.rs
@@ -70,22 +70,32 @@ impl<W: SimpleWrite> std::fmt::Write for CountingWriter<'_, W> {
     }
 }
 
-/// Trims leading empty lines from a string slice.
+/// A struct that represents trimmed leading empty lines from a string.
 ///
 /// An "empty line" is defined as a line that consists of zero or more whitespace characters,
 /// and nothing else.
-pub fn trim_leading_empty_lines(s: &str) -> &str {
-    let mut start = 0;
-    // using split_inclusive() instead of just split() because we need to count \r\n as 2 chars; so we can't just take
-    // the split()s, and assume a one-char newline for each one.
-    for line in s.split_inclusive('\n') {
-        if line.chars().all(|c| c.is_whitespace()) {
-            start += line.len();
-        } else {
-            break;
+pub(crate) struct TrimmedEmptyLines<S> {
+    pub(crate) trimmed: S,
+    pub(crate) remaining: S,
+}
+
+impl<'a> From<&'a str> for TrimmedEmptyLines<&'a str> {
+    fn from(s: &'a str) -> Self {
+        let mut start = 0;
+        // using split_inclusive() instead of just split() because we need to count \r\n as 2 chars; so we can't just take
+        // the split()s, and assume a one-char newline for each one.
+        for line in s.split_inclusive('\n') {
+            if line.chars().all(|c| c.is_whitespace()) {
+                start += line.len();
+            } else {
+                break;
+            }
+        }
+        Self {
+            trimmed: &s[..start],
+            remaining: &s[start..],
         }
     }
-    &s[start..]
 }
 
 #[cfg(test)]

--- a/src/util/str_utils.rs
+++ b/src/util/str_utils.rs
@@ -78,8 +78,7 @@ pub fn trim_leading_empty_lines(s: &str) -> &str {
     let mut start = 0;
     // using split_inclusive() instead of just split() because we need to count \r\n as 2 chars; so we can't just take
     // the split()s, and assume a one-char newline for each one.
-    let mut lines = s.split_inclusive(|c| c == '\n');
-    while let Some(line) = lines.next() {
+    for line in s.split_inclusive('\n') {
         if line.chars().all(|c| c.is_whitespace()) {
             start += line.len();
         } else {

--- a/src/util/str_utils.rs
+++ b/src/util/str_utils.rs
@@ -194,7 +194,7 @@ mod test {
         }
 
         fn check(given: &str, expected: &str) {
-            assert_eq!(trim_leading_empty_lines(given), expected);
+            assert_eq!(TrimmedEmptyLines::from(given).remaining, expected);
         }
     }
 

--- a/tests/md_cases/select_front_matter.toml
+++ b/tests/md_cases/select_front_matter.toml
@@ -14,7 +14,7 @@ This is the document body.
 needed = false
 
 
-[expect."select front matter"]
+[expect."select any front matter"]
 cli_args = ["+++"]
 output = '''
 +++
@@ -22,6 +22,27 @@ title: Test Front Matter
 author: Me
 +++
 '''
+
+[expect."select toml matter"]
+cli_args = ["+++toml"]
+output = '''
++++
+title: Test Front Matter
+author: Me
++++
+'''
+
+[expect."select yaml matter"]
+cli_args = ["+++yaml"]
+output = '''
+'''
+expect_success = false
+
+[expect."select other matter"]
+cli_args = ["+++other"]
+output = '''
+'''
+expect_success = false
 
 [expect."select front matter with text matcher"]
 cli_args = ["+++ title: Test Front Matter"]

--- a/tests/md_cases/select_front_matter.toml
+++ b/tests/md_cases/select_front_matter.toml
@@ -75,6 +75,18 @@ output = '''
 expect_success = false
 
 
+[expect."plain output"]
+cli_args = ["-o", "plain"]
+output = '''
+title: Test Front Matter
+author: Me
+My Document
+This is the document body.
+it has: a block that looks like front matter
+but: isn't
+'''
+
+
 [expect."select a paragraph that looks like front matter"]
 cli_args = ["-o", "json"]
 output_json = true

--- a/tests/md_cases/select_front_matter.toml
+++ b/tests/md_cases/select_front_matter.toml
@@ -1,0 +1,48 @@
+[given]
+md = '''
++++
+title: Test Front Matter
+author: Me
++++
+
+# My Document
+
+This is the document body.
+'''
+
+[chained]
+needed = false
+
+
+[expect."select front matter"]
+cli_args = ["+++"]
+output = '''
++++
+title: Test Front Matter
+author: Me
++++
+'''
+
+[expect."select front matter with text matcher"]
+cli_args = ["+++ title: Test Front Matter"]
+output = '''
++++
+title: Test Front Matter
+author: Me
++++
+'''
+
+[expect."select front matter with regex matcher"]
+cli_args = ["+++ /author: .*/"]
+output = '''
++++
+title: Test Front Matter
+author: Me
++++
+'''
+
+[expect."select front matter with no match"]
+cli_args = ["+++ non-existent"]
+output = '''
+'''
+expect_success = false

--- a/tests/md_cases/select_front_matter.toml
+++ b/tests/md_cases/select_front_matter.toml
@@ -46,7 +46,14 @@ expect_success = false
 
 [expect."select other matter"]
 cli_args = ["+++other"]
-output = '''
+output = ''
+output_err = '''Syntax error in select specifier:
+ --> 1:4
+  |
+1 | +++other
+  |    ^---^
+  |
+  = front matter language must be "toml" or "yaml". Found "other".
 '''
 expect_success = false
 

--- a/tests/md_cases/select_front_matter.toml
+++ b/tests/md_cases/select_front_matter.toml
@@ -8,6 +8,12 @@ author: Me
 # My Document
 
 This is the document body.
+
+---
+it has: a block that looks like front matter
+but: isn't
+---
+
 '''
 
 [chained]
@@ -67,3 +73,45 @@ cli_args = ["+++ non-existent"]
 output = '''
 '''
 expect_success = false
+
+
+[expect."select a paragraph that looks like front matter"]
+cli_args = ["-o", "json"]
+output_json = true
+output = '''
+{
+  "items": [
+    {
+      "document": [
+        {
+          "front_matter": {
+            "body": "title: Test Front Matter\nauthor: Me",
+            "variant": "toml"
+          }
+        },
+        {
+          "section": {
+            "depth": 1,
+            "title": "My Document",
+            "body": [
+              {
+                "paragraph": "This is the document body."
+              },
+              {
+                "thematic_break": null
+              },
+              {
+                "section": {
+                  "depth": 2,
+                  "title": "it has: a block that looks like front matter\nbut: isn't",
+                  "body": []
+                }
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
+}
+'''


### PR DESCRIPTION
Add front matter parsing and selection. The syntax is:

```text
+++variant contents
```

## Examples

```md
---
title: my title
---
```

The following will match:

```
+++
```

```
+++ my title
```

```
+++yaml
```

```
+++yaml my title
```
... but this won't:

```
+++toml
````

## Breaking changes to API:

- rm `CodeVariant::{ Toml, Yaml }` (these really should have been front matter variants, not general code variants)
- add `MdElem::FrontMatter`, with supporting types for the contents and variants
- `ParseOptions::default()` now enables front matter
- add a new selector (this isn't actually a breaking change, since the selectors enum is non-exhaustive; but it's worth mentioning)
- `BlockHtml` no longer implements `Display`; it was the only one of its siblings that did, so this makes it more consistent with the others

## Issues

Resolves #214 