### PR TITLE
pass node slices around, instead of iterators

### DIFF
--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -97,16 +97,15 @@ pub enum ReferencePlacement {
     Doc,
 }
 
-pub(crate) fn write_md<'md, I, W>(options: MdWriterOptions, out: &mut Output<W>, ctx: &'md MdContext, nodes: I)
+pub(crate) fn write_md<'md, W>(options: MdWriterOptions, out: &mut Output<W>, ctx: &'md MdContext, nodes: &'md [MdElem])
 where
-    I: Iterator<Item = &'md MdElem>,
     W: SimpleWrite,
 {
     let mut writer_state = MdWriterState {
         ctx,
         opts: options,
         prev_was_thematic_break: false,
-        inlines_writer: &mut MdInlinesWriter::new(ctx, options.inline_options),
+        inlines_writer: &mut MdInlinesWriter::new(ctx, options.inline_options, nodes),
     };
     let nodes_count = writer_state.write_md(out, nodes.into_iter(), true);
 
@@ -2511,7 +2510,7 @@ pub(crate) mod tests {
         nodes.iter().for_each(|n| VARIANTS_CHECKER.see(n));
 
         let mut out = Output::without_text_wrapping(String::default());
-        write_md(options, &mut out, &ctx, nodes.iter());
+        write_md(options, &mut out, &ctx, &nodes);
         let actual = out.take_underlying().unwrap();
         assert_eq!(&actual, expect);
     }

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -107,7 +107,7 @@ where
         prev_was_thematic_break: false,
         inlines_writer: &mut MdInlinesWriter::new(ctx, options.inline_options, nodes),
     };
-    let nodes_count = writer_state.write_md(out, nodes.into_iter(), true);
+    let nodes_count = writer_state.write_md(out, nodes.iter(), true);
 
     // Always write the pending definitions at the end of the doc. If there were no sections, then BottomOfSection
     // won't have been triggered, but we still want to write them. We'll add a thematic break before the links if there

--- a/src/output/fmt_md_inlines.rs
+++ b/src/output/fmt_md_inlines.rs
@@ -73,14 +73,14 @@ impl<'md> LinkLike<'md> for &'md Image {
 }
 
 impl<'md> MdInlinesWriter<'md> {
-    pub(crate) fn new(ctx: &'md MdContext, options: InlineElemOptions) -> Self {
+    pub(crate) fn new(ctx: &'md MdContext, options: InlineElemOptions, nodes: &'md [MdElem]) -> Self {
         let pending_refs_capacity = 8; // arbitrary guess
         Self {
             ctx,
             seen_links: HashSet::with_capacity(pending_refs_capacity),
             seen_footnotes: HashSet::with_capacity(pending_refs_capacity),
             pending_references: PendingReferences::with_capacity(pending_refs_capacity),
-            link_transformer: LinkTransformer::from(options.link_format),
+            link_transformer: LinkTransformer::new(options.link_format, nodes),
             footnote_transformer: FootnoteTransformer::new(options.renumber_footnotes),
         }
     }
@@ -681,6 +681,7 @@ mod tests {
                     link_format: LinkTransform::Keep,
                     renumber_footnotes: false,
                 },
+                &[], // don't need to care about the nodes here
             );
             let link = Inline::Image(Image {
                 alt: input_description.to_string(),
@@ -710,6 +711,7 @@ mod tests {
                 link_format: LinkTransform::Keep,
                 renumber_footnotes: false,
             },
+            &[], // don't need to care about the nodes here
         );
         writer.write_inline_element(&mut output, orig);
         let md_str = output.take_underlying().unwrap();
@@ -737,6 +739,7 @@ mod tests {
                 link_format: LinkTransform::Keep,
                 renumber_footnotes: false,
             },
+            &[], // don't need to care about the nodes here
         );
         let link = Inline::Link(Link::Standard(StandardLink {
             display: vec![Inline::Text(Text {

--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -246,7 +246,7 @@ struct ReferenceAssigner {
 }
 
 impl ReferenceAssigner {
-    fn new(nodes: &[MdElem]) -> Self {
+    fn new(_nodes: &[MdElem]) -> Self {
         Self {
             next_index: 1,
             reorderings: HashMap::with_capacity(16), // arbitrary

--- a/src/output/output_adapter.rs
+++ b/src/output/output_adapter.rs
@@ -16,16 +16,15 @@ impl MdWriter {
     }
 
     /// Writes the given nodes to the given writer.
-    pub fn write<'md, I, W>(&self, ctx: &'md MdContext, nodes: I, out: &mut W)
+    pub fn write<'md, W>(&self, ctx: &'md MdContext, nodes: &'md [MdElem], out: &mut W)
     where
-        I: IntoIterator<Item = &'md MdElem>,
         W: fmt::Write,
     {
         write_md(
             self.options,
             &mut Output::new(IoAdapter(out), self.options.text_width),
             ctx,
-            nodes.into_iter(),
+            nodes,
         )
     }
 }

--- a/src/output/tree_ref_serde.rs
+++ b/src/output/tree_ref_serde.rs
@@ -150,7 +150,7 @@ pub(crate) enum CodeBlockType {
 
 impl<'md> SerializableMd<'md> {
     pub fn new(elems: &'md [MdElem], ctx: &'md MdContext, opts: InlineElemOptions) -> Self {
-        let mut inlines_writer = MdInlinesWriter::new(ctx, opts);
+        let mut inlines_writer = MdInlinesWriter::new(ctx, opts, elems);
         const DEFAULT_CAPACITY: usize = 16; // we could compute these, but it's not really worth it
         let mut result = SerializableMd {
             items: Vec::with_capacity(elems.len()),


### PR DESCRIPTION
In service of #390. For that change, we'll want the set of all reference-style links (e.g. `[1]`) before we start writing markdown. This lets us do that without having to collect the iterator, which is especially nice since the iterator is itself just coming from a vec that's sliceable.

## Breaking change

- `mdq::output::MdWriter::write` takes an `&[MdElem]` instead of an `impl IntoIterator<Item = &MdElem>`