### PR TITLE
simplify link transformation

### DIFF
--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -53,6 +53,14 @@ impl MdContext {
             empty_md_elems: Vec::new(),
         }
     }
+
+    /// Creates an empty context, which will not allocate.
+    pub(crate) fn zero_sized() -> Self {
+        Self {
+            footnotes: HashMap::with_capacity(0),
+            empty_md_elems: Vec::new(),
+        }
+    }
 }
 
 /// A fully parsed Markdown document.

--- a/src/output/find_numbered_links.rs
+++ b/src/output/find_numbered_links.rs
@@ -1,0 +1,222 @@
+use crate::md_elem::elem::{Inline, Link, LinkReference, StandardLink};
+use crate::md_elem::{MdContext, MdElem};
+use crate::output::{inlines_to_string, InlineElemOptions, LinkTransform, MdInlinesWriter};
+use std::collections::BTreeSet;
+use std::str::FromStr;
+
+/// Find all numbers that should not be used when generating `[full links][123]`.
+pub(crate) fn find_reserved_link_numbers<'md>(
+    nodes: impl IntoIterator<Item = &'md MdElem>,
+    ctx: &'md MdContext,
+) -> BTreeSet<u64> {
+    let mut finder = ReservedLinkNumbers {
+        result: BTreeSet::new(),
+        ctx,
+    };
+    finder.build_from_nodes(nodes);
+    finder.result
+}
+
+struct ReservedLinkNumbers<'md> {
+    result: BTreeSet<u64>,
+    ctx: &'md MdContext,
+}
+
+impl<'md> ReservedLinkNumbers<'md> {
+    fn build_from_nodes(&mut self, nodes: impl IntoIterator<Item = &'md MdElem>) {
+        for node in nodes.into_iter() {
+            match node {
+                MdElem::Doc(doc) => self.build_from_nodes(doc),
+                MdElem::BlockQuote(block) => self.build_from_nodes(&block.body),
+                MdElem::List(list) => {
+                    for li in &list.items {
+                        self.build_from_nodes(&li.item);
+                    }
+                }
+                MdElem::Section(section) => {
+                    self.build_from_inlines(&section.title);
+                    self.build_from_nodes(&section.body);
+                }
+                MdElem::Paragraph(p) => self.build_from_inlines(&p.body),
+                MdElem::Table(table) => {
+                    for row in &table.rows {
+                        for col in row {
+                            self.build_from_inlines(col);
+                        }
+                    }
+                }
+                MdElem::Inline(inline) => self.build_from_inlines(std::iter::once(inline)),
+                MdElem::ThematicBreak | MdElem::CodeBlock(_) | MdElem::FrontMatter(_) | MdElem::BlockHtml(_) => {}
+            }
+        }
+    }
+
+    fn build_from_inlines(&mut self, inline: impl IntoIterator<Item = &'md Inline>) {
+        for inline in inline.into_iter() {
+            match inline {
+                Inline::Footnote(footnote) => {
+                    self.build_from_nodes(self.ctx.get_footnote(footnote));
+                }
+                Inline::Span(span) => self.build_from_inlines(&span.children),
+                Inline::Link(link) => {
+                    match link {
+                        Link::Standard(link) => self.build_from_link(&link),
+                        Link::Autolink(_) => {} // autolinks are never just numeric
+                    }
+                }
+                Inline::Image(_) | Inline::Text(_) => {}
+            }
+        }
+    }
+
+    fn build_from_link(&mut self, link: &StandardLink) {
+        match &link.link.reference {
+            LinkReference::Inline => {
+                // inline links are never numeric
+            }
+            LinkReference::Full(_) | LinkReference::Collapsed | LinkReference::Shortcut => {
+                // For full links, collapsed links, and shortcuts: if the display next is numeric, we'll reserve it.
+                // (that will prevent output like `[123][4]`, which could be confusing. Otherwise, we won't.
+                // Note that something like `[foo bar][1]` will not reserve the 1. That's because we'll be renumbering
+                // it anyway.
+                let options = InlineElemOptions {
+                    link_format: LinkTransform::Keep,
+                    renumber_footnotes: false,
+                };
+                let tmp_ctx = MdContext::zero_sized();
+                let mut writer = MdInlinesWriter::new(&tmp_ctx, options, &[]);
+                let text = inlines_to_string(&mut writer, &link.display);
+                self.build_from_text(&text);
+            }
+        }
+    }
+
+    fn build_from_text(&mut self, text: &str) {
+        if let Ok(num) = u64::from_str(text) {
+            self.result.insert(num);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::md_elem::{MdDoc, ParseOptions};
+    use indoc::indoc;
+
+    #[test]
+    fn no_links() {
+        check_link_nums("some markdown", []);
+    }
+
+    #[test]
+    fn autolink() {
+        check_link_nums("<https://example.com>", []);
+    }
+
+    #[test]
+    fn collapsed_not_num() {
+        check_link_nums(
+            indoc! {r#"
+            [apple][]
+
+            [apple]: https://example.com"#},
+            [],
+        );
+    }
+
+    #[test]
+    fn collapsed_with_num() {
+        check_link_nums(
+            indoc! {r#"
+            [123][]
+
+            [123]: https://example.com"#},
+            [123],
+        );
+    }
+
+    #[test]
+    fn shortcut_not_num() {
+        check_link_nums(
+            indoc! {r#"
+            [apple]
+
+            [apple]: https://example.com"#},
+            [],
+        );
+    }
+
+    #[test]
+    fn shortcut_with_num() {
+        check_link_nums(
+            indoc! {r#"
+            [123]
+
+            [123]: https://example.com"#},
+            [123],
+        );
+    }
+
+    #[test]
+    fn full_not_num() {
+        check_link_nums(
+            indoc! {r#"
+            [display text][a]
+
+            [a]: https://example.com"#},
+            [],
+        );
+    }
+
+    #[test]
+    fn full_with_num() {
+        check_link_nums(
+            indoc! {r#"
+            [display text][123]
+
+            [123]: https://example.com"#},
+            [],
+        );
+    }
+
+    #[test]
+    fn full_with_num_display() {
+        check_link_nums(
+            indoc! {r#"
+            [123][a]
+
+            [456][7]
+
+            [a]: https://example.com
+            [7]: https://example.com"#},
+            [123, 456], // but not 7; that link will turn into a collapsed
+        );
+    }
+
+    #[test]
+    fn within_some_nested_items() {
+        check_link_nums(
+            indoc! {r#"
+            > Some quoting
+            >
+            > - list item including [123][] collapsed link
+
+            # Section with [456] shortcut link
+
+            Some text under it.
+
+            [123]: https://example.com/a
+            [456]: https://example.com/b
+            "#},
+            [123, 456],
+        );
+    }
+
+    /// Simple little check based on parsed markdown. This makes it not quite unit-y, but very easy to create tests.
+    fn check_link_nums<const N: usize>(md_text: &str, expected: [u64; N]) {
+        let MdDoc { roots, ctx } = MdDoc::parse(md_text, &ParseOptions::gfm()).unwrap();
+        let actual = find_reserved_link_numbers(&roots, &ctx);
+        assert_eq!(actual, expected.into());
+    }
+}

--- a/src/output/fmt_md.rs
+++ b/src/output/fmt_md.rs
@@ -1976,7 +1976,7 @@ pub(crate) mod tests {
         fn two_links_doc_pos_no_thematic_break() {
             let mut options = MdWriterOptions::default_for_tests();
             options.include_thematic_breaks = false;
-            options.inline_options.link_format = LinkTransform::Reference;
+            options.inline_options.link_format = LinkTransform::NeverInline;
             options.link_reference_placement = ReferencePlacement::Doc;
             check_render_refs_with(
                 options,
@@ -2011,7 +2011,7 @@ pub(crate) mod tests {
         #[test]
         fn reference_transform_smoke_test() {
             check_render_refs_with(
-                MdWriterOptions::new_with(|mdo| mdo.inline_options.link_format = LinkTransform::Reference),
+                MdWriterOptions::new_with(|mdo| mdo.inline_options.link_format = LinkTransform::NeverInline),
                 vec![link_elem(Link::Standard(StandardLink {
                     display: vec![mdq_inline!("link text")],
                     link: LinkDefinition {
@@ -2091,7 +2091,7 @@ pub(crate) mod tests {
         #[test]
         fn reference_transform_smoke_test() {
             check_render_refs_with(
-                MdWriterOptions::new_with(|mdo| mdo.inline_options.link_format = LinkTransform::Reference),
+                MdWriterOptions::new_with(|mdo| mdo.inline_options.link_format = LinkTransform::NeverInline),
                 vec![image_elem(Image {
                     alt: "alt text".to_string(),
                     link: LinkDefinition {

--- a/src/output/fmt_md_inlines.rs
+++ b/src/output/fmt_md_inlines.rs
@@ -1,7 +1,7 @@
 use crate::md_elem::elem::*;
 use crate::md_elem::*;
 use crate::output::footnote_transform::FootnoteTransformer;
-use crate::output::link_transform::{LinkLabel, LinkTransform, LinkTransformation, LinkTransformer};
+use crate::output::link_transform::{LinkLabel, LinkTransform, LinkTransformer};
 use crate::util::output::{Output, SimpleWrite};
 use derive_builder::Builder;
 use serde::Serialize;
@@ -80,7 +80,7 @@ impl<'md> MdInlinesWriter<'md> {
             seen_links: HashSet::with_capacity(pending_refs_capacity),
             seen_footnotes: HashSet::with_capacity(pending_refs_capacity),
             pending_references: PendingReferences::with_capacity(pending_refs_capacity),
-            link_transformer: LinkTransformer::new(options.link_format, nodes),
+            link_transformer: LinkTransformer::new(options.link_format, nodes, ctx),
             footnote_transformer: FootnoteTransformer::new(options.renumber_footnotes),
         }
     }
@@ -312,8 +312,7 @@ impl<'md> MdInlinesWriter<'md> {
 
             out.write_char(']');
 
-            let link_ref = LinkTransformation::new(self.link_transformer.transform_variant(), self, link_like)
-                .apply(&mut self.link_transformer, &link.reference);
+            let link_ref = self.link_transformer.apply(&link.reference);
             let reference_to_add = match link_ref {
                 LinkReference::Inline => {
                     out.write_char('(');

--- a/src/output/link_transform.rs
+++ b/src/output/link_transform.rs
@@ -1,45 +1,8 @@
-/// Link transformation system for converting between different link formats.
-///
-/// # Overview
-///
-/// This module provides a flexible system for transforming links between different
-/// formats (inline, reference, etc.) while maintaining proper reference numbering and avoiding
-/// conflicts. The system is designed around a delegation pattern that separates the public
-/// API from the stateful transformation logic.
-///
-/// # Architecture
-///
-/// ## Core Components
-/// - [`LinkTransform`]: Public enum defining transformation strategies
-/// - [`LinkTransformer`]: Crate-public type for transformations; trivially delegates to [`LinkTransformerStrategy`].
-/// - [`LinkTransformerStrategy`]: Internal enum implementing the different transformation strategies
-/// - [`LinkTransformation`]: Temporary holder for preprocessing data
-/// - [`ReferenceAssigner`]: Stateful numbering system for reference links
-///
-/// ## Data Flow
-/// ```text
-/// LinkTransform (user choice)
-///       ↓
-/// LinkTransformer::from() → LinkTransformerStrategy (with ReferenceAssigner if needed)
-///       ↓
-/// For each link:
-///   LinkTransformation::new() → extract preprocessing data
-///       ↓
-///   LinkTransformation::apply() → perform transformation using strategy
-/// ```
-///
-/// The two-step process (new → apply) exists because Rust's borrowing rules prevent:
-/// ```text
-/// let result = transformer.transform(&mut self, link)
-/// //           ^^^^^^^^^^^            ^^^^
-/// //           first borrow           second borrow
-/// ```
-///
-/// By extracting data in `new()` and applying in `apply()`, we can release the borrow
-///
 use crate::md_elem::elem::*;
 use crate::md_elem::*;
+use crate::output::find_numbered_links::find_reserved_link_numbers;
 use crate::output::fmt_md_inlines::{InlineElemOptions, LinkLike, MdInlinesWriter};
+use crate::util::number_assigner::NumberAssigner;
 use crate::util::output::Output;
 use clap::ValueEnum;
 use std::borrow::Cow;
@@ -57,24 +20,24 @@ pub enum LinkTransform {
     /// Turn all links into inlined form: `[link text](https://example.com)`
     Inline,
 
-    /// Turn all links into reference form: `[link text][1]`
-    ///
-    /// Links that weren't already in reference form will be auto-assigned a reference id. Links that were in reference
-    /// form will have the link number be reordered.
-    Reference,
-
     #[default]
-    /// Keep `[full][123]`, `[collapsed][]`, and `[shortcut]` links unchanged, but replace
-    /// `[inlined](https://example.com)` links.
+    /// Never output `[inline](https://example.com)` links.
     ///
-    /// The current implementation will turn them into full-style links with incrementing numbers, but this may
-    /// change in future versions.
+    /// The exact implementation is subject to change. As of this version:
+    ///
+    /// - `[inline](https://example.com)` links will always be turned into `[full][1]` links, with the link id being
+    ///    an auto-assigned number
+    /// - `[collapsed][]` and `[shortcut]` links will always be unchanged
+    /// - `[full][a]` links will:
+    ///    - turn into `[collapsed][]` links if the display text is numeric: `[123][a]` → `[123][]`
+    ///    - otherwise, be renumbered if the link id is numeric: `[example][3]` → `[example][1]`
+    ///    - otherwise, be left unchanged: `[example][a]` is unchanged
     NeverInline,
 }
 
 /// The crate-public orchestrator for link transformations.
 //
-// # Internal documentation for just this file:
+// Internal documentation for just this file:
 //
 // This struct just provides a crate-public interface to the real logic, which is all in LinkTransformerStrategy.
 pub(crate) struct LinkTransformer {
@@ -127,104 +90,42 @@ impl<'md> LinkLabel<'md> {
 enum LinkTransformerStrategy {
     Keep,
     Inline,
-    Reference(ReferenceAssigner),
     NeverInline(ReferenceAssigner),
 }
 
-/// Temporary holder for preprocessing data needed during link transformation.
-///
-/// This struct exists to work around Rust's borrowing rules by separating the
-/// data extraction phase from the transformation phase. It holds any preprocessing
-/// data that needs to be computed before the actual transformation can occur.
-///
-/// # Borrowing Workaround
-/// Without this pattern, we'd need to do:
-/// ```text
-/// let result = transformer.transform(&mut self, link)
-/// //           ^^^^^^^^^^^            ^^^^
-/// //           first borrow           second borrow (ERROR!)
-/// ```
-///
-/// Instead, we can do:
-/// ```text
-/// let transformation = LinkTransformation::new(variant, writer, link); // extract data
-/// let result = transformation.apply(&mut transformer, link_ref);       // use data
-/// ```
-pub(crate) struct LinkTransformation<'md> {
-    /// Text extracted from collapsed/shortcut links for use as reference IDs.
-    /// Only populated for [`LinkTransform::Reference`] and [`LinkTransform::NeverInline`] when processing
-    /// [`LinkReference::Collapsed`] or [`LinkReference::Shortcut`].
-    link_text: Option<Cow<'md, str>>,
-}
-
-impl<'md> LinkTransformation<'md> {
-    /// Extracts preprocessing data needed for the given transformation strategy.
-    pub(crate) fn new<L>(transform: LinkTransform, inline_writer: &mut MdInlinesWriter<'md>, item: L) -> Self
-    where
-        L: LinkLike<'md> + Copy,
-    {
-        let link_text = match transform {
-            LinkTransform::Keep | LinkTransform::Inline => None,
-            LinkTransform::Reference | LinkTransform::NeverInline => {
-                let (_, label, definition) = item.link_info();
-                match &definition.reference {
-                    LinkReference::Inline | LinkReference::Full(_) => None,
-                    LinkReference::Collapsed | LinkReference::Shortcut => {
-                        let text = match label {
-                            LinkLabel::Text(text) => text,
-                            LinkLabel::Inline(text) => Cow::Owned(inlines_to_string(inline_writer, text)),
-                        };
-                        Some(text)
-                    }
-                }
-            }
-        };
-        Self { link_text }
-    }
-
-    /// Applies the transformation using the preprocessed data and transformer state.
-    // We could in principle return a Cow<'md, LinkReference>, and save some clones in the assigner.
-    // To do that, fmt_md_inlines.rs would need to adjust to hold Cows instead of LinkLabels directly. For now, not
-    // a high priority.
-    pub(crate) fn apply(self, transformer: &mut LinkTransformer, link: &'md LinkReference) -> LinkReference {
-        match &mut transformer.delegate {
-            LinkTransformerStrategy::Keep => Cow::Borrowed(link),
-            LinkTransformerStrategy::Inline => Cow::Owned(LinkReference::Inline),
-            LinkTransformerStrategy::Reference(assigner) => assigner.assign(self, link),
-            LinkTransformerStrategy::NeverInline(assigner) => match &link {
-                LinkReference::Inline => assigner.assign_new(),
-                LinkReference::Full(prev) => assigner.assign_if_numeric(prev).unwrap_or(Cow::Borrowed(link)),
-                a @ LinkReference::Collapsed | a @ LinkReference::Shortcut => {
-                    let text_cow = self.link_text.unwrap();
-                    assigner
-                        .assign_if_numeric(text_cow.deref())
-                        .unwrap_or(Cow::Borrowed(*a))
-                }
-            },
-        }
-        .into_owned()
-    }
-}
-
 impl LinkTransformer {
-    pub(crate) fn new(transform: LinkTransform, nodes: &[MdElem]) -> Self {
+    pub(crate) fn new(transform: LinkTransform, nodes: &[MdElem], ctx: &MdContext) -> Self {
         let delegate = match transform {
             LinkTransform::Keep => LinkTransformerStrategy::Keep,
             LinkTransform::Inline => LinkTransformerStrategy::Inline,
-            LinkTransform::Reference => LinkTransformerStrategy::Reference(ReferenceAssigner::new(nodes)),
-            LinkTransform::NeverInline => LinkTransformerStrategy::NeverInline(ReferenceAssigner::new(nodes)),
+            LinkTransform::NeverInline => LinkTransformerStrategy::NeverInline(ReferenceAssigner::new(nodes, ctx)),
         };
         Self { delegate }
     }
 
-    /// Returns the transformation variant this transformer was created with.
-    pub(crate) fn transform_variant(&self) -> LinkTransform {
-        match self.delegate {
-            LinkTransformerStrategy::Keep => LinkTransform::Keep,
-            LinkTransformerStrategy::Inline => LinkTransform::Inline,
-            LinkTransformerStrategy::Reference(_) => LinkTransform::Reference,
-            LinkTransformerStrategy::NeverInline(_) => LinkTransform::NeverInline,
+    pub(crate) fn apply(&mut self, link: &LinkReference) -> LinkReference {
+        match &mut self.delegate {
+            LinkTransformerStrategy::Keep => Cow::Borrowed(link),
+            LinkTransformerStrategy::Inline => Cow::Owned(LinkReference::Inline),
+            LinkTransformerStrategy::NeverInline(assigner) => match &link {
+                LinkReference::Inline => assigner.assign_new(),
+                LinkReference::Full(link_id) => {
+                    // For full links (`[foo][a]`), only reassign if the link was a number originally.
+                    if is_numeric(link_id) {
+                        assigner.reassign(link_id)
+                    } else {
+                        Cow::Borrowed(link)
+                    }
+                }
+                // LinkReference::Full(prev) => assigner.assign_if_numeric(prev).unwrap_or(Cow::Borrowed(link)),
+                LinkReference::Collapsed | LinkReference::Shortcut => {
+                    // For collapsed and shortcut links, never renumber! This could turn `[123][]` into `[123][6]`, which
+                    // is confusing.
+                    Cow::Borrowed(link)
+                }
+            },
         }
+        .into_owned()
     }
 }
 
@@ -235,7 +136,7 @@ struct ReferenceAssigner {
     /// Let's not worry about overflow. The minimum size for each link is 5 bytes (`[][1]`), so u64 of those is about
     ///  80 exabytes of markdown -- and it would be even bigger than that, since the digits get bigger. It's just not a
     /// case I'm too worried about right now.
-    next_index: u64,
+    index_assigner: NumberAssigner,
 
     /// Mappings from old numeric reference IDs to their new assigned numbers.
     ///
@@ -246,58 +147,30 @@ struct ReferenceAssigner {
 }
 
 impl ReferenceAssigner {
-    fn new(_nodes: &[MdElem]) -> Self {
+    fn new(nodes: &[MdElem], ctx: &MdContext) -> Self {
+        let reserved_ints = find_reserved_link_numbers(nodes.iter(), ctx);
+        let index_assigner = NumberAssigner::new(reserved_ints);
+
         Self {
-            next_index: 1,
+            index_assigner,
             reorderings: HashMap::with_capacity(16), // arbitrary
         }
     }
 
-    /// Assigns a reference ID for the given link using the Reference transform strategy.
-    ///
-    /// This method implements the full reference transformation logic:
-    /// - **Inline links**: Get a new auto-assigned number
-    /// - **Full references**: Renumber if numeric, otherwise keep as-is
-    /// - **Collapsed/Shortcut**: Use the link text as reference ID, renumbering if it's numeric
-    ///
-    /// # Reference ID Logic
-    /// For collapsed/shortcut links, the link text becomes the reference ID:
-    /// - `[example][]` → `[example][example]` (text is "example")
-    /// - `[123][]` → `[123][1]` (text is "123", gets renumbered)
-    /// - `[_123_][]` → `[_123_][_123_]` (text is "_123_", not purely numeric)
-    fn assign<'md>(&mut self, state: LinkTransformation<'md>, link: &'md LinkReference) -> Cow<'md, LinkReference> {
-        match &link {
-            LinkReference::Inline => self.assign_new(),
-            LinkReference::Full(prev) => self.assign_if_numeric(prev).unwrap_or(Cow::Borrowed(link)),
-            LinkReference::Collapsed | LinkReference::Shortcut => {
-                let text_cow = state.link_text.unwrap();
-                self.assign_if_numeric(text_cow.deref()).unwrap_or_else(|| {
-                    let ref_text_owned = String::from(text_cow.deref());
-                    Cow::Owned(LinkReference::Full(ref_text_owned))
-                })
-            }
-        }
-    }
-
     /// Attempts to renumber a reference ID if it's purely numeric.
-    fn assign_if_numeric<'md>(&mut self, prev: &str) -> Option<Cow<'md, LinkReference>> {
-        if prev.chars().all(|ch| ch.is_numeric()) {
-            match self.reorderings.entry(String::from(prev)) {
-                Entry::Occupied(map_to) => Some(Cow::Owned(LinkReference::Full(map_to.get().to_string()))),
-                Entry::Vacant(e) => {
-                    e.insert(self.next_index);
-                    Some(self.assign_new())
-                }
+    fn reassign<'md>(&mut self, prev: &str) -> Cow<'md, LinkReference> {
+        match self.reorderings.entry(String::from(prev)) {
+            Entry::Occupied(map_to) => Cow::Owned(LinkReference::Full(map_to.get().to_string())),
+            Entry::Vacant(e) => {
+                e.insert(self.index_assigner.next_num());
+                self.assign_new()
             }
-        } else {
-            None
         }
     }
 
     /// Assigns a new auto-incremented reference number.
     fn assign_new<'md>(&mut self) -> Cow<'md, LinkReference> {
-        let idx_str = self.next_index.to_string();
-        self.next_index += 1;
+        let idx_str = self.index_assigner.next_num().to_string();
         Cow::Owned(LinkReference::Full(idx_str))
     }
 }
@@ -306,12 +179,16 @@ impl ReferenceAssigner {
 ///
 /// Unlike [crate::output::fmt_plain_str::inlines_to_plain_string], this respects formatting spans
 /// like emphasis, strong, etc.
-fn inlines_to_string<'md>(inline_writer: &mut MdInlinesWriter<'md>, inlines: &'md Vec<Inline>) -> String {
+pub(crate) fn inlines_to_string<'md>(inline_writer: &mut MdInlinesWriter<'md>, inlines: &'md Vec<Inline>) -> String {
     let mut string_writer = Output::without_text_wrapping(String::with_capacity(32)); // guess at capacity
     inline_writer.write_line(&mut string_writer, inlines);
     string_writer
         .take_underlying()
         .expect("internal error while parsing collapsed- or shortcut-style link")
+}
+
+fn is_numeric(text: &str) -> bool {
+    text.chars().all(char::is_numeric)
 }
 
 #[cfg(test)]
@@ -334,16 +211,17 @@ mod tests {
         Of(LinkTransform::Inline, LinkReference::Full(_)),
         Of(LinkTransform::Inline, LinkReference::Inline),
 
-        Of(LinkTransform::Reference, LinkReference::Collapsed),
-        Of(LinkTransform::Reference, LinkReference::Full(_)),
-        Of(LinkTransform::Reference, LinkReference::Inline),
-        Of(LinkTransform::Reference, LinkReference::Shortcut),
-
         Of(LinkTransform::NeverInline, LinkReference::Collapsed),
         Of(LinkTransform::NeverInline, LinkReference::Full(_)),
         Of(LinkTransform::NeverInline, LinkReference::Inline),
         Of(LinkTransform::NeverInline, LinkReference::Shortcut),
     });
+
+    #[test]
+    fn todo_check_all() {
+        // read the LinkTransform docs and come up with tests accordingly
+        panic!("make sure to do a full check of all the tests!")
+    }
 
     mod keep {
         use super::*;
@@ -414,123 +292,6 @@ mod tests {
         }
     }
 
-    mod reference {
-        use super::*;
-
-        #[test]
-        fn inline() {
-            Given {
-                transform: LinkTransform::Reference,
-                label: mdq_inline!("doesn't matter"),
-                orig_reference: LinkReference::Inline,
-            }
-            .expect(LinkReference::Full("1".to_string()));
-        }
-
-        #[test]
-        fn collapsed_label_not_number() {
-            Given {
-                transform: LinkTransform::Reference,
-                label: mdq_inline!("not a number"),
-                orig_reference: LinkReference::Collapsed,
-            }
-            .expect(LinkReference::Full("not a number".to_string()));
-        }
-
-        #[test]
-        fn collapsed_label_is_number() {
-            Given {
-                transform: LinkTransform::Reference,
-                label: mdq_inline!("321"),
-                orig_reference: LinkReference::Collapsed,
-            }
-            .expect(LinkReference::Full("1".to_string()));
-        }
-
-        #[test]
-        fn full_ref_id_not_number() {
-            Given {
-                transform: LinkTransform::Reference,
-                label: mdq_inline!("doesn't matter"),
-                orig_reference: LinkReference::Full("non-number".to_string()),
-            }
-            .expect(LinkReference::Full("non-number".to_string()));
-        }
-
-        #[test]
-        fn full_ref_id_is_number() {
-            Given {
-                transform: LinkTransform::Reference,
-                label: mdq_inline!("doesn't matter"),
-                orig_reference: LinkReference::Full("non-number".to_string()),
-            }
-            .expect(LinkReference::Full("non-number".to_string()));
-        }
-
-        #[test]
-        fn full_ref_id_is_huge_number() {
-            let huge_num_str = format!("{}00000", u128::MAX);
-            Given {
-                transform: LinkTransform::Reference,
-                label: mdq_inline!("doesn't matter"),
-                orig_reference: LinkReference::Full(huge_num_str),
-            }
-            .expect(LinkReference::Full("1".to_string()));
-        }
-
-        #[test]
-        fn shortcut_label_not_number() {
-            Given {
-                transform: LinkTransform::Reference,
-                label: mdq_inline!("not a number"),
-                orig_reference: LinkReference::Shortcut,
-            }
-            .expect(LinkReference::Full("not a number".to_string()));
-        }
-
-        #[test]
-        fn shortcut_label_is_number() {
-            Given {
-                transform: LinkTransform::Reference,
-                label: mdq_inline!("321"),
-                orig_reference: LinkReference::Shortcut,
-            }
-            .expect(LinkReference::Full("1".to_string()));
-        }
-
-        /// The label isn't even close to a number.
-        ///
-        /// _c.f._ [shortcut_label_inlines_are_emphasized_number]
-        #[test]
-        fn shortcut_label_inlines_not_number_like() {
-            Given {
-                transform: LinkTransform::Reference,
-                label: mdq_inline!("hello world"),
-                orig_reference: LinkReference::Shortcut,
-            }
-            .expect(LinkReference::Full("hello world".to_string()));
-        }
-
-        /// The label is kind of like a number, except that it's emphasized: `_123_`. This makes it not a number.
-        ///
-        /// _c.f._ [shortcut_label_inlines_not_number_like]
-        #[test]
-        fn shortcut_label_inlines_are_emphasized_number() {
-            Given {
-                transform: LinkTransform::Reference,
-                label: Inline::Span(Span {
-                    variant: SpanVariant::Emphasis,
-                    children: vec![Inline::Text(Text {
-                        variant: TextVariant::Plain,
-                        value: "123".to_string(),
-                    })],
-                }),
-                orig_reference: LinkReference::Shortcut,
-            }
-            .expect(LinkReference::Full("_123_".to_string()));
-        }
-    }
-
     mod never_inline {
         use super::*;
 
@@ -551,7 +312,7 @@ mod tests {
         fn full() {
             check_never_inline(
                 LinkReference::Full("5".to_string()),
-                LinkReference::Full("1".to_string()),
+                LinkReference::Full("5".to_string()),
             );
         }
 
@@ -570,69 +331,6 @@ mod tests {
         }
     }
 
-    /// A smoke test basically to ensure that we increment values correctly. We won't test every transformation type,
-    /// since the sibling sub-modules already do that.
-    #[test]
-    fn smoke_test_multi() {
-        let alpha = make_link("alpha", LinkReference::Inline);
-        let bravo = make_link("bravo", LinkReference::Full("1".to_string()));
-        let charlie = make_link("charlie", LinkReference::Shortcut);
-        let delta = make_link("delta", LinkReference::Full("delta".to_string()));
-        let echo = make_link("789", LinkReference::Collapsed);
-        let foxtrot = make_link("echo", LinkReference::Collapsed);
-
-        let as_md_elem: [MdElem; 6] = [&alpha, &bravo, &charlie, &delta, &echo, &foxtrot]
-            .map(Link::clone)
-            .map(Link::into);
-
-        let mut transformer = LinkTransformer::new(LinkTransform::Reference, as_md_elem.as_slice());
-        let ctx = MdContext::empty();
-        let mut iw = MdInlinesWriter::new(
-            &ctx,
-            InlineElemOptions {
-                link_format: LinkTransform::Keep,
-                renumber_footnotes: false,
-            },
-            as_md_elem.as_slice(),
-        );
-
-        // [alpha](https://example.com) ==> [alpha][1]
-        assert_eq!(
-            transform(&mut transformer, &mut iw, &alpha),
-            LinkReference::Full("1".to_string())
-        );
-
-        // [bravo][1] ==> [bravo][2]
-        assert_eq!(
-            transform(&mut transformer, &mut iw, &bravo),
-            LinkReference::Full("2".to_string())
-        );
-
-        // [charlie][] ==> [charlie][charlie]
-        assert_eq!(
-            transform(&mut transformer, &mut iw, &charlie),
-            LinkReference::Full("charlie".to_string())
-        );
-
-        // [delta][delta] ==> [delta][delta]
-        assert_eq!(
-            transform(&mut transformer, &mut iw, &delta),
-            LinkReference::Full("delta".to_string())
-        );
-
-        // [789] ==> [789][3]
-        assert_eq!(
-            transform(&mut transformer, &mut iw, &echo),
-            LinkReference::Full("3".to_string())
-        );
-
-        // [echo] ==> [echo][echo]
-        assert_eq!(
-            transform(&mut transformer, &mut iw, &foxtrot),
-            LinkReference::Full("echo".to_string())
-        );
-    }
-
     #[test]
     fn smoke_test_multi_with_never_inline() {
         let alpha = make_link("alpha", LinkReference::Collapsed);
@@ -647,8 +345,8 @@ mod tests {
             .map(Link::clone)
             .map(Link::into);
 
-        let mut transformer = LinkTransformer::new(LinkTransform::NeverInline, as_md_elem.as_slice());
         let ctx = MdContext::empty();
+        let mut transformer = LinkTransformer::new(LinkTransform::NeverInline, as_md_elem.as_slice(), &ctx);
         let mut iw = MdInlinesWriter::new(
             &ctx,
             InlineElemOptions {
@@ -703,16 +401,12 @@ mod tests {
         iw: &mut MdInlinesWriter<'md>,
         link: &'md Link,
     ) -> LinkReference {
-        let actual = match link {
-            Link::Standard(standard_link) => {
-                LinkTransformation::new(transformer.transform_variant(), iw, standard_link)
-                    .apply(transformer, &standard_link.link.reference)
-            }
+        match link {
+            Link::Standard(standard_link) => transformer.apply(&standard_link.link.reference),
             Link::Autolink(autolink) => {
                 panic!("unexpected autolink: {autolink:?}")
             }
-        };
-        actual
+        }
     }
 
     fn make_link(label: &str, link_ref: LinkReference) -> Link {
@@ -754,8 +448,8 @@ mod tests {
 
             let link_md_slice: [MdElem; 1] = [link.clone().into()];
 
-            let mut transformer = LinkTransformer::new(transform, &link_md_slice);
             let ctx = MdContext::empty();
+            let mut transformer = LinkTransformer::new(transform, &link_md_slice, &ctx);
             let mut iw = MdInlinesWriter::new(
                 &ctx,
                 InlineElemOptions {

--- a/src/output/mod.rs
+++ b/src/output/mod.rs
@@ -1,4 +1,5 @@
 //! Output `md_elem`s to various formats.
+mod find_numbered_links;
 mod fmt_md;
 mod fmt_md_inlines;
 mod fmt_plain_inline;

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod number_assigner;
 pub(crate) mod output;
 pub(crate) mod str_utils;
 pub(crate) mod utils_for_test;

--- a/src/util/number_assigner.rs
+++ b/src/util/number_assigner.rs
@@ -1,0 +1,65 @@
+use std::collections::BTreeSet;
+
+pub(crate) struct NumberAssigner {
+    next_int: u64,
+    reserved_nums: BTreeSet<u64>,
+}
+
+impl NumberAssigner {
+    pub(crate) fn new(reserved_nums: BTreeSet<u64>) -> Self {
+        NumberAssigner {
+            next_int: 1,
+            reserved_nums,
+        }
+    }
+
+    pub(crate) fn next_num(&mut self) -> u64 {
+        let mut available_number = self.next_int;
+        let mut reserved_range = self.reserved_nums.range(self.next_int..);
+        while let Some(&reserved_num) = reserved_range.next() {
+            if available_number != reserved_num {
+                break;
+            }
+            available_number += 1;
+        }
+        self.next_int = available_number + 1;
+        available_number
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn nothing_reserved() {
+        check([], [1, 2, 3, 4]);
+    }
+
+    #[test]
+    fn first_is_reserved() {
+        check([1], [2, 3]);
+    }
+
+    #[test]
+    fn just_one_reserved() {
+        check([3], [1, 2, 4]);
+    }
+
+    #[test]
+    fn multiple_in_range_reserved() {
+        check([3, 4, 5], [1, 2, 6]);
+    }
+
+    /// Reserves some numbers, and then checks that the next `E` are what we expect.
+    fn check<const R: usize, const E: usize>(reserved: [u64; R], expect: [u64; E]) {
+        let mut assigner = NumberAssigner::new(reserved.into());
+
+        let mut actual = [None; E];
+        for i in 0..E {
+            actual[i] = Some(assigner.next_num());
+        }
+
+        assert_eq!(actual, expect.map(Some));
+    }
+}

--- a/src/util/utils_for_test.rs
+++ b/src/util/utils_for_test.rs
@@ -159,7 +159,7 @@ mod test_utils {
                     fn wait_for_all(&self) {
                         use std::{thread, time};
 
-                        let timeout = test_delay_ms!(500);
+                        let timeout = crate::util::utils_for_test::test_delay_ms!(500);
                         let retry_delay = time::Duration::from_millis(50);
                         let start = time::Instant::now();
                         loop {


### PR DESCRIPTION
Remove `LinkTransform::Reference`, replacing it with `LinkTransform::NeverInline`. This keeps collapsed and shortcut links as they were (unlike `Reference`, which replaced them with `[full references][1]`).

Additionally, collapsed and shortcut links whose display text is just a number (e.g. `[1][]` or `[2]`) will now reserve that number, rather than having it be renumbered as a full-style link. Otherwise, the link transformer would change something like `[3]` to `[3][1]` (if that shortcut `[3]` link happened to be the first link in the document), which would result in confusing markdown. Full-style links like `[some text][4]` will still be renumbered.

This simplifies link transformation, and also provides for a nicer user experience. Resolves #390.

## Breaking changes

- `LinkTransform::Reference` has been removed