### PR TITLE
make replacement always be an error

### DIFF
--- a/src/md_elem/tree_ref.rs
+++ b/src/md_elem/tree_ref.rs
@@ -37,9 +37,9 @@ mod elem_ref {
             }
         }
 
-        pub fn retain_columns_by_header<F, X>(&mut self, mut f: F) -> Result<(), X>
+        pub fn retain_columns_by_header<F, E>(&mut self, mut f: F) -> Result<(), E>
         where
-            F: FnMut(&TableCell) -> Result<bool, X>,
+            F: FnMut(&TableCell) -> Result<bool, E>,
         {
             let Some(first_row) = self.rows.first() else {
                 return Ok(());
@@ -67,9 +67,9 @@ mod elem_ref {
             Ok(())
         }
 
-        pub fn retain_rows<F, X>(&mut self, mut f: F) -> Result<(), X>
+        pub fn retain_rows<F, E>(&mut self, mut f: F) -> Result<(), E>
         where
-            F: FnMut(&TableCell) -> Result<bool, X>,
+            F: FnMut(&TableCell) -> Result<bool, E>,
         {
             self.rows.retain_with_index(|idx, row| {
                 if idx == 0 {

--- a/src/md_elem/tree_ref.rs
+++ b/src/md_elem/tree_ref.rs
@@ -37,15 +37,15 @@ mod elem_ref {
             }
         }
 
-        pub fn retain_columns_by_header<F>(&mut self, mut f: F)
+        pub fn retain_columns_by_header<F, X>(&mut self, mut f: F) -> Result<(), X>
         where
-            F: FnMut(&TableCell) -> bool,
+            F: FnMut(&TableCell) -> Result<bool, X>,
         {
             let Some(first_row) = self.rows.first() else {
-                return;
+                return Ok(());
             };
             let mut keeper_indices = IndexKeeper::new();
-            keeper_indices.retain_when(first_row, |_, cell| f(cell));
+            keeper_indices.retain_when(first_row, |_, cell| f(cell))?;
 
             match keeper_indices.count_keeps() {
                 0 => {
@@ -58,24 +58,30 @@ mod elem_ref {
                 }
                 _ => {
                     // some columns match: retain those, and discard the rest
-                    self.alignments.retain_with_index(keeper_indices.retain_fn());
+                    self.alignments.retain_with_index(keeper_indices.retain_fn())?;
                     for row in self.rows.iter_mut() {
-                        row.retain_with_index(keeper_indices.retain_fn());
+                        row.retain_with_index(keeper_indices.retain_fn())?;
                     }
                 }
             }
+            Ok(())
         }
 
-        pub fn retain_rows<F>(&mut self, mut f: F)
+        pub fn retain_rows<F, X>(&mut self, mut f: F) -> Result<(), X>
         where
-            F: FnMut(&TableCell) -> bool,
+            F: FnMut(&TableCell) -> Result<bool, X>,
         {
             self.rows.retain_with_index(|idx, row| {
                 if idx == 0 {
-                    return true;
+                    return Ok(true);
                 }
-                row.iter().any(&mut f)
-            });
+                for cell in row {
+                    if f(cell)? {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            })
         }
 
         pub fn is_empty(&self) -> bool {
@@ -102,7 +108,7 @@ mod tests {
                 vec!["data 1 a", "data 1 b", "data 1 c"],
                 vec!["data 2 a", "data 2 b", "KEEPER c"],
             ]);
-            table.retain_columns_by_header(cell_matches("KEEPER"));
+            table.retain_columns_by_header(cell_matches("KEEPER")).unwrap();
 
             // note: "KEEPER" is in the last column, but not in the header; only the header gets
             // matched.
@@ -123,10 +129,12 @@ mod tests {
             table.normalize();
 
             let mut seen_lines = Vec::with_capacity(3);
-            table.retain_columns_by_header(|line| {
-                seen_lines.push(simple_to_string(line));
-                true
-            });
+            table
+                .retain_columns_by_header(|line| {
+                    seen_lines.push(simple_to_string(line));
+                    Ok::<_, ()>(true)
+                })
+                .unwrap();
 
             // normalization
             assert_eq!(
@@ -154,7 +162,7 @@ mod tests {
                 vec!["data 1 a", "data 1 b", "data 1 c"],
                 vec!["data 2 a", "KEEPER b", "data 2 c"],
             ]);
-            table.retain_rows(cell_matches("KEEPER"));
+            table.retain_rows(cell_matches("KEEPER")).unwrap();
 
             assert_eq!(
                 table.alignments,
@@ -187,10 +195,12 @@ mod tests {
             // retain only the rows with empty cells. This lets us get around the short-circuiting
             // of retain_rows (it short-circuits within each row as soon as it finds a matching
             // cell), to validate that the normalization works as expected.
-            table.retain_rows(|line| {
-                seen_lines.push(simple_to_string(line));
-                line.is_empty()
-            });
+            table
+                .retain_rows(|line| {
+                    seen_lines.push(simple_to_string(line));
+                    Ok::<_, ()>(line.is_empty())
+                })
+                .unwrap();
 
             // normalization
             assert_eq!(
@@ -219,10 +229,10 @@ mod tests {
             );
         }
 
-        fn cell_matches(substring: &str) -> impl Fn(&TableCell) -> bool + '_ {
+        fn cell_matches(substring: &str) -> impl Fn(&TableCell) -> Result<bool, ()> + '_ {
             move |line| {
                 let line_str = format!("{:?}", line);
-                line_str.contains(substring)
+                Ok(line_str.contains(substring))
             }
         }
 

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -27,14 +27,16 @@ pub(crate) enum Select {
 }
 
 /// An error that occurred during selection processing.
-#[derive(Debug)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash)]
 pub struct SelectError {
     message: String,
 }
 
 impl SelectError {
-    pub(crate) fn new(message: String) -> Self {
-        Self { message }
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
     }
 }
 

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -32,6 +32,12 @@ pub struct SelectError {
     message: String,
 }
 
+impl SelectError {
+    pub(crate) fn new(message: String) -> Self {
+        Self { message }
+    }
+}
+
 impl Display for SelectError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", self.message)

--- a/src/select/match_selector.rs
+++ b/src/select/match_selector.rs
@@ -8,9 +8,7 @@ use crate::select::TrySelector;
 pub trait MatchSelector<I> {
     fn matches(&self, item: &I) -> std::result::Result<bool, StringMatchError>;
 
-    fn name() -> &'static str {
-        todo!() // will be something like "section" for SectionSelector, etc
-    }
+    fn name() -> &'static str;
 }
 
 impl<I, M> TrySelector<I> for M

--- a/src/select/match_selector.rs
+++ b/src/select/match_selector.rs
@@ -1,11 +1,16 @@
 use crate::md_elem::*;
 use crate::select::api::{Result, Select};
+use crate::select::string_matcher::StringMatchError;
 use crate::select::TrySelector;
 
 /// MatchSelector is a helper trait for implementing [TrySelector]. Simply provide the boolean predicate for whether a
 /// given item matches, and MatchSelector will do the rest.
 pub trait MatchSelector<I> {
-    fn matches(&self, item: &I) -> bool;
+    fn matches(&self, item: &I) -> std::result::Result<bool, StringMatchError>;
+
+    fn name() -> &'static str {
+        todo!() // will be something like "section" for SectionSelector, etc
+    }
 }
 
 impl<I, M> TrySelector<I> for M
@@ -14,7 +19,7 @@ where
     M: MatchSelector<I>,
 {
     fn try_select(&self, _: &MdContext, item: I) -> Result<Select> {
-        if self.matches(&item) {
+        if self.matches(&item).map_err(|e| e.to_select_error(M::name()))? {
             Ok(Select::Hit(vec![item.into()]))
         } else {
             Ok(Select::Miss(item.into()))

--- a/src/select/match_selector.rs
+++ b/src/select/match_selector.rs
@@ -6,9 +6,9 @@ use crate::select::TrySelector;
 /// MatchSelector is a helper trait for implementing [TrySelector]. Simply provide the boolean predicate for whether a
 /// given item matches, and MatchSelector will do the rest.
 pub trait MatchSelector<I> {
-    fn matches(&self, item: &I) -> std::result::Result<bool, StringMatchError>;
+    const NAME: &'static str;
 
-    fn name() -> &'static str;
+    fn matches(&self, item: &I) -> std::result::Result<bool, StringMatchError>;
 }
 
 impl<I, M> TrySelector<I> for M
@@ -17,7 +17,7 @@ where
     M: MatchSelector<I>,
 {
     fn try_select(&self, _: &MdContext, item: I) -> Result<Select> {
-        if self.matches(&item).map_err(|e| e.to_select_error(M::name()))? {
+        if self.matches(&item).map_err(|e| e.to_select_error(M::NAME))? {
             Ok(Select::Hit(vec![item.into()]))
         } else {
             Ok(Select::Miss(item.into()))

--- a/src/select/sel_code_block.rs
+++ b/src/select/sel_code_block.rs
@@ -1,6 +1,6 @@
 use crate::md_elem::elem::*;
 use crate::select::match_selector::MatchSelector;
-use crate::select::string_matcher::{StringMatcher, StringMatchError};
+use crate::select::string_matcher::{StringMatchError, StringMatcher};
 use crate::select::CodeBlockMatcher;
 
 #[derive(Debug, PartialEq)]
@@ -31,5 +31,58 @@ impl MatchSelector<CodeBlock> for CodeBlockSelector {
             CodeVariant::Math { .. } => false,
         };
         Ok(lang_matches && self.contents_matcher.matches(&code_block.value)?)
+    }
+
+    fn name() -> &'static str {
+        "code block"
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::md_elem::MdContext;
+    use crate::select::{MatchReplace, Matcher, TrySelector};
+
+    #[test]
+    fn code_block_selector_match_error() {
+        let code_block_matcher = CodeBlockMatcher {
+            language: MatchReplace {
+                matcher: Matcher::Text {
+                    case_sensitive: false,
+                    anchor_start: false,
+                    text: "rust".to_string(),
+                    anchor_end: false,
+                },
+                replacement: Some("replacement".to_string()),
+            },
+            contents: MatchReplace {
+                matcher: Matcher::Any { explicit: false },
+                replacement: None,
+            },
+        };
+
+        let code_block = CodeBlock {
+            variant: CodeVariant::Code(Some(CodeOpts {
+                language: "rust".to_string(),
+                metadata: None,
+            })),
+            value: "fn main() {}".to_string(),
+        };
+
+        let code_block_selector = CodeBlockSelector::from(code_block_matcher);
+
+        assert_eq!(
+            code_block_selector.matches(&code_block),
+            Err(StringMatchError::NotSupported)
+        );
+
+        assert_eq!(
+            code_block_selector
+                .try_select(&MdContext::default(), code_block)
+                .unwrap_err()
+                .to_string(),
+            "code block selector does not support string replace"
+        );
     }
 }

--- a/src/select/sel_code_block.rs
+++ b/src/select/sel_code_block.rs
@@ -1,6 +1,6 @@
 use crate::md_elem::elem::*;
 use crate::select::match_selector::MatchSelector;
-use crate::select::string_matcher::StringMatcher;
+use crate::select::string_matcher::{StringMatcher, StringMatchError};
 use crate::select::CodeBlockMatcher;
 
 #[derive(Debug, PartialEq)]
@@ -19,17 +19,17 @@ impl From<CodeBlockMatcher> for CodeBlockSelector {
 }
 
 impl MatchSelector<CodeBlock> for CodeBlockSelector {
-    fn matches(&self, code_block: &CodeBlock) -> bool {
+    fn matches(&self, code_block: &CodeBlock) -> Result<bool, StringMatchError> {
         let lang_matches = match &code_block.variant {
             CodeVariant::Code(code_opts) => {
                 let actual_lang = match code_opts {
                     Some(co) => &co.language,
                     None => "",
                 };
-                self.lang_matcher.matches(actual_lang)
+                self.lang_matcher.matches(actual_lang)?
             }
             CodeVariant::Math { .. } => false,
         };
-        lang_matches && self.contents_matcher.matches(&code_block.value)
+        Ok(lang_matches && self.contents_matcher.matches(&code_block.value)?)
     }
 }

--- a/src/select/sel_code_block.rs
+++ b/src/select/sel_code_block.rs
@@ -19,6 +19,8 @@ impl From<CodeBlockMatcher> for CodeBlockSelector {
 }
 
 impl MatchSelector<CodeBlock> for CodeBlockSelector {
+    const NAME: &'static str = "code block";
+
     fn matches(&self, code_block: &CodeBlock) -> Result<bool, StringMatchError> {
         let lang_matches = match &code_block.variant {
             CodeVariant::Code(code_opts) => {
@@ -31,10 +33,6 @@ impl MatchSelector<CodeBlock> for CodeBlockSelector {
             CodeVariant::Math { .. } => false,
         };
         Ok(lang_matches && self.contents_matcher.matches(&code_block.value)?)
-    }
-
-    fn name() -> &'static str {
-        "code block"
     }
 }
 

--- a/src/select/sel_link_like.rs
+++ b/src/select/sel_link_like.rs
@@ -1,6 +1,6 @@
 use crate::md_elem::elem::*;
 use crate::select::match_selector::MatchSelector;
-use crate::select::string_matcher::{StringMatcher, StringMatchError};
+use crate::select::string_matcher::{StringMatchError, StringMatcher};
 use crate::select::LinklikeMatcher;
 
 #[derive(Debug, PartialEq)]
@@ -19,6 +19,10 @@ impl MatchSelector<Link> for LinkSelector {
         Ok(self.matchers.display_matcher.matches_inlines(&item.display)?
             && self.matchers.url_matcher.matches(&item.link.url)?)
     }
+
+    fn name() -> &'static str {
+        "link"
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -36,6 +40,10 @@ impl MatchSelector<Image> for ImageSelector {
     fn matches(&self, item: &Image) -> Result<bool, StringMatchError> {
         Ok(self.matchers.display_matcher.matches(&item.alt)? && self.matchers.url_matcher.matches(&item.link.url)?)
     }
+
+    fn name() -> &'static str {
+        "image"
+    }
 }
 
 #[derive(Debug, PartialEq)]
@@ -50,5 +58,94 @@ impl From<LinklikeMatcher> for LinkMatchers {
             display_matcher: value.display_matcher.into(),
             url_matcher: value.url_matcher.into(),
         }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::md_elem::MdContext;
+    use crate::select::{MatchReplace, Matcher, TrySelector};
+
+    #[test]
+    fn link_selector_match_error() {
+        let link_matcher = LinklikeMatcher {
+            display_matcher: MatchReplace {
+                matcher: Matcher::Text {
+                    case_sensitive: false,
+                    anchor_start: false,
+                    text: "test".to_string(),
+                    anchor_end: false,
+                },
+                replacement: Some("replacement".to_string()),
+            },
+            url_matcher: MatchReplace {
+                matcher: Matcher::Any { explicit: false },
+                replacement: None,
+            },
+        };
+
+        let link = Link {
+            display: vec![],
+            link: LinkDefinition {
+                url: "https://example.com".to_string(),
+                title: None,
+                reference: LinkReference::Inline,
+            },
+        };
+
+        let link_selector = LinkSelector::from(link_matcher);
+
+        assert_eq!(link_selector.matches(&link), Err(StringMatchError::NotSupported));
+
+        assert_eq!(
+            link_selector
+                .try_select(&MdContext::default(), link)
+                .unwrap_err()
+                .to_string(),
+            "link selector does not support string replace"
+        );
+    }
+
+    #[test]
+    fn image_selector_match_error() {
+        let image_matcher = LinklikeMatcher {
+            display_matcher: MatchReplace {
+                matcher: Matcher::Text {
+                    case_sensitive: false,
+                    anchor_start: false,
+                    text: "alt text".to_string(),
+                    anchor_end: false,
+                },
+                replacement: Some("replacement".to_string()),
+            },
+            url_matcher: MatchReplace {
+                matcher: Matcher::Any { explicit: false },
+                replacement: None,
+            },
+        };
+
+        let image = Image {
+            alt: "alt text".to_string(),
+            link: LinkDefinition {
+                url: "https://example.com/image.png".to_string(),
+                title: None,
+                reference: LinkReference::Inline,
+            },
+        };
+
+        let image_selector = ImageSelector::from(image_matcher);
+
+        // Test that matches() propagates the StringMatchError::NotSupported
+        assert_eq!(image_selector.matches(&image), Err(StringMatchError::NotSupported));
+
+        // Test that try_select() converts the error to SelectError with proper selector name
+        assert_eq!(
+            image_selector
+                .try_select(&MdContext::default(), image)
+                .unwrap_err()
+                .to_string(),
+            "image selector does not support string replace"
+        );
     }
 }

--- a/src/select/sel_link_like.rs
+++ b/src/select/sel_link_like.rs
@@ -15,13 +15,11 @@ impl From<LinklikeMatcher> for LinkSelector {
 }
 
 impl MatchSelector<Link> for LinkSelector {
+    const NAME: &'static str = "hyperlink";
+
     fn matches(&self, item: &Link) -> Result<bool, StringMatchError> {
         Ok(self.matchers.display_matcher.matches_inlines(&item.display)?
             && self.matchers.url_matcher.matches(&item.link.url)?)
-    }
-
-    fn name() -> &'static str {
-        "link"
     }
 }
 
@@ -37,12 +35,10 @@ impl From<LinklikeMatcher> for ImageSelector {
 }
 
 impl MatchSelector<Image> for ImageSelector {
+    const NAME: &'static str = "image";
+
     fn matches(&self, item: &Image) -> Result<bool, StringMatchError> {
         Ok(self.matchers.display_matcher.matches(&item.alt)? && self.matchers.url_matcher.matches(&item.link.url)?)
-    }
-
-    fn name() -> &'static str {
-        "image"
     }
 }
 

--- a/src/select/sel_link_like.rs
+++ b/src/select/sel_link_like.rs
@@ -99,7 +99,7 @@ mod test {
                 .try_select(&MdContext::default(), link)
                 .unwrap_err()
                 .to_string(),
-            "link selector does not support string replace"
+            "hyperlink selector does not support string replace"
         );
     }
 

--- a/src/select/sel_link_like.rs
+++ b/src/select/sel_link_like.rs
@@ -1,6 +1,6 @@
 use crate::md_elem::elem::*;
 use crate::select::match_selector::MatchSelector;
-use crate::select::string_matcher::StringMatcher;
+use crate::select::string_matcher::{StringMatcher, StringMatchError};
 use crate::select::LinklikeMatcher;
 
 #[derive(Debug, PartialEq)]
@@ -15,9 +15,9 @@ impl From<LinklikeMatcher> for LinkSelector {
 }
 
 impl MatchSelector<Link> for LinkSelector {
-    fn matches(&self, item: &Link) -> bool {
-        self.matchers.display_matcher.matches_inlines(&item.display)
-            && self.matchers.url_matcher.matches(&item.link.url)
+    fn matches(&self, item: &Link) -> Result<bool, StringMatchError> {
+        Ok(self.matchers.display_matcher.matches_inlines(&item.display)?
+            && self.matchers.url_matcher.matches(&item.link.url)?)
     }
 }
 
@@ -33,8 +33,8 @@ impl From<LinklikeMatcher> for ImageSelector {
 }
 
 impl MatchSelector<Image> for ImageSelector {
-    fn matches(&self, item: &Image) -> bool {
-        self.matchers.display_matcher.matches(&item.alt) && self.matchers.url_matcher.matches(&item.link.url)
+    fn matches(&self, item: &Image) -> Result<bool, StringMatchError> {
+        Ok(self.matchers.display_matcher.matches(&item.alt)? && self.matchers.url_matcher.matches(&item.link.url)?)
     }
 }
 

--- a/src/select/sel_list_item.rs
+++ b/src/select/sel_list_item.rs
@@ -51,7 +51,10 @@ impl TrySelector<List> for ListItemSelector {
             [li] => {
                 let matched = self.li_type.matches(&starting_index)
                     && task_matches(self.checkbox, li.checked)
-                    && self.string_matcher.matches_any(&li.item);
+                    && self
+                        .string_matcher
+                        .matches_any(&li.item)
+                        .map_err(|e| e.to_select_error("list item"))?;
                 let list = MdElem::List(List { starting_index, items });
                 if matched {
                     Ok(Select::Hit(vec![list]))

--- a/src/select/sel_section.rs
+++ b/src/select/sel_section.rs
@@ -1,6 +1,6 @@
 use crate::md_elem::elem::*;
 use crate::select::match_selector::MatchSelector;
-use crate::select::string_matcher::StringMatcher;
+use crate::select::string_matcher::{StringMatcher, StringMatchError};
 use crate::select::SectionMatcher;
 
 #[derive(Debug, PartialEq)]
@@ -17,7 +17,7 @@ impl From<SectionMatcher> for SectionSelector {
 }
 
 impl MatchSelector<Section> for SectionSelector {
-    fn matches(&self, section: &Section) -> bool {
+    fn matches(&self, section: &Section) -> Result<bool, StringMatchError> {
         self.matcher.matches_inlines(&section.title)
     }
 }

--- a/src/select/sel_section.rs
+++ b/src/select/sel_section.rs
@@ -1,6 +1,6 @@
 use crate::md_elem::elem::*;
 use crate::select::match_selector::MatchSelector;
-use crate::select::string_matcher::{StringMatcher, StringMatchError};
+use crate::select::string_matcher::{StringMatchError, StringMatcher};
 use crate::select::SectionMatcher;
 
 #[derive(Debug, PartialEq)]
@@ -19,5 +19,48 @@ impl From<SectionMatcher> for SectionSelector {
 impl MatchSelector<Section> for SectionSelector {
     fn matches(&self, section: &Section) -> Result<bool, StringMatchError> {
         self.matcher.matches_inlines(&section.title)
+    }
+
+    fn name() -> &'static str {
+        "section"
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::select::{MatchReplace, Matcher, SelectError};
+
+    #[test]
+    fn section_selector_match_error() {
+        use crate::md_elem::MdContext;
+        use crate::select::TrySelector;
+
+        let section_matcher = SectionMatcher {
+            title: MatchReplace {
+                matcher: Matcher::Text {
+                    case_sensitive: false,
+                    anchor_start: false,
+                    text: "test".to_string(),
+                    anchor_end: false,
+                },
+                replacement: Some("replacement".to_string()),
+            },
+        };
+
+        let section = Section {
+            depth: 1,
+            title: vec![],
+            body: vec![],
+        };
+
+        let section_selector = SectionSelector::from(section_matcher);
+
+        assert_eq!(section_selector.matches(&section), Err(StringMatchError::NotSupported));
+
+        assert_eq!(
+            section_selector.try_select(&MdContext::default(), section).unwrap_err(),
+            SelectError::new("section selector does not support string replace"),
+        );
     }
 }

--- a/src/select/sel_section.rs
+++ b/src/select/sel_section.rs
@@ -17,12 +17,10 @@ impl From<SectionMatcher> for SectionSelector {
 }
 
 impl MatchSelector<Section> for SectionSelector {
+    const NAME: &'static str = "section";
+
     fn matches(&self, section: &Section) -> Result<bool, StringMatchError> {
         self.matcher.matches_inlines(&section.title)
-    }
-
-    fn name() -> &'static str {
-        "section"
     }
 }
 

--- a/src/select/sel_single_matcher.rs
+++ b/src/select/sel_single_matcher.rs
@@ -1,11 +1,11 @@
 use crate::md_elem::elem::*;
 use crate::select::match_selector::MatchSelector;
-use crate::select::string_matcher::{StringMatcher, StringMatchError};
-use crate::select::{BlockQuoteMatcher, FrontMatterMatcher, HtmlMatcher, ParagraphMatcher, SectionMatcher};
+use crate::select::string_matcher::{StringMatchError, StringMatcher};
+use crate::select::{BlockQuoteMatcher, FrontMatterMatcher, HtmlMatcher, ParagraphMatcher};
 use paste::paste;
 
 macro_rules! single_matcher_adapter {
-    { $name:ident {$matcher_field:ident} $match_fn:ident $tree_struct_field:ident } => {
+    { $name:ident {$matcher_field:ident} $match_fn:ident $tree_struct_field:ident $selector_name:literal } => {
         paste! {
             #[derive(Debug, PartialEq)]
             pub struct [<$name Selector>] {
@@ -15,6 +15,10 @@ macro_rules! single_matcher_adapter {
             impl MatchSelector<$name> for [<$name Selector>] {
                 fn matches(&self, matcher: &$name) -> Result<bool, StringMatchError> {
                     self.matcher.$match_fn(&matcher.$tree_struct_field)
+                }
+
+                fn name() -> &'static str {
+                    $selector_name
                 }
             }
 
@@ -27,9 +31,8 @@ macro_rules! single_matcher_adapter {
     };
 }
 
-single_matcher_adapter! { Section {title} matches_any body }
-single_matcher_adapter! { BlockQuote {text} matches_any body }
-single_matcher_adapter! { Paragraph {text} matches_inlines body }
+single_matcher_adapter! { BlockQuote {text} matches_any body "block quote" }
+single_matcher_adapter! { Paragraph {text} matches_inlines body "paragraph" }
 
 #[derive(Debug, PartialEq)]
 pub struct HtmlSelector {
@@ -47,6 +50,10 @@ impl From<HtmlMatcher> for HtmlSelector {
 impl MatchSelector<BlockHtml> for HtmlSelector {
     fn matches(&self, html: &BlockHtml) -> Result<bool, StringMatchError> {
         self.matcher.matches(&html.value)
+    }
+
+    fn name() -> &'static str {
+        "html"
     }
 }
 
@@ -72,5 +79,157 @@ impl MatchSelector<FrontMatter> for FrontMatterSelector {
             .map(|selected| selected == front_matter.variant)
             .unwrap_or(true);
         Ok(variant_selected && self.text.matches(&front_matter.body)?)
+    }
+
+    fn name() -> &'static str {
+        "front matter"
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::md_elem::{
+        elem::{BlockHtml, BlockQuote, FrontMatter, FrontMatterVariant, Inline, Paragraph, Text, TextVariant},
+        MdContext, MdElem,
+    };
+    use crate::select::{MatchReplace, Matcher, TrySelector};
+
+    #[test]
+    fn block_quote_selector_match_error() {
+        let block_quote_matcher = BlockQuoteMatcher {
+            text: MatchReplace {
+                matcher: Matcher::Text {
+                    case_sensitive: false,
+                    anchor_start: false,
+                    text: "test".to_string(),
+                    anchor_end: false,
+                },
+                replacement: Some("replacement".to_string()),
+            },
+        };
+
+        let block_quote = BlockQuote {
+            body: vec![MdElem::Paragraph(Paragraph {
+                body: vec![Inline::Text(Text {
+                    variant: TextVariant::Plain,
+                    value: "test content".to_string(),
+                })],
+            })],
+        };
+
+        let block_quote_selector = BlockQuoteSelector::from(block_quote_matcher);
+
+        assert_eq!(
+            block_quote_selector.matches(&block_quote),
+            Err(StringMatchError::NotSupported)
+        );
+
+        assert_eq!(
+            block_quote_selector
+                .try_select(&MdContext::default(), block_quote)
+                .unwrap_err()
+                .to_string(),
+            "block quote selector does not support string replace"
+        );
+    }
+
+    #[test]
+    fn paragraph_selector_match_error() {
+        let paragraph_matcher = ParagraphMatcher {
+            text: MatchReplace {
+                matcher: Matcher::Text {
+                    case_sensitive: false,
+                    anchor_start: false,
+                    text: "test".to_string(),
+                    anchor_end: false,
+                },
+                replacement: Some("replacement".to_string()),
+            },
+        };
+
+        let paragraph = Paragraph { body: vec![] };
+
+        let paragraph_selector = ParagraphSelector::from(paragraph_matcher);
+
+        assert_eq!(
+            paragraph_selector.matches(&paragraph),
+            Err(StringMatchError::NotSupported)
+        );
+
+        assert_eq!(
+            paragraph_selector
+                .try_select(&MdContext::default(), paragraph)
+                .unwrap_err()
+                .to_string(),
+            "paragraph selector does not support string replace"
+        );
+    }
+
+    #[test]
+    fn html_selector_match_error() {
+        let html_matcher = HtmlMatcher {
+            html: MatchReplace {
+                matcher: Matcher::Text {
+                    case_sensitive: false,
+                    anchor_start: false,
+                    text: "div".to_string(),
+                    anchor_end: false,
+                },
+                replacement: Some("replacement".to_string()),
+            },
+        };
+
+        let block_html = BlockHtml {
+            value: "<div>content</div>".to_string(),
+        };
+
+        let html_selector = HtmlSelector::from(html_matcher);
+
+        assert_eq!(html_selector.matches(&block_html), Err(StringMatchError::NotSupported));
+
+        assert_eq!(
+            html_selector
+                .try_select(&MdContext::default(), block_html)
+                .unwrap_err()
+                .to_string(),
+            "html selector does not support string replace"
+        );
+    }
+
+    #[test]
+    fn front_matter_selector_match_error() {
+        let front_matter_matcher = FrontMatterMatcher {
+            variant: None,
+            text: MatchReplace {
+                matcher: Matcher::Text {
+                    case_sensitive: false,
+                    anchor_start: false,
+                    text: "title".to_string(),
+                    anchor_end: false,
+                },
+                replacement: Some("replacement".to_string()),
+            },
+        };
+
+        let front_matter = FrontMatter {
+            variant: FrontMatterVariant::Yaml,
+            body: "title: test".to_string(),
+        };
+
+        let front_matter_selector = FrontMatterSelector::from(front_matter_matcher);
+
+        assert_eq!(
+            front_matter_selector.matches(&front_matter),
+            Err(StringMatchError::NotSupported)
+        );
+
+        assert_eq!(
+            front_matter_selector
+                .try_select(&MdContext::default(), front_matter)
+                .unwrap_err()
+                .to_string(),
+            "front matter selector does not support string replace"
+        );
     }
 }

--- a/src/select/sel_single_matcher.rs
+++ b/src/select/sel_single_matcher.rs
@@ -13,12 +13,10 @@ macro_rules! single_matcher_adapter {
             }
 
             impl MatchSelector<$name> for [<$name Selector>] {
+                const NAME: &'static str = $selector_name;
+
                 fn matches(&self, matcher: &$name) -> Result<bool, StringMatchError> {
                     self.matcher.$match_fn(&matcher.$tree_struct_field)
-                }
-
-                fn name() -> &'static str {
-                    $selector_name
                 }
             }
 
@@ -48,12 +46,10 @@ impl From<HtmlMatcher> for HtmlSelector {
 }
 
 impl MatchSelector<BlockHtml> for HtmlSelector {
+    const NAME: &'static str = "html";
+
     fn matches(&self, html: &BlockHtml) -> Result<bool, StringMatchError> {
         self.matcher.matches(&html.value)
-    }
-
-    fn name() -> &'static str {
-        "html"
     }
 }
 
@@ -73,16 +69,14 @@ impl From<FrontMatterMatcher> for FrontMatterSelector {
 }
 
 impl MatchSelector<FrontMatter> for FrontMatterSelector {
+    const NAME: &'static str = "front matter";
+
     fn matches(&self, front_matter: &FrontMatter) -> Result<bool, StringMatchError> {
         let variant_selected = self
             .variant
             .map(|selected| selected == front_matter.variant)
             .unwrap_or(true);
         Ok(variant_selected && self.text.matches(&front_matter.body)?)
-    }
-
-    fn name() -> &'static str {
-        "front matter"
     }
 }
 

--- a/src/select/sel_single_matcher.rs
+++ b/src/select/sel_single_matcher.rs
@@ -1,6 +1,6 @@
 use crate::md_elem::elem::*;
 use crate::select::match_selector::MatchSelector;
-use crate::select::string_matcher::StringMatcher;
+use crate::select::string_matcher::{StringMatcher, StringMatchError};
 use crate::select::{BlockQuoteMatcher, FrontMatterMatcher, HtmlMatcher, ParagraphMatcher, SectionMatcher};
 use paste::paste;
 
@@ -13,7 +13,7 @@ macro_rules! single_matcher_adapter {
             }
 
             impl MatchSelector<$name> for [<$name Selector>] {
-                fn matches(&self, matcher: &$name) -> bool {
+                fn matches(&self, matcher: &$name) -> Result<bool, StringMatchError> {
                     self.matcher.$match_fn(&matcher.$tree_struct_field)
                 }
             }
@@ -45,7 +45,7 @@ impl From<HtmlMatcher> for HtmlSelector {
 }
 
 impl MatchSelector<BlockHtml> for HtmlSelector {
-    fn matches(&self, html: &BlockHtml) -> bool {
+    fn matches(&self, html: &BlockHtml) -> Result<bool, StringMatchError> {
         self.matcher.matches(&html.value)
     }
 }
@@ -66,11 +66,11 @@ impl From<FrontMatterMatcher> for FrontMatterSelector {
 }
 
 impl MatchSelector<FrontMatter> for FrontMatterSelector {
-    fn matches(&self, front_matter: &FrontMatter) -> bool {
+    fn matches(&self, front_matter: &FrontMatter) -> Result<bool, StringMatchError> {
         let variant_selected = self
             .variant
             .map(|selected| selected == front_matter.variant)
             .unwrap_or(true);
-        variant_selected && self.text.matches(&front_matter.body)
+        Ok(variant_selected && self.text.matches(&front_matter.body)?)
     }
 }

--- a/src/select/sel_table.rs
+++ b/src/select/sel_table.rs
@@ -15,15 +15,20 @@ impl TrySelector<Table> for TableSelector {
 
         table.normalize();
 
-        table.retain_columns_by_header(|line| self.headers_matcher.matches_inlines(line));
+        table
+            .retain_columns_by_header(|line| self.headers_matcher.matches_inlines(line))
+            .map_err(|e| e.to_select_error("table"))?;
         if table.is_empty() {
             return Ok(Select::Miss(orig.into()));
         }
 
-        table.retain_rows(|line| self.rows_matcher.matches_inlines(line));
+        table
+            .retain_rows(|line| self.rows_matcher.matches_inlines(line))
+            .map_err(|e| e.to_select_error("table"))?;
         if table.is_empty() {
             return Ok(Select::Miss(orig.into()));
         }
+
         Ok(Select::Hit(vec![table.into()]))
     }
 }

--- a/src/select/selector.rs
+++ b/src/select/selector.rs
@@ -121,12 +121,8 @@ impl Selector {
     /// The result also includes an [`MdContext`] that you can use with [`MdWriter`](crate::output::MdWriter).
     pub fn find_nodes(self, doc: MdDoc) -> Result<(Vec<MdElem>, MdContext)> {
         let MdDoc { ctx, roots } = doc;
-        let result_elems = self.find_nodes0(&ctx, vec![MdElem::Doc(roots)])?;
+        let result_elems = SelectorAdapter::from(self).find_nodes(&ctx, vec![MdElem::Doc(roots)])?;
         Ok((result_elems, ctx))
-    }
-
-    fn find_nodes0(self, ctx: &MdContext, nodes: Vec<MdElem>) -> Result<Vec<MdElem>> {
-        SelectorAdapter::from(self).find_nodes(ctx, nodes)
     }
 }
 

--- a/src/select/string_matcher.rs
+++ b/src/select/string_matcher.rs
@@ -143,6 +143,22 @@ mod test {
     use crate::query::{ParseError, StringVariant};
     use std::str::FromStr;
 
+    /// PartialEq implementation for StringMatchError. This is only available in tests, so that we don't expose the
+    /// brittle handling of our `RegexError` variant.
+    impl PartialEq for StringMatchError {
+        fn eq(&self, other: &Self) -> bool {
+            match (self, other) {
+                (StringMatchError::NotSupported, StringMatchError::NotSupported) => true,
+                (StringMatchError::RegexError(_), StringMatchError::RegexError(_)) => {
+                    // We can't compare fancy_regex::Error instances, so we'll consider them equal
+                    // if they're both RegexError variants. This is sufficient for our testing needs.
+                    true
+                }
+                _ => false,
+            }
+        }
+    }
+
     #[test]
     fn bareword() {
         parse_and_check("hello", re_insensitive("hello"), "");
@@ -364,6 +380,48 @@ mod test {
         assert!(matcher.matches("foobar").unwrap());
         assert!(!matcher.matches("foo").unwrap());
         assert!(!matcher.matches("foobaz").unwrap());
+    }
+
+    #[test]
+    fn matches_with_replacement_returns_not_supported_error() {
+        let matcher_with_replacement = StringMatcher::from(MatchReplace {
+            matcher: Matcher::Text {
+                case_sensitive: false,
+                anchor_start: false,
+                text: "hello".to_string(),
+                anchor_end: false,
+            },
+            replacement: Some("world".to_string()),
+        });
+
+        assert_eq!(
+            matcher_with_replacement.matches("hello"),
+            Err(StringMatchError::NotSupported)
+        );
+    }
+
+    #[test]
+    fn matches_inlines_with_replacement_returns_not_supported_error() {
+        let matcher_with_replacement = StringMatcher::from(MatchReplace {
+            matcher: Matcher::Any { explicit: false },
+            replacement: Some("replacement".to_string()),
+        });
+
+        let inlines: Vec<Inline> = vec![]; // empty inlines for simplicity
+        assert_eq!(
+            matcher_with_replacement.matches_inlines(&inlines),
+            Err(StringMatchError::NotSupported)
+        );
+    }
+
+    #[test]
+    fn string_match_error_to_select_error_formatting() {
+        let not_supported_error = StringMatchError::NotSupported;
+        let select_error = not_supported_error.to_select_error("section");
+        assert_eq!(
+            select_error.to_string(),
+            "section selector does not support string replace"
+        );
     }
 
     fn parse_and_check_with(

--- a/src/select/string_matcher.rs
+++ b/src/select/string_matcher.rs
@@ -21,7 +21,7 @@ impl StringMatchError {
     pub fn to_select_error(&self, selector_name: &str) -> SelectError {
         let message = match self {
             StringMatchError::NotSupported => format!("{selector_name} selector does not support string replace"),
-            StringMatchError::RegexError(err) => format!("regex evaluation error in {err} selector"),
+            StringMatchError::RegexError(err) => format!("regex evaluation error in {selector_name} selector: {err}"),
         };
         SelectError::new(message)
     }

--- a/src/select/string_matcher.rs
+++ b/src/select/string_matcher.rs
@@ -14,7 +14,7 @@ pub struct StringMatcher {
 #[derive(Clone, Debug)]
 pub(crate) enum StringMatchError {
     NotSupported,
-    RegexError(fancy_regex::Error),
+    RegexError(Box<fancy_regex::Error>),
 }
 
 impl StringMatchError {
@@ -40,7 +40,7 @@ impl StringMatcher {
         }
         match self.re.is_match(haystack) {
             Ok(m) => Ok(m),
-            Err(e) => Err(StringMatchError::RegexError(e)),
+            Err(e) => Err(StringMatchError::RegexError(Box::new(e))),
         }
     }
 

--- a/src/util/vec_utils.rs
+++ b/src/util/vec_utils.rs
@@ -11,9 +11,9 @@ impl IndexKeeper {
         }
     }
 
-    pub fn retain_when<I, F, X>(&mut self, items: &[I], mut allow_filter: F) -> Result<(), X>
+    pub fn retain_when<I, F, E>(&mut self, items: &[I], mut allow_filter: F) -> Result<(), E>
     where
-        F: FnMut(usize, &I) -> Result<bool, X>,
+        F: FnMut(usize, &I) -> Result<bool, E>,
     {
         for (idx, item) in items.iter().enumerate() {
             if allow_filter(idx, item)? {
@@ -24,7 +24,7 @@ impl IndexKeeper {
     }
 
     /// Returns an `FnMut` suitable for use in [ItemRetainer::retain_with_index].
-    pub fn retain_fn<I, X>(&self) -> impl FnMut(usize, &I) -> Result<bool, X> + '_ {
+    pub fn retain_fn<I, E>(&self) -> impl FnMut(usize, &I) -> Result<bool, E> + '_ {
         let mut next_to_keep = self.indices_to_keep.iter().peekable();
         move |target, _| {
             while let Some(&&value) = next_to_keep.peek() {
@@ -50,15 +50,15 @@ pub trait ItemRetainer<I> {
     /// `true`.
     ///
     /// This is guaranteed to iterate over items sequentially, and filters can take advantage of that fact.
-    fn retain_with_index<F, X>(&mut self, f: F) -> Result<(), X>
+    fn retain_with_index<F, E>(&mut self, f: F) -> Result<(), E>
     where
-        F: FnMut(usize, &I) -> Result<bool, X>;
+        F: FnMut(usize, &I) -> Result<bool, E>;
 }
 
 impl<I> ItemRetainer<I> for Vec<I> {
-    fn retain_with_index<F, X>(&mut self, mut f: F) -> Result<(), X>
+    fn retain_with_index<F, E>(&mut self, mut f: F) -> Result<(), E>
     where
-        F: FnMut(usize, &I) -> Result<bool, X>,
+        F: FnMut(usize, &I) -> Result<bool, E>,
     {
         // A simple algorithm, which is O(n) in both space and time.
         // I feel like there's an algorithm out there that's O(n) in time and O(1) in space, but this is good enough,

--- a/tests/md_cases/search_replace_errors.toml
+++ b/tests/md_cases/search_replace_errors.toml
@@ -1,0 +1,100 @@
+[given]
+md = '''
+# Section Title
+
+This is a paragraph with text.
+
+```language
+code content here
+```
+
+Here are some list items:
+
+- Item with **bold text** formatting
+- Item with *emphasis and **nested bold*** formatting
+- ![image alt](https://example.com/image.png) description
+- [link text](https://example.com/url) description
+'''
+
+[chained]
+needed = false
+
+[expect."search-replace section title"]
+cli_args = ['# !s/Title/Header/']
+expect_success = false
+output = ''
+output_err = '''Selection error:
+section selector does not support string replace
+'''
+
+[expect."search-replace code block language"]
+cli_args = ['``` !s/language/python/']
+expect_success = false
+output = ''
+output_err = '''Selection error:
+code block selector does not support string replace
+'''
+
+[expect."search-replace code block contents"]
+cli_args = ['``` !s/content/text/']
+expect_success = false
+output = ''
+output_err = '''Selection error:
+code block selector does not support string replace
+'''
+
+[expect."search-replace image alt text"]
+cli_args = ['![](!s/alt/description/)']
+expect_success = false
+output = ''
+output_err = '''Selection error:
+image selector does not support string replace
+'''
+
+[expect."search-replace image url"]
+cli_args = ['![](!s/image/photo/)']
+expect_success = false
+output = ''
+output_err = '''Selection error:
+image selector does not support string replace
+'''
+
+[expect."search-replace link text"]
+cli_args = ['[](!s/text/label/)']
+expect_success = false
+output = ''
+output_err = '''Selection error:
+hyperlink selector does not support string replace
+'''
+
+[expect."search-replace link url"]
+cli_args = ['[](!s/url/link/)']
+expect_success = false
+output = ''
+output_err = '''Selection error:
+hyperlink selector does not support string replace
+'''
+
+[expect."search-replace straightforward formatting"]
+cli_args = ['- !s/bold/strong/']
+expect_success = false
+output = ''
+output_err = '''Selection error:
+list item selector does not support string replace
+'''
+
+[expect."search-replace nested formatting"]
+cli_args = ['- !s/and nested/and formerly/']
+expect_success = false
+output = ''
+output_err = '''Selection error:
+list item selector does not support string replace
+'''
+
+[expect."search-replace paragraph text"]
+cli_args = ['P: !s/paragraph/text/']
+expect_success = false
+output = ''
+output_err = '''Selection error:
+paragraph selector does not support string replace
+'''


### PR DESCRIPTION
Instead of ignoring the replacement, check for it in `StringMatcher::matches` and return an Err if the replacement is `Some`. In a subsequent PR, we'll be allowing it in very limited cases (link and image URLs).

Includes lots of testing!