### PR TITLE
add MatchReplace

### DIFF
--- a/src/query/match_replace_try_from.rs
+++ b/src/query/match_replace_try_from.rs
@@ -1,0 +1,12 @@
+use crate::query::{InnerParseError, Pair};
+use crate::select::{MatchReplace, Matcher};
+
+impl MatchReplace {
+    pub(crate) fn try_from(pair: Option<Pair>) -> Result<Self, InnerParseError> {
+        let matcher = Matcher::try_from(pair)?;
+        Ok(MatchReplace {
+            matcher,
+            replacement: None,
+        })
+    }
+}

--- a/src/query/mod.rs
+++ b/src/query/mod.rs
@@ -1,6 +1,7 @@
 mod pest;
 
 mod error;
+mod match_replace_try_from;
 mod matcher_try_from;
 mod selector_try_from;
 mod strings;

--- a/src/select/match_replace.rs
+++ b/src/select/match_replace.rs
@@ -1,0 +1,7 @@
+use crate::select::Matcher;
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct MatchReplace {
+    pub matcher: Matcher,
+    pub replacement: Option<String>,
+}

--- a/src/select/mod.rs
+++ b/src/select/mod.rs
@@ -5,6 +5,7 @@
 //! - Parse text into `Selector` using `try_into`.
 //! - Run it against an [`MdDoc`](crate::md_elem::MdDoc) using [`Selector::find_nodes`].
 mod api;
+mod match_replace;
 mod match_selector;
 mod matcher;
 mod sel_chain;
@@ -20,5 +21,6 @@ mod string_matcher;
 pub(crate) use api::*;
 
 pub use crate::query::ParseError;
+pub use match_replace::*;
 pub use matcher::*;
 pub use selector::*;

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -1,7 +1,7 @@
 use crate::md_elem::elem::FrontMatterVariant;
 use crate::md_elem::{MdContext, MdDoc, MdElem};
 use crate::query::ParseError;
-use crate::select::{Matcher, SelectorAdapter};
+use crate::select::{MatchReplace, SelectorAdapter};
 
 /// The completion state that a [`ListItemMatcher`] looks for.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -25,59 +25,59 @@ pub struct ListItemMatcher {
     ///
     /// Tasks are typically unordered, but may also be ordered (`1. [ ] foo`).
     pub task: ListItemTask,
-    pub matcher: Matcher,
+    pub matcher: MatchReplace,
 }
 
 /// matcher for [`Selector::Section`]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SectionMatcher {
-    pub title: Matcher,
+    pub title: MatchReplace,
 }
 
 /// matcher for both [`Selector::Link`] and [`Selector::Image`]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct LinklikeMatcher {
-    pub display_matcher: Matcher,
-    pub url_matcher: Matcher,
+    pub display_matcher: MatchReplace,
+    pub url_matcher: MatchReplace,
 }
 
 /// matcher for [`Selector::BlockQuote`]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct BlockQuoteMatcher {
-    pub text: Matcher,
+    pub text: MatchReplace,
 }
 
 /// matcher for [`Selector::Html`]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HtmlMatcher {
-    pub html: Matcher,
+    pub html: MatchReplace,
 }
 
 /// matcher for [`Selector::Paragraph`]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ParagraphMatcher {
-    pub text: Matcher,
+    pub text: MatchReplace,
 }
 
 /// matcher for [`Selector::CodeBlock`]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct CodeBlockMatcher {
-    pub language: Matcher,
-    pub contents: Matcher,
+    pub language: MatchReplace,
+    pub contents: MatchReplace,
 }
 
 /// matcher for [`Selector::FrontMatter`]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FrontMatterMatcher {
     pub variant: Option<FrontMatterVariant>,
-    pub text: Matcher,
+    pub text: MatchReplace,
 }
 
 /// matcher for [`Selector::Table`]
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct TableMatcher {
-    pub headers: Matcher,
-    pub rows: Matcher,
+    pub headers: MatchReplace,
+    pub rows: MatchReplace,
 }
 
 /// The in-memory equivalent of mdq's selector query string.

--- a/src/select/string_matcher.rs
+++ b/src/select/string_matcher.rs
@@ -1,7 +1,7 @@
 use crate::md_elem::elem::*;
 use crate::md_elem::*;
 use crate::output::inlines_to_plain_string;
-use crate::select::Matcher;
+use crate::select::{MatchReplace, Matcher};
 use fancy_regex::Regex;
 use std::borrow::Borrow;
 
@@ -93,6 +93,12 @@ impl From<Matcher> for StringMatcher {
             Matcher::Regex(re) => Self::regex(re.re),
             Matcher::Any { .. } => Self::any(),
         }
+    }
+}
+
+impl From<MatchReplace> for StringMatcher {
+    fn from(value: MatchReplace) -> Self {
+        Self::from(value.matcher)
     }
 }
 


### PR DESCRIPTION
This will eventually serve as a search-replace mechanism for a search-and-replace.

In service of #277.

Breaking change:

- the various selector matchers now take MatchReplace instead of Matcher