### PR TITLE
don't use MDQ_PORTABLE_ERRORS env var

### DIFF
--- a/scripts/system_test
+++ b/scripts/system_test
@@ -86,7 +86,7 @@ function run_test_spec() {
 
     local actual_success=true
     set -x
-    MDQ_PORTABLE_ERRORS=1 "$mdq" <<<"$stdin" "${cli_args[@]}" >actual_out.txt 2>actual_err.txt || actual_success=false
+    "$mdq" <<<"$stdin" "${cli_args[@]}" >actual_out.txt 2>actual_err.txt || actual_success=false
     set +x
 
     if [[ "$output_json" == true ]]; then

--- a/src/run/run_main.rs
+++ b/src/run/run_main.rs
@@ -7,8 +7,8 @@ use crate::select::Selector;
 use crate::{md_elem, output, query};
 use pest::Span;
 use std::fmt::{Display, Formatter};
+use std::io;
 use std::io::Write;
-use std::{env, io};
 
 /// The run's overall possible error.
 #[derive(Debug)]
@@ -94,11 +94,16 @@ impl Display for Error {
                 writeln!(f, "{err}")
             }
             Error::FileReadError(file, err) => {
-                if env::var("MDQ_PORTABLE_ERRORS").unwrap_or_default().is_empty() {
-                    writeln!(f, "{err} while reading {file}")
-                } else {
-                    writeln!(f, "{} while reading {file}", err.kind())
+                #[cfg(test)]
+                {
+                    // For tests, use a simpler, more portable error string. Especially useful for integ tests.
+                    writeln!(f, "{err} while reading {file}")?
                 }
+                #[cfg(not(test))]
+                {
+                    writeln!(f, "{} while reading {file}", err.kind())?
+                }
+                Ok(())
             }
         }
     }


### PR DESCRIPTION
Instead, just use `#[cfg(test)]`.

`env::set_var` is not thread-safe.