### PR TITLE
pipe the replacement string from MatchReplace to StringMatcher

### DIFF
--- a/src/select/string_matcher.rs
+++ b/src/select/string_matcher.rs
@@ -75,9 +75,9 @@ impl StringMatcher {
     }
 }
 
-impl From<Matcher> for StringMatcher {
-    fn from(value: Matcher) -> Self {
-        match value {
+impl From<MatchReplace> for StringMatcher {
+    fn from(value: MatchReplace) -> Self {
+        match value.matcher {
             Matcher::Text {
                 case_sensitive,
                 anchor_start,
@@ -93,12 +93,6 @@ impl From<Matcher> for StringMatcher {
             Matcher::Regex(re) => Self::regex(re.re),
             Matcher::Any { .. } => Self::any(),
         }
-    }
-}
-
-impl From<MatchReplace> for StringMatcher {
-    fn from(value: MatchReplace) -> Self {
-        Self::from(value.matcher)
     }
 }
 

--- a/src/select/string_matcher.rs
+++ b/src/select/string_matcher.rs
@@ -8,7 +8,7 @@ use std::borrow::Borrow;
 #[derive(Debug)]
 pub struct StringMatcher {
     re: Regex,
-    pub replacement: Option<String>,
+    replacement: Option<String>,
 }
 
 impl PartialEq for StringMatcher {

--- a/src/select/string_matcher.rs
+++ b/src/select/string_matcher.rs
@@ -65,7 +65,7 @@ impl StringMatcher {
         }
     }
 
-    pub fn re_for_any() -> Regex {
+    fn re_for_any() -> Regex {
         Regex::new(".*").expect("internal error")
     }
 

--- a/src/select/string_matcher.rs
+++ b/src/select/string_matcher.rs
@@ -73,10 +73,7 @@ impl StringMatcher {
     }
 
     fn regex(re: Regex) -> Self {
-        Self {
-            re,
-            replacement: None,
-        }
+        Self { re, replacement: None }
     }
 
     fn from_text(text: String, case_sensitive: bool, anchor_start: bool, anchor_end: bool) -> Self {
@@ -94,10 +91,7 @@ impl StringMatcher {
         }
 
         let re = Regex::new(&pattern).expect("internal error");
-        Self {
-            re,
-            replacement: None,
-        }
+        Self { re, replacement: None }
     }
 }
 


### PR DESCRIPTION
For now, just pass it through; we're not going to use it yet. That'll be subsequent PRs.

In service of #277.