### PR TITLE
handle autolinks in parsing and rendering

### DIFF
--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -1255,7 +1255,7 @@ pub mod elem {
         /// <mailto:mdq@example.com>
         /// <mdq@example.com>
         /// ```
-        Explicit,
+        Bracketed,
 
         /// An autolink without the surrounding `<` and `>`:
         ///
@@ -1266,7 +1266,7 @@ pub mod elem {
         /// This variant only applies with [gfm parsing]. See <https://github.github.com/gfm/#autolinks-extension->.
         ///
         /// [gfm parsing]: ParseOptions::gfm
-        Implicit,
+        Bare,
     }
 
     /// Supporting struct representing the metadata on a fenced code block.
@@ -1763,9 +1763,9 @@ impl MdElem {
         // actual underlying Markdown source, so we can use that to get at the angle brackets.
         let source_md = &source_md[position.start.offset..position.end.offset];
         let (trimmed_source_md, autolink_style) = if source_md.starts_with('<') && source_md.ends_with('>') {
-            (&source_md[1..source_md.len() - 1], AutolinkStyle::Explicit)
+            (&source_md[1..source_md.len() - 1], AutolinkStyle::Bracketed)
         } else {
-            (source_md, AutolinkStyle::Implicit)
+            (source_md, AutolinkStyle::Bare)
         };
         if display_text != trimmed_source_md {
             // This shouldn't ever happen if I understand markdown parsing correctly, but let's check anyway.
@@ -2603,7 +2603,7 @@ mod tests {
                 check!(&p.children[0], Node::Link(_), lookups => MdElem::Inline(Inline::Link(Link::Autolink(autolink))) = {
                     assert_eq!(autolink, Autolink{
                         url: "https://example.com".to_string(),
-                        style: AutolinkStyle::Explicit,
+                        style: AutolinkStyle::Bracketed,
                     });
                 });
             }
@@ -2616,7 +2616,7 @@ mod tests {
                 check!(&p.children[0], Node::Link(_), lookups => MdElem::Inline(Inline::Link(Link::Autolink(autolink))) = {
                     assert_eq!(autolink, Autolink{
                         url: "mailto:mdq@example.com".to_string(),
-                        style: AutolinkStyle::Explicit,
+                        style: AutolinkStyle::Bracketed,
                     });
                 });
             }
@@ -2629,7 +2629,7 @@ mod tests {
                 check!(&p.children[0], Node::Link(_), lookups => MdElem::Inline(Inline::Link(Link::Autolink(autolink))) = {
                     assert_eq!(autolink, Autolink{
                         url: "mdq@example.com".to_string(),
-                        style: AutolinkStyle::Explicit,
+                        style: AutolinkStyle::Bracketed,
                     });
                 });
             }
@@ -2653,7 +2653,7 @@ mod tests {
                 assert_eq!(p.children.len(), 1);
                 check!(&p.children[0], Node::Link(_), lookups => MdElem::Inline(Inline::Link(Link::Autolink(autolink))) = {
                     assert_eq!(autolink.url, "https://example.com");
-                    assert_eq!(autolink.style, AutolinkStyle::Implicit);
+                    assert_eq!(autolink.style, AutolinkStyle::Bare);
                 });
             }
 
@@ -2666,7 +2666,7 @@ mod tests {
                 check!(&p.children[0], Node::Link(_), lookups => MdElem::Inline(Inline::Link(Link::Autolink(autolink))) = {
                     assert_eq!(autolink, Autolink{
                         url: "mdq@example.com".to_string(),
-                        style: AutolinkStyle::Implicit,
+                        style: AutolinkStyle::Bare,
                     })
                 });
             }
@@ -2680,7 +2680,7 @@ mod tests {
                 check!(&p.children[0], Node::Link(_), lookups => MdElem::Inline(Inline::Link(Link::Autolink(autolink))) = {
                     assert_eq!(autolink, Autolink{
                         url: "xmpp:mdq@example.com/txt".to_string(),
-                        style: AutolinkStyle::Implicit,
+                        style: AutolinkStyle::Bare,
                     })
                 });
             }
@@ -2697,7 +2697,7 @@ mod tests {
                         // note: the display text, being a bare URL, _is_ an autolink!
                         display: vec![m_node!(autolink: {
                             url: "https://example.com".to_string(),
-                            style: AutolinkStyle::Implicit,
+                            style: AutolinkStyle::Bare,
                         })],
                         link: LinkDefinition {
                             url: "https://example.com".to_string(),

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -699,11 +699,7 @@ pub mod elem {
         /// [display text](https://example.com)
         ///  ^^^^^^^^^^^^
         /// ```
-        ///
-        /// If the link definition's reference type is [`LinkReference::Autolink`], this will be a single-element list
-        /// containing a single [`Inline::Text`] whose value is the same as the [`LinkDefinition::url`] and whose variant
-        /// is [`TextVariant::Plain`]. See [`LinkReference::Autolink`] for more.
-        pub display: Vec<crate::md_elem::tree::elem::Inline>,
+        pub display: Vec<Inline>,
 
         /// The link's destination, including reference style and optional title.
         ///
@@ -714,7 +710,7 @@ pub mod elem {
         ///               ^^^
         /// etc
         /// ```
-        pub link: crate::md_elem::tree::elem::LinkDefinition,
+        pub link: LinkDefinition,
     }
 
     /// An autolink like `<https://example.com>` or `https://example.com`.
@@ -1383,7 +1379,7 @@ macro_rules! m_node {
     };
 
     // Terminal cases for Foo{ bar: bazz } in its various configurations
-    // Also for Foo<Fizz>{bar: bazz
+    // Also for Foo<Fizz>{bar: bazz}
     ($last:ident $( < $last_variant:ident > )? { $($args:tt)* }) => {
         $last $(::$last_variant)? {
             $($args)*

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -2502,6 +2502,11 @@ mod tests {
             use super::*;
 
             #[test]
+            fn todo_fix_me() {
+                panic!("we need to fix the tests in this module to expect autolinks!")
+            }
+
+            #[test]
             fn url_in_angle_brackets() {
                 let (root, lookups) = parse("<https://example.com>");
                 unwrap!(&root.children[0], Node::Paragraph(p));

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -1749,9 +1749,7 @@ impl MdElem {
         if title.is_some() {
             return None;
         }
-        let Some(position) = position else {
-            return None;
-        };
+        let position = position?;
         let [Inline::Text(Text {
             variant: TextVariant::Plain,
             value: display_text,

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -2445,9 +2445,11 @@ mod tests {
             }
         }
 
-        #[test]
-        fn autolinks() {
-            {
+        mod autolinks {
+            use super::*;
+
+            #[test]
+            fn url_in_angle_brackets() {
                 let (root, lookups) = parse("<https://example.com>");
                 unwrap!(&root.children[0], Node::Paragraph(p));
                 assert_eq!(p.children.len(), 1);
@@ -2459,7 +2461,9 @@ mod tests {
                     });
                 });
             }
-            {
+
+            #[test]
+            fn mailto_in_angle_brackets() {
                 let (root, lookups) = parse("<mailto:md@example.com>");
                 unwrap!(&root.children[0], Node::Paragraph(p));
                 assert_eq!(p.children.len(), 1);
@@ -2471,7 +2475,9 @@ mod tests {
                     });
                 });
             }
-            {
+
+            #[test]
+            fn bare_url_with_default_parsing() {
                 // in default parsing, bare URLs aren't autolink
                 let (root, lookups) = parse_with(&ParseOptions::default(), "https://example.com");
                 unwrap!(&root.children[0], Node::Paragraph(p));
@@ -2480,7 +2486,9 @@ mod tests {
                     assert_eq!(value, "https://example.com".to_string());
                 });
             }
-            {
+
+            #[test]
+            fn bare_url_with_gfm_parsing() {
                 // in GFM parsing, bare URLs *are* autolink
                 let (root, lookups) = parse_with(&ParseOptions::gfm(), "https://example.com");
                 unwrap!(&root.children[0], Node::Paragraph(p));

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -553,14 +553,15 @@ pub(crate) mod tests {
         Inline(Inline::Text(Text{variant: TextVariant::Math, ..})),
         Inline(Inline::Text(Text{variant: TextVariant::InlineHtml, ..})),
 
-        Inline(Inline::Link(Link{link: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..})),
-        Inline(Inline::Link(Link{link: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..})),
-        Inline(Inline::Link(Link{link: LinkDefinition{title: None, reference: LinkReference::Collapsed, ..}, ..})),
-        Inline(Inline::Link(Link{link: LinkDefinition{title: None, reference: LinkReference::Shortcut, ..}, ..})),
-        Inline(Inline::Link(Link{link: LinkDefinition{title: Some(_), reference: LinkReference::Inline, ..}, ..})),
-        Inline(Inline::Link(Link{link: LinkDefinition{title: Some(_), reference: LinkReference::Full(_), ..}, ..})),
-        Inline(Inline::Link(Link{link: LinkDefinition{title: Some(_), reference: LinkReference::Collapsed, ..}, ..})),
-        Inline(Inline::Link(Link{link: LinkDefinition{title: Some(_), reference: LinkReference::Shortcut, ..}, ..})),
+        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..})),
+        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..})),
+        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: None, reference: LinkReference::Collapsed, ..}, ..})),
+        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: None, reference: LinkReference::Shortcut, ..}, ..})),
+        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: Some(_), reference: LinkReference::Inline, ..}, ..})),
+        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: Some(_), reference: LinkReference::Full(_), ..}, ..})),
+        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: Some(_), reference: LinkReference::Collapsed, ..}, ..})),
+        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: Some(_), reference: LinkReference::Shortcut, ..}, ..})),
+        Inline(Inline::Link(Link::Autolink{..})),
 
         Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..})),
         Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..})),
