### PR TITLE
add a LinkTransform::NeverInline option

### DIFF
--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -22,8 +22,19 @@ pub enum LinkTransform {
     ///
     /// Links that weren't already in reference form will be auto-assigned a reference id. Links that were in reference
     /// form will have the link number be reordered.
-    #[default]
     Reference,
+
+    #[default]
+    /// Keep [`Full`], [`Collapsed`], and [`Shortcut`] as they are, but replace links.
+    ///
+    /// The current implementation will turn them into full-style links with incrementing numbers, but this may
+    /// change in future versions.
+    ///
+    /// [`Full`]: LinkReference::Full
+    /// [`Collapsed`]: LinkReference::Collapsed
+    /// [`Shortcut`]: LinkReference::Shortcut
+    /// [`Inline`]: LinkReference::Inline
+    NeverInline,
 }
 
 pub(crate) struct LinkTransformer {
@@ -61,6 +72,7 @@ impl From<LinkTransform> for LinkTransformer {
             LinkTransform::Keep => LinkTransformState::Keep,
             LinkTransform::Inline => LinkTransformState::Inline,
             LinkTransform::Reference => LinkTransformState::Reference(ReferenceAssigner::new()),
+            LinkTransform::NeverInline => LinkTransformState::NeverInline(ReferenceAssigner::new()),
         };
         Self { delegate }
     }
@@ -70,6 +82,7 @@ enum LinkTransformState {
     Keep,
     Inline,
     Reference(ReferenceAssigner),
+    NeverInline(ReferenceAssigner),
 }
 
 pub(crate) struct LinkTransformation<'md> {

--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -64,15 +64,11 @@ pub enum LinkTransform {
     Reference,
 
     #[default]
-    /// Keep [`Full`], [`Collapsed`], and [`Shortcut`] as they are, but replace links.
+    /// Keep `[full][123]`, `[collapsed][]`, and `[shortcut]` links unchanged, but replace
+    /// `[inlined](https://example.com)` links.
     ///
     /// The current implementation will turn them into full-style links with incrementing numbers, but this may
     /// change in future versions.
-    ///
-    /// [`Full`]: LinkReference::Full
-    /// [`Collapsed`]: LinkReference::Collapsed
-    /// [`Shortcut`]: LinkReference::Shortcut
-    /// [`Inline`]: LinkReference::Inline
     NeverInline,
 }
 

--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -308,6 +308,9 @@ impl ReferenceAssigner {
 }
 
 /// Converts a vector of inline elements back to markdown string format.
+///
+/// Unlike [crate::output::fmt_plain_str::inlines_to_plain_string], this respects formatting spans
+/// like emphasis, strong, etc.
 fn inlines_to_string<'md>(inline_writer: &mut MdInlinesWriter<'md>, inlines: &'md Vec<Inline>) -> String {
     let mut string_writer = Output::without_text_wrapping(String::with_capacity(32)); // guess at capacity
     inline_writer.write_line(&mut string_writer, inlines);

--- a/src/run/cli.rs
+++ b/src/run/cli.rs
@@ -170,7 +170,7 @@ impl Default for RunOptions {
         Self {
             link_pos: ReferencePlacement::Section,
             footnote_pos: None,
-            link_format: LinkTransform::Reference,
+            link_format: LinkTransform::NeverInline,
             renumber_footnotes: true,
             output: OutputFormat::Markdown,
             add_breaks: None,

--- a/src/run/cli.rs
+++ b/src/run/cli.rs
@@ -137,7 +137,7 @@ create_options_structs! {
     clap(long, value_enum)
     pub footnote_pos: Option<ReferencePlacement>,
 
-    clap(long, short, value_enum, default_value_t=LinkTransform::Reference)
+    clap(long, short, value_enum, default_value_t)
     pub link_format: LinkTransform,
 
     clap(long, default_value_t = true, action = clap::ArgAction::Set)

--- a/tests/md_cases/links_references.toml
+++ b/tests/md_cases/links_references.toml
@@ -20,8 +20,54 @@ md = '''
 needed = false
 
 
-[expect."default"]
+[expect."default (never inline)"]
 cli_args = []
+output = '''
+- an [inline link][1]
+- a [standard reference link][2]
+- a [link with a non-numeric reference id][a]
+- a [link with a non-sequential reference id][3]
+- a [collapsed link][]
+- a [shortcut link]
+- a [link with a title][4]
+- a [link with a title that contains double-quotes][5]
+
+[1]: https://example.com
+[2]: https://example.com/1
+[3]: https://example.com/non-sequential
+[4]: https://example.com "my title"
+[5]: https://example.com 'my "alleged" title'
+[a]: https://example.com/a "with a title"
+[collapsed link]: https://example.com/collapsed
+[shortcut link]: https://example.com/shortcut
+'''
+
+
+[expect."never inline"]
+cli_args = ['--link-format', 'never-inline']
+output = '''
+- an [inline link][1]
+- a [standard reference link][2]
+- a [link with a non-numeric reference id][a]
+- a [link with a non-sequential reference id][3]
+- a [collapsed link][]
+- a [shortcut link]
+- a [link with a title][4]
+- a [link with a title that contains double-quotes][5]
+
+[1]: https://example.com
+[2]: https://example.com/1
+[3]: https://example.com/non-sequential
+[4]: https://example.com "my title"
+[5]: https://example.com 'my "alleged" title'
+[a]: https://example.com/a "with a title"
+[collapsed link]: https://example.com/collapsed
+[shortcut link]: https://example.com/shortcut
+'''
+
+
+[expect."full references"]
+cli_args = ["--link-format", "reference"]
 output = '''
 - an [inline link][1]
 - a [standard reference link][2]


### PR DESCRIPTION
Adds a new option, which will keep references, collapsed, and shortcut links as they were (other than reordering them -- see #390), but turns inlines into numbered full references. This new option is now the default.

Also adds a bunch of comments.

Resolves #176

## Breaking change

- Adds a new enum variant, `LinkTransform::NeverInline`. This variant is now the `LinkTransform::default()`.
- `RunOptions::default()` now uses `LinkTransform::NeverInline` as its default link formatter.