### PR TITLE
possible parsing improvements for regexes

### DIFF
--- a/src/query/grammar.pest
+++ b/src/query/grammar.pest
@@ -74,7 +74,7 @@ regex_char          = ${
     (regex_escaped_slash | regex_normal_char)
 }
 regex_escaped_slash = @{ "\\/" }
-regex_normal_char   = @{ !("/") ~ ANY }
+regex_normal_char   = @{ (!("/" | "\\/") ~ ANY)+ }
 
 quoted_string = ${ PUSH("'" | "\"") ~ quoted_char* ~ POP }
 


### PR DESCRIPTION
These have a good amount of functional testing, so I'm not worried about that. But I'd be interested to see if there's actually any perf benefit.

The motivation here is that I noticed there are a lot of Pairs being created (in the code before this PR), since each char in the regex match is a single-char Pair. This makes debugging a pain, but it also means there are more heap allocations (I _think_ Pairs are heap-allocated, but I may be wrong about that).

I should do at least a bit of perf testing before I merge this.