### PR TITLE
future-proof enums

### DIFF
--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -10,6 +10,7 @@ use std::ops::Deref;
 
 /// Whether to render links as inline, reference form, or keep them as they were.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Default, ValueEnum)]
+#[non_exhaustive]
 pub enum LinkTransform {
     /// Keep links as they were in the original
     Keep,

--- a/src/output/tree_ref_serde.rs
+++ b/src/output/tree_ref_serde.rs
@@ -212,16 +212,10 @@ impl<'md> SerdeElem<'md> {
                     language,
                 }
             }
-            MdElem::FrontMatter(fm) => {
-                let variant = match fm.variant {
-                    FrontMatterVariant::Yaml => "yaml",
-                    FrontMatterVariant::Toml => "toml",
-                };
-                Self::FrontMatter {
-                    variant,
-                    body: &fm.body,
-                }
-            }
+            MdElem::FrontMatter(fm) => Self::FrontMatter {
+                variant: fm.variant.name(),
+                body: &fm.body,
+            },
             MdElem::Inline(Inline::Link(link)) => match link {
                 crate::md_elem::elem::Link::Standard(standard_link) => Self::Link {
                     display: inlines_to_string(&standard_link.display, inlines_writer),

--- a/src/run/cli.rs
+++ b/src/run/cli.rs
@@ -240,6 +240,7 @@ impl CliOptions {
 
 /// Output formats, analogous to `--output` in the CLI.
 #[derive(Copy, Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, ValueEnum)]
+#[non_exhaustive]
 pub enum OutputFormat {
     /// Output results as Markdown.
     Markdown,

--- a/src/run/run_main.rs
+++ b/src/run/run_main.rs
@@ -12,6 +12,7 @@ use std::io::Write;
 
 /// The run's overall possible error.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum Error {
     /// User provided an invalid selector string.
     ///


### PR DESCRIPTION
Add variants and attributes to future-proof enums. My guiding principles were:

1. enums that reflect markdown should be exhaustive, since we can assume a fairly stable markdown spec
2. enums that reflect mdq-specific inputs or non-markdown outputs (specifically, errors) should be non-exhaustive, so that mdq can add new features without breaking the API

Resolves #377. See that ticket for an analysis of the enums currently in the code base.

## Breaking changes

- add `FrontMatterVariant::Json` variant
- change `FrontMatterVariant::separator()`'s signature to reflect that Json doesn't have a separator line.
- add various `#[non_exhaustive]` attributes