@@ -1653,7 +1654,7 @@ pub(crate) mod tests {
 
             fn check_link_and_thematic_break(link: LinkDefinition, expect: &str) {
                 let nodes = vec![
-                    MdElem::Inline(Inline::Link(Link {
+                    MdElem::Inline(Inline::Link(Link::Standard {
                         display: vec![
                             mdq_inline!("hello "),
                             mdq_inline!(span Emphasis [mdq_inline!("world")]),
@@ -1821,7 +1822,7 @@ pub(crate) mod tests {
         #[test]
         fn single_link() {
             check_render_refs(
-                vec![link_elem(Link {
+                vec![link_elem(Link::Standard {
                     display: vec![mdq_inline!("link text")],
                     link: LinkDefinition {
                         url: "https://example.com".to_string(),
@@ -1840,7 +1841,7 @@ pub(crate) mod tests {
         fn two_links() {
             check_render_refs(
                 vec![
-                    link_elem(Link {
+                    link_elem(Link::Standard {
                         display: vec![mdq_inline!("link text one")],
                         link: LinkDefinition {
                             url: "https://example.com/1".to_string(),
@@ -1848,7 +1849,7 @@ pub(crate) mod tests {
                             reference: LinkReference::Full("1".to_string()),
                         },
                     }),
-                    link_elem(Link {
+                    link_elem(Link::Standard {
                         display: vec![mdq_inline!("link text two")],
                         link: LinkDefinition {
                             url: "https://example.com/2".to_string(),
@@ -1874,7 +1875,7 @@ pub(crate) mod tests {
         fn two_links_inline() {
             check_render_refs(
                 vec![
-                    link_elem(Link {
+                    link_elem(Link::Standard {
                         display: vec![mdq_inline!("link text one")],
                         link: LinkDefinition {
                             url: "https://example.com/1".to_string(),
@@ -1882,7 +1883,7 @@ pub(crate) mod tests {
                             reference: LinkReference::Inline,
                         },
                     }),
-                    link_elem(Link {
+                    link_elem(Link::Standard {
                         display: vec![mdq_inline!("link text two")],
                         link: LinkDefinition {
                             url: "https://example.com/2".to_string(),
@@ -1907,7 +1908,7 @@ pub(crate) mod tests {
             check_render_refs_with(
                 options,
                 vec![
-                    link_elem(Link {
+                    link_elem(Link::Standard {
                         display: vec![mdq_inline!("link text one")],
                         link: LinkDefinition {
                             url: "https://example.com/1".to_string(),
@@ -1915,7 +1916,7 @@ pub(crate) mod tests {
                             reference: LinkReference::Inline,
                         },
                     }),
-                    link_elem(Link {
+                    link_elem(Link::Standard {
                         display: vec![mdq_inline!("link text two")],
                         link: LinkDefinition {
                             url: "https://example.com/2".to_string(),
@@ -1939,7 +1940,7 @@ pub(crate) mod tests {
             check_render_refs_with(
                 options,
                 vec![
-                    link_elem(Link {
+                    link_elem(Link::Standard {
                         display: vec![mdq_inline!("link text one")],
                         link: LinkDefinition {
                             url: "https://example.com/1".to_string(),
@@ -1947,7 +1948,7 @@ pub(crate) mod tests {
                             reference: LinkReference::Inline,
                         },
                     }),
-                    link_elem(Link {
+                    link_elem(Link::Standard {
                         display: vec![mdq_inline!("link text two")],
                         link: LinkDefinition {
                             url: "https://example.com/2".to_string(),
@@ -1970,7 +1971,7 @@ pub(crate) mod tests {
         fn reference_transform_smoke_test() {
             check_render_refs_with(
                 MdWriterOptions::new_with(|mdo| mdo.inline_options.link_format = LinkTransform::Reference),
-                vec![link_elem(Link {
+                vec![link_elem(Link::Standard {
                     display: vec![mdq_inline!("link text")],
                     link: LinkDefinition {
                         url: "https://example.com".to_string(),
@@ -2164,7 +2165,7 @@ pub(crate) mod tests {
                     md_elems![Paragraph {
                         body: vec![
                             mdq_inline!("Hello, "),
-                            m_node!(Inline::Link {
+                            m_node!(Inline::Link<Standard> {
                                 display: vec![mdq_inline!("world"),],
                                 link: LinkDefinition {
                                     url: "https://example.com".to_string(),
@@ -2245,7 +2246,7 @@ pub(crate) mod tests {
                     mdo.footnote_reference_placement = ReferencePlacement::Section;
                 }),
                 md_elems![Paragraph {
-                    body: vec![m_node!(Inline::Link {
+                    body: vec![m_node!(Inline::Link<Standard> {
                         display: vec![mdq_inline!("link description")],
                         link: LinkDefinition {
                             url: "https://example.com".to_string(),
@@ -2330,7 +2331,7 @@ pub(crate) mod tests {
                         body: vec![
                             Inline::Footnote("d".into()),
                             Inline::Footnote("c".into()),
-                            m_node!(Inline::Link {
+                            m_node!(Inline::Link<Standard> {
                                 display: vec![mdq_inline!("b-text")],
                                 link: LinkDefinition {
                                     url: "https://example.com/b".to_string(),
@@ -2338,7 +2339,7 @@ pub(crate) mod tests {
                                     reference: LinkReference::Full("b".to_string()),
                                 },
                             }),
-                            m_node!(Inline::Link {
+                            m_node!(Inline::Link<Standard> {
                                 display: vec![mdq_inline!("a-text")],
                                 link: LinkDefinition {
                                     url: "https://example.com/a".to_string(),
@@ -2366,7 +2367,7 @@ pub(crate) mod tests {
                     title: vec![mdq_inline!("First section")],
                     body: md_elems![Paragraph {
                         body: vec![
-                            m_node!(Inline::Link {
+                            m_node!(Inline::Link<Standard> {
                                 display: vec![mdq_inline!("link description")],
                                 link: LinkDefinition {
                                     url: "https://example.com".to_string(),

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -553,15 +553,15 @@ pub(crate) mod tests {
         Inline(Inline::Text(Text{variant: TextVariant::Math, ..})),
         Inline(Inline::Text(Text{variant: TextVariant::InlineHtml, ..})),
 
-        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..})),
-        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..})),
-        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: None, reference: LinkReference::Collapsed, ..}, ..})),
-        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: None, reference: LinkReference::Shortcut, ..}, ..})),
-        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: Some(_), reference: LinkReference::Inline, ..}, ..})),
-        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: Some(_), reference: LinkReference::Full(_), ..}, ..})),
-        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: Some(_), reference: LinkReference::Collapsed, ..}, ..})),
-        Inline(Inline::Link(Link::Standard{link: LinkDefinition{title: Some(_), reference: LinkReference::Shortcut, ..}, ..})),
-        Inline(Inline::Link(Link::Autolink{..})),
+        Inline(Inline::Link(Link::Standard(StandardLink{link: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..}))),
+        Inline(Inline::Link(Link::Standard(StandardLink{link: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..}))),
+        Inline(Inline::Link(Link::Standard(StandardLink{link: LinkDefinition{title: None, reference: LinkReference::Collapsed, ..}, ..}))),
+        Inline(Inline::Link(Link::Standard(StandardLink{link: LinkDefinition{title: None, reference: LinkReference::Shortcut, ..}, ..}))),
+        Inline(Inline::Link(Link::Standard(StandardLink{link: LinkDefinition{title: Some(_), reference: LinkReference::Inline, ..}, ..}))),
+        Inline(Inline::Link(Link::Standard(StandardLink{link: LinkDefinition{title: Some(_), reference: LinkReference::Full(_), ..}, ..}))),
+        Inline(Inline::Link(Link::Standard(StandardLink{link: LinkDefinition{title: Some(_), reference: LinkReference::Collapsed, ..}, ..}))),
+        Inline(Inline::Link(Link::Standard(StandardLink{link: LinkDefinition{title: Some(_), reference: LinkReference::Shortcut, ..}, ..}))),
+        Inline(Inline::Link(Link::Autolink(..))),
 
         Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Inline, ..}, ..})),
         Inline(Inline::Image(Image{link: LinkDefinition{title: None, reference: LinkReference::Full(_), ..}, ..})),
@@ -1654,14 +1654,14 @@ pub(crate) mod tests {
 
             fn check_link_and_thematic_break(link: LinkDefinition, expect: &str) {
                 let nodes = vec![
-                    MdElem::Inline(Inline::Link(Link::Standard {
+                    MdElem::Inline(Inline::Link(Link::Standard(StandardLink {
                         display: vec![
                             mdq_inline!("hello "),
                             mdq_inline!(span Emphasis [mdq_inline!("world")]),
                             mdq_inline!("!"),
                         ],
                         link,
-                    })),
+                    }))),
                     m_node!(MdElem::ThematicBreak),
                 ];
                 check_render(nodes, expect);
@@ -1822,10 +1822,10 @@ pub(crate) mod tests {
         #[test]
         fn normal_autolink() {
             check_render_refs(
-                vec![link_elem(Link::Autolink {
+                vec![link_elem(Link::Autolink(Autolink {
                     url: "https://example.com".to_string(),
                     style: AutolinkStyle::Explicit,
-                })],
+                }))],
                 r#"<https://example.com>"#,
             );
         }
@@ -1833,10 +1833,10 @@ pub(crate) mod tests {
         #[test]
         fn gfm_plain_autolink() {
             check_render_refs(
-                vec![link_elem(Link::Autolink {
+                vec![link_elem(Link::Autolink(Autolink {
                     url: "https://example.com".to_string(),
                     style: AutolinkStyle::Implicit,
-                })],
+                }))],
                 r#"https://example.com"#,
             );
         }
@@ -1844,14 +1844,14 @@ pub(crate) mod tests {
         #[test]
         fn single_link() {
             check_render_refs(
-                vec![link_elem(Link::Standard {
+                vec![link_elem(Link::Standard(StandardLink {
                     display: vec![mdq_inline!("link text")],
                     link: LinkDefinition {
                         url: "https://example.com".to_string(),
                         title: None,
                         reference: LinkReference::Full("1".to_string()),
                     },
-                })],
+                }))],
                 indoc! {r#"
                     [link text][1]
 
@@ -1863,22 +1863,22 @@ pub(crate) mod tests {
         fn two_links() {
             check_render_refs(
                 vec![
-                    link_elem(Link::Standard {
+                    link_elem(Link::Standard(StandardLink {
                         display: vec![mdq_inline!("link text one")],
                         link: LinkDefinition {
                             url: "https://example.com/1".to_string(),
                             title: None,
                             reference: LinkReference::Full("1".to_string()),
                         },
-                    }),
-                    link_elem(Link::Standard {
+                    })),
+                    link_elem(Link::Standard(StandardLink {
                         display: vec![mdq_inline!("link text two")],
                         link: LinkDefinition {
                             url: "https://example.com/2".to_string(),
                             title: None,
                             reference: LinkReference::Full("2".to_string()),
                         },
-                    }),
+                    })),
                 ],
                 indoc! {r#"
                     [link text one][1]
@@ -1897,22 +1897,22 @@ pub(crate) mod tests {
         fn two_links_inline() {
             check_render_refs(
                 vec![
-                    link_elem(Link::Standard {
+                    link_elem(Link::Standard(StandardLink {
                         display: vec![mdq_inline!("link text one")],
                         link: LinkDefinition {
                             url: "https://example.com/1".to_string(),
                             title: None,
                             reference: LinkReference::Inline,
                         },
-                    }),
-                    link_elem(Link::Standard {
+                    })),
+                    link_elem(Link::Standard(StandardLink {
                         display: vec![mdq_inline!("link text two")],
                         link: LinkDefinition {
                             url: "https://example.com/2".to_string(),
                             title: None,
                             reference: LinkReference::Inline,
                         },
-                    }),
+                    })),
                 ],
                 indoc! {r#"
                 [link text one](https://example.com/1)
@@ -1930,22 +1930,22 @@ pub(crate) mod tests {
             check_render_refs_with(
                 options,
                 vec![
-                    link_elem(Link::Standard {
+                    link_elem(Link::Standard(StandardLink {
                         display: vec![mdq_inline!("link text one")],
                         link: LinkDefinition {
                             url: "https://example.com/1".to_string(),
                             title: None,
                             reference: LinkReference::Inline,
                         },
-                    }),
-                    link_elem(Link::Standard {
+                    })),
+                    link_elem(Link::Standard(StandardLink {
                         display: vec![mdq_inline!("link text two")],
                         link: LinkDefinition {
                             url: "https://example.com/2".to_string(),
                             title: None,
                             reference: LinkReference::Inline,
                         },
-                    }),
+                    })),
                 ],
                 indoc! {r#"
                 [link text one](https://example.com/1)
@@ -1962,22 +1962,22 @@ pub(crate) mod tests {
             check_render_refs_with(
                 options,
                 vec![
-                    link_elem(Link::Standard {
+                    link_elem(Link::Standard(StandardLink {
                         display: vec![mdq_inline!("link text one")],
                         link: LinkDefinition {
                             url: "https://example.com/1".to_string(),
                             title: None,
                             reference: LinkReference::Inline,
                         },
-                    }),
-                    link_elem(Link::Standard {
+                    })),
+                    link_elem(Link::Standard(StandardLink {
                         display: vec![mdq_inline!("link text two")],
                         link: LinkDefinition {
                             url: "https://example.com/2".to_string(),
                             title: None,
                             reference: LinkReference::Inline,
                         },
-                    }),
+                    })),
                 ],
                 indoc! {r#"
                 [link text one][1]
@@ -1993,14 +1993,14 @@ pub(crate) mod tests {
         fn reference_transform_smoke_test() {
             check_render_refs_with(
                 MdWriterOptions::new_with(|mdo| mdo.inline_options.link_format = LinkTransform::Reference),
-                vec![link_elem(Link::Standard {
+                vec![link_elem(Link::Standard(StandardLink {
                     display: vec![mdq_inline!("link text")],
                     link: LinkDefinition {
                         url: "https://example.com".to_string(),
                         title: None,
                         reference: LinkReference::Inline, // note! inline, but will be transformed to full
                     },
-                })],
+                }))],
                 indoc! {r#"
                     [link text][1]
 
@@ -2187,7 +2187,7 @@ pub(crate) mod tests {
                     md_elems![Paragraph {
                         body: vec![
                             mdq_inline!("Hello, "),
-                            m_node!(Inline::Link<Standard> {
+                            m_node!(link: {
                                 display: vec![mdq_inline!("world"),],
                                 link: LinkDefinition {
                                     url: "https://example.com".to_string(),
@@ -2268,7 +2268,7 @@ pub(crate) mod tests {
                     mdo.footnote_reference_placement = ReferencePlacement::Section;
                 }),
                 md_elems![Paragraph {
-                    body: vec![m_node!(Inline::Link<Standard> {
+                    body: vec![m_node!(link: {
                         display: vec![mdq_inline!("link description")],
                         link: LinkDefinition {
                             url: "https://example.com".to_string(),
@@ -2353,7 +2353,7 @@ pub(crate) mod tests {
                         body: vec![
                             Inline::Footnote("d".into()),
                             Inline::Footnote("c".into()),
-                            m_node!(Inline::Link<Standard> {
+                            m_node!(link: {
                                 display: vec![mdq_inline!("b-text")],
                                 link: LinkDefinition {
                                     url: "https://example.com/b".to_string(),
@@ -2361,7 +2361,7 @@ pub(crate) mod tests {
                                     reference: LinkReference::Full("b".to_string()),
                                 },
                             }),
-                            m_node!(Inline::Link<Standard> {
+                            m_node!(link: {
                                 display: vec![mdq_inline!("a-text")],
                                 link: LinkDefinition {
                                     url: "https://example.com/a".to_string(),
@@ -2389,7 +2389,7 @@ pub(crate) mod tests {
                     title: vec![mdq_inline!("First section")],
                     body: md_elems![Paragraph {
                         body: vec![
-                            m_node!(Inline::Link<Standard> {
+                            m_node!(link: {
                                 display: vec![mdq_inline!("link description")],
                                 link: LinkDefinition {
                                     url: "https://example.com".to_string(),

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -1820,6 +1820,28 @@ pub(crate) mod tests {
         use super::*;
 
         #[test]
+        fn normal_autolink() {
+            check_render_refs(
+                vec![link_elem(Link::Autolink {
+                    url: "https://example.com".to_string(),
+                    style: AutolinkStyle::Explicit,
+                })],
+                r#"<https://example.com>"#,
+            );
+        }
+
+        #[test]
+        fn gfm_plain_autolink() {
+            check_render_refs(
+                vec![link_elem(Link::Autolink {
+                    url: "https://example.com".to_string(),
+                    style: AutolinkStyle::Implicit,
+                })],
+                r#"https://example.com"#,
+            );
+        }
+
+        #[test]
         fn single_link() {
             check_render_refs(
                 vec![link_elem(Link::Standard {

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -1824,7 +1824,7 @@ pub(crate) mod tests {
             check_render_refs(
                 vec![link_elem(Link::Autolink(Autolink {
                     url: "https://example.com".to_string(),
-                    style: AutolinkStyle::Explicit,
+                    style: AutolinkStyle::Bracketed,
                 }))],
                 r#"<https://example.com>"#,
             );
@@ -1835,7 +1835,7 @@ pub(crate) mod tests {
             check_render_refs(
                 vec![link_elem(Link::Autolink(Autolink {
                     url: "https://example.com".to_string(),
-                    style: AutolinkStyle::Implicit,
+                    style: AutolinkStyle::Bare,
                 }))],
                 r#"https://example.com"#,
             );

--- a/src/output/fmt_md_inlines.rs
+++ b/src/output/fmt_md_inlines.rs
@@ -253,22 +253,17 @@ impl<'md> MdInlinesWriter<'md> {
                 Inline::Span(item) => {
                     self.find_references_in_footnote_inlines(&item.children);
                 }
-                Inline::Link(link) => match link {
-                    Link::Standard(standard_link) => {
-                        let link_label = match &standard_link.link.reference {
-                            LinkReference::Inline => None,
-                            LinkReference::Full(reference) => Some(LinkLabel::Text(Cow::Borrowed(reference))),
-                            LinkReference::Collapsed | LinkReference::Shortcut => Some(LinkLabel::Inline(&standard_link.display)),
-                        };
-                        if let Some(label) = link_label {
-                            self.add_link_reference(label, &standard_link.link);
-                        }
+                Inline::Link(Link::Standard(link)) => {
+                    let link_label = match &link.link.reference {
+                        LinkReference::Inline => None,
+                        LinkReference::Full(reference) => Some(LinkLabel::Text(Cow::Borrowed(reference))),
+                        LinkReference::Collapsed | LinkReference::Shortcut => Some(LinkLabel::Inline(&link.display)),
+                    };
+                    if let Some(label) = link_label {
+                        self.add_link_reference(label, &link.link);
                     }
-                    Link::Autolink(_) => {
-                        // Autolinks don't have references to track
-                    }
-                },
-                Inline::Image(_) | Inline::Text(_) => {
+                }
+                Inline::Image(_) | Inline::Text(_) | Inline::Link(Link::Autolink(_)) => {
                     // nothing
                 }
             }

--- a/src/output/fmt_md_inlines.rs
+++ b/src/output/fmt_md_inlines.rs
@@ -171,12 +171,12 @@ impl<'md> MdInlinesWriter<'md> {
             Inline::Link(link) => match link {
                 Link::Standard(standard_link) => self.write_linklike(out, standard_link),
                 Link::Autolink(autolink) => match autolink.style {
-                    AutolinkStyle::Explicit => {
+                    AutolinkStyle::Bracketed => {
                         out.write_char('<');
                         out.write_str(&autolink.url);
                         out.write_char('>');
                     }
-                    AutolinkStyle::Implicit => {
+                    AutolinkStyle::Bare => {
                         out.write_str(&autolink.url);
                     }
                 },

--- a/src/output/fmt_md_inlines.rs
+++ b/src/output/fmt_md_inlines.rs
@@ -177,12 +177,12 @@ impl<'md> MdInlinesWriter<'md> {
             Inline::Link(link) => match link {
                 Link::Standard { .. } => self.write_linklike(out, link),
                 Link::Autolink { url, style } => match style {
-                    crate::md_elem::elem::AutolinkStyle::Explicit => {
+                    AutolinkStyle::Explicit => {
                         out.write_char('<');
                         out.write_str(url);
                         out.write_char('>');
                     }
-                    crate::md_elem::elem::AutolinkStyle::Implicit => {
+                    AutolinkStyle::Implicit => {
                         out.write_str(url);
                     }
                 },

--- a/src/output/fmt_plain_inline.rs
+++ b/src/output/fmt_plain_inline.rs
@@ -166,8 +166,8 @@ where
         Inline::Footnote(_) => Ok(()),
         Inline::Span(Span { children, .. }) => write_inlines(out, children),
         Inline::Image(Image { alt, .. }) => write!(out, "{alt}"),
-        Inline::Link(Link::Standard { display: text, .. }) => write_inlines(out, text),
-        Inline::Link(Link::Autolink { url, .. }) => write!(out, "{url}"),
+        Inline::Link(Link::Standard(standard_link)) => write_inlines(out, &standard_link.display),
+        Inline::Link(Link::Autolink(autolink)) => write!(out, "{}", autolink.url),
         Inline::Text(Text { value, .. }) => write!(out, "{value}"),
     }
 }
@@ -502,14 +502,14 @@ mod test {
 
     #[test]
     fn link() {
-        let link = Link::Standard {
+        let link = Link::Standard(StandardLink {
             display: vec![mdq_inline!("display text")],
             link: LinkDefinition {
                 url: "https://example.com".to_string(),
                 title: Some("the title".to_string()),
                 reference: LinkReference::Inline,
             },
-        };
+        });
         check_plain(
             MdElem::Inline(Inline::Link(link)),
             Expect {
@@ -563,14 +563,14 @@ mod test {
                 mdq_inline!("hello "),
                 mdq_inline!(span Emphasis [mdq_inline!("world")]),
                 mdq_inline!("! sponsored by "),
-                Inline::Link(Link::Standard {
+                Inline::Link(Link::Standard(StandardLink {
                     display: vec![mdq_inline!("Example Corp")],
                     link: LinkDefinition {
                         url: "https://example.com".to_string(),
                         title: None,
                         reference: LinkReference::Inline
                     }
-                }),
+                })),
                 mdq_inline!("."),
             ]
         });

--- a/src/output/fmt_plain_inline.rs
+++ b/src/output/fmt_plain_inline.rs
@@ -166,7 +166,8 @@ where
         Inline::Footnote(_) => Ok(()),
         Inline::Span(Span { children, .. }) => write_inlines(out, children),
         Inline::Image(Image { alt, .. }) => write!(out, "{alt}"),
-        Inline::Link(Link { display: text, .. }) => write_inlines(out, text),
+        Inline::Link(Link::Standard { display: text, .. }) => write_inlines(out, text),
+        Inline::Link(Link::Autolink { url, .. }) => write!(out, "{url}"),
         Inline::Text(Text { value, .. }) => write!(out, "{value}"),
     }
 }
@@ -501,7 +502,7 @@ mod test {
 
     #[test]
     fn link() {
-        let link = Link {
+        let link = Link::Standard {
             display: vec![mdq_inline!("display text")],
             link: LinkDefinition {
                 url: "https://example.com".to_string(),
@@ -562,7 +563,7 @@ mod test {
                 mdq_inline!("hello "),
                 mdq_inline!(span Emphasis [mdq_inline!("world")]),
                 mdq_inline!("! sponsored by "),
-                Inline::Link(Link {
+                Inline::Link(Link::Standard {
                     display: vec![mdq_inline!("Example Corp")],
                     link: LinkDefinition {
                         url: "https://example.com".to_string(),

--- a/src/output/fmt_plain_str.rs
+++ b/src/output/fmt_plain_str.rs
@@ -17,7 +17,8 @@ fn build_inline(out: &mut String, elem: &Inline) {
     match elem {
         Inline::Span(Span { children, .. }) => build_inlines(out, children),
         Inline::Text(Text { value, .. }) => out.push_str(value),
-        Inline::Link(Link { display: text, .. }) => build_inlines(out, text),
+        Inline::Link(Link::Standard { display: text, .. }) => build_inlines(out, text),
+        Inline::Link(Link::Autolink { url, .. }) => out.push_str(url),
         Inline::Image(Image { alt, .. }) => out.push_str(alt),
         Inline::Footnote(footnote) => {
             out.push_str("[^");

--- a/src/output/fmt_plain_str.rs
+++ b/src/output/fmt_plain_str.rs
@@ -17,8 +17,8 @@ fn build_inline(out: &mut String, elem: &Inline) {
     match elem {
         Inline::Span(Span { children, .. }) => build_inlines(out, children),
         Inline::Text(Text { value, .. }) => out.push_str(value),
-        Inline::Link(Link::Standard { display: text, .. }) => build_inlines(out, text),
-        Inline::Link(Link::Autolink { url, .. }) => out.push_str(url),
+        Inline::Link(Link::Standard(standard_link)) => build_inlines(out, &standard_link.display),
+        Inline::Link(Link::Autolink(autolink)) => out.push_str(&autolink.url),
         Inline::Image(Image { alt, .. }) => out.push_str(alt),
         Inline::Footnote(footnote) => {
             out.push_str("[^");

--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -471,10 +471,12 @@ mod tests {
         link: &'md Link,
     ) -> LinkReference {
         let actual = match link {
-            Link::Standard(standard_link) => LinkTransformation::new(transformer.transform_variant(), iw, standard_link)
-                .apply(transformer, &standard_link.link.reference),
-            Link::Autolink(_) => {
-                todo!()
+            Link::Standard(standard_link) => {
+                LinkTransformation::new(transformer.transform_variant(), iw, standard_link)
+                    .apply(transformer, &standard_link.link.reference)
+            }
+            Link::Autolink(autolink) => {
+                panic!("unexpected autolink: {autolink:?}")
             }
         };
         actual

--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -471,9 +471,9 @@ mod tests {
         link: &'md Link,
     ) -> LinkReference {
         let actual = match link {
-            Link::Standard { link: link_def, .. } => LinkTransformation::new(transformer.transform_variant(), iw, link)
-                .apply(transformer, &link_def.reference),
-            Link::Autolink { .. } => {
+            Link::Standard(standard_link) => LinkTransformation::new(transformer.transform_variant(), iw, standard_link)
+                .apply(transformer, &standard_link.link.reference),
+            Link::Autolink(_) => {
                 todo!()
             }
         };
@@ -481,7 +481,7 @@ mod tests {
     }
 
     fn make_link(label: &str, link_ref: LinkReference) -> Link {
-        Link::Standard {
+        Link::Standard(StandardLink {
             display: vec![Inline::Text(Text {
                 variant: TextVariant::Plain,
                 value: label.to_string(),
@@ -491,7 +491,7 @@ mod tests {
                 title: None,
                 reference: link_ref,
             },
-        }
+        })
     }
 
     struct Given {
@@ -516,14 +516,14 @@ mod tests {
                     renumber_footnotes: false,
                 },
             );
-            let link = Link::Standard {
+            let link = Link::Standard(StandardLink {
                 display: vec![label],
                 link: LinkDefinition {
                     url: "https://example.com".to_string(),
                     title: None,
                     reference: reference.clone(),
                 },
-            };
+            });
 
             let actual = self::transform(&mut transformer, &mut iw, &link);
 

--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -470,13 +470,18 @@ mod tests {
         iw: &mut MdInlinesWriter<'md>,
         link: &'md Link,
     ) -> LinkReference {
-        let actual =
-            LinkTransformation::new(transformer.transform_variant(), iw, link).apply(transformer, &link.link.reference);
+        let actual = match link {
+            Link::Standard { link: link_def, .. } => LinkTransformation::new(transformer.transform_variant(), iw, link)
+                .apply(transformer, &link_def.reference),
+            Link::Autolink { .. } => {
+                todo!()
+            }
+        };
         actual
     }
 
     fn make_link(label: &str, link_ref: LinkReference) -> Link {
-        Link {
+        Link::Standard {
             display: vec![Inline::Text(Text {
                 variant: TextVariant::Plain,
                 value: label.to_string(),
@@ -511,7 +516,7 @@ mod tests {
                     renumber_footnotes: false,
                 },
             );
-            let link = Link {
+            let link = Link::Standard {
                 display: vec![label],
                 link: LinkDefinition {
                     url: "https://example.com".to_string(),

--- a/src/output/tree_ref_serde.rs
+++ b/src/output/tree_ref_serde.rs
@@ -222,9 +222,20 @@ impl<'md> SerdeElem<'md> {
                     body: &fm.body,
                 }
             }
-            MdElem::Inline(Inline::Link(link)) => Self::Link {
-                display: inlines_to_string(&link.display, inlines_writer),
-                link: (&link.link).into(),
+            MdElem::Inline(Inline::Link(link)) => match link {
+                crate::md_elem::elem::Link::Standard { display, link } => Self::Link {
+                    display: inlines_to_string(display, inlines_writer),
+                    link: link.into(),
+                },
+                crate::md_elem::elem::Link::Autolink { url, .. } => Self::Link {
+                    display: url.clone(),
+                    link: LinkSerde {
+                        url,
+                        title: &None,
+                        reference: None,
+                        reference_style: None,
+                    },
+                },
             },
             MdElem::Inline(Inline::Image(img)) => Self::Image {
                 alt: &img.alt,
@@ -480,7 +491,7 @@ mod tests {
     #[test]
     fn link_with_reference() {
         check_md_ref(
-            MdElem::Inline(Inline::Link(Link {
+            MdElem::Inline(Inline::Link(Link::Standard {
                 display: vec![mdq_inline!("hello")],
                 link: LinkDefinition {
                     url: "https://example.com/hi.html".to_string(),

--- a/src/output/tree_ref_serde.rs
+++ b/src/output/tree_ref_serde.rs
@@ -223,14 +223,14 @@ impl<'md> SerdeElem<'md> {
                 }
             }
             MdElem::Inline(Inline::Link(link)) => match link {
-                crate::md_elem::elem::Link::Standard { display, link } => Self::Link {
-                    display: inlines_to_string(display, inlines_writer),
-                    link: link.into(),
+                crate::md_elem::elem::Link::Standard(standard_link) => Self::Link {
+                    display: inlines_to_string(&standard_link.display, inlines_writer),
+                    link: (&standard_link.link).into(),
                 },
-                crate::md_elem::elem::Link::Autolink { url, .. } => Self::Link {
-                    display: url.clone(),
+                crate::md_elem::elem::Link::Autolink(autolink) => Self::Link {
+                    display: autolink.url.clone(),
                     link: LinkSerde {
-                        url,
+                        url: &autolink.url,
                         title: &None,
                         reference: None,
                         reference_style: None,
@@ -491,14 +491,14 @@ mod tests {
     #[test]
     fn link_with_reference() {
         check_md_ref(
-            MdElem::Inline(Inline::Link(Link::Standard {
+            MdElem::Inline(Inline::Link(Link::Standard(StandardLink {
                 display: vec![mdq_inline!("hello")],
                 link: LinkDefinition {
                     url: "https://example.com/hi.html".to_string(),
                     title: None,
                     reference: LinkReference::Collapsed,
                 },
-            })),
+            }))),
             json_str!(
                 {"items": [
                     {"link": {

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -193,7 +193,7 @@ impl SelectorAdapter {
                     vec![MdElem::BlockHtml(value.into())]
                 }
                 Inline::Link(Link::Standard { display: text, .. }) => text.into_iter().map(MdElem::Inline).collect(),
-                Inline::Text(_) | Inline::Image(_) | Inline::Link(Link::Autolink { url, .. }) => Vec::new(),
+                Inline::Text(_) | Inline::Image(_) | Inline::Link(Link::Autolink { .. }) => Vec::new(),
             },
             MdElem::ThematicBreak | MdElem::CodeBlock(_) | MdElem::FrontMatter(_) | MdElem::BlockHtml(_) => Vec::new(),
         }

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -192,8 +192,8 @@ impl SelectorAdapter {
                 }) => {
                     vec![MdElem::BlockHtml(value.into())]
                 }
-                Inline::Link(Link { display: text, .. }) => text.into_iter().map(MdElem::Inline).collect(),
-                Inline::Text(_) | Inline::Image(_) => Vec::new(),
+                Inline::Link(Link::Standard { display: text, .. }) => text.into_iter().map(MdElem::Inline).collect(),
+                Inline::Text(_) | Inline::Image(_) | Inline::Link(Link::Autolink { url, .. }) => Vec::new(),
             },
             MdElem::ThematicBreak | MdElem::CodeBlock(_) | MdElem::FrontMatter(_) | MdElem::BlockHtml(_) => Vec::new(),
         }
@@ -225,7 +225,7 @@ mod test {
 
         #[test]
         fn link_direct() {
-            let link = Link {
+            let link = Link::Standard {
                 display: vec![mdq_inline!("link text")],
                 link: LinkDefinition {
                     url: "https://example.com".to_string(),

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -192,8 +192,8 @@ impl SelectorAdapter {
                 }) => {
                     vec![MdElem::BlockHtml(value.into())]
                 }
-                Inline::Link(Link::Standard { display: text, .. }) => text.into_iter().map(MdElem::Inline).collect(),
-                Inline::Text(_) | Inline::Image(_) | Inline::Link(Link::Autolink { .. }) => Vec::new(),
+                Inline::Link(Link::Standard(standard_link)) => standard_link.display.into_iter().map(MdElem::Inline).collect(),
+                Inline::Text(_) | Inline::Image(_) | Inline::Link(Link::Autolink(_)) => Vec::new(),
             },
             MdElem::ThematicBreak | MdElem::CodeBlock(_) | MdElem::FrontMatter(_) | MdElem::BlockHtml(_) => Vec::new(),
         }
@@ -225,14 +225,14 @@ mod test {
 
         #[test]
         fn link_direct() {
-            let link = Link::Standard {
+            let link = Link::Standard(StandardLink {
                 display: vec![mdq_inline!("link text")],
                 link: LinkDefinition {
                     url: "https://example.com".to_string(),
                     title: None,
                     reference: LinkReference::Inline,
                 },
-            };
+            });
             let node_ref = MdElem::Inline(Inline::Link(link));
             let md_context = MdContext::empty();
             let mut ctx = SearchContext {

--- a/src/select/api.rs
+++ b/src/select/api.rs
@@ -192,7 +192,9 @@ impl SelectorAdapter {
                 }) => {
                     vec![MdElem::BlockHtml(value.into())]
                 }
-                Inline::Link(Link::Standard(standard_link)) => standard_link.display.into_iter().map(MdElem::Inline).collect(),
+                Inline::Link(Link::Standard(standard_link)) => {
+                    standard_link.display.into_iter().map(MdElem::Inline).collect()
+                }
                 Inline::Text(_) | Inline::Image(_) | Inline::Link(Link::Autolink(_)) => Vec::new(),
             },
             MdElem::ThematicBreak | MdElem::CodeBlock(_) | MdElem::FrontMatter(_) | MdElem::BlockHtml(_) => Vec::new(),


### PR DESCRIPTION
The `mdq::md_elem::elem::Link` type has changed from a struct to an enum, with variants for normal links (containing the struct's previous information) and autolinks.

This feels a bit cumbersome, but I think it correctly models the difference between normal links and autolinks. The alternatives I considered were:

- Not encoding autolink-ness at all, and instead just inferring it from the link's display text, title, and URL. This works in many cases, but would also convert intentionally-not-autolinks into autolinks. It also feels like autolinks shouldn't participate in link transformation.
- Adding a variant to the `LinkReference` enum for `Autolink` (or alternatively, adding an is-autolink flag to `LinkReference::Inline`). This would be a smaller change, but still an API-breaking one. Worse, the autolink implies certain invariants (that the title is `None`, and that the display text is just the plaintext of the URL) that would be impossible to enforce without making the types' fields non-public, in contrast to the other types in the module which are all PODs. I would therefore have to define what happens if an autolink has a title or incorrect display text, and that would inevitably lead towards "autolink is just a suggestion", which feels like a bug waiting to happen.

All in all, it felt like it was better to just be explicit about autolinks, and how they're different from normal links.

This change resolves #297.

## Breaking change

The `mdq::md_elem::elem::Link` type has changed from a struct to an enum, with variants for normal links (containing the struct's previous information) and autolinks.