### PR TITLE
implement regex-replace for all selectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,3 @@ lazy_static = "1.4.0"
 indoc = "2"
 serde = { version = "1", features = ["derive"] }
 toml = "0.8"
-
-[lints.rust]
-dead_code = "allow" # TODO remove this; it's a temporary crutch for the phased commits of #376

--- a/src/md_elem/flat_inlines.rs
+++ b/src/md_elem/flat_inlines.rs
@@ -3,7 +3,6 @@ use crate::md_elem::tree::elem::{Autolink, AutolinkStyle, Image, Link, StandardL
 use crate::md_elem::tree::elem::{FootnoteId, Inline, LinkDefinition, SpanVariant, Text, TextVariant};
 use crate::output::{inlines_to_plain_string, FootnoteToString, InlineToStringOpts};
 use std::cmp::Ordering;
-use crate::output::{inlines_to_plain_string, FootnoteToString, InlineToStringOpts};
 use std::iter::Peekable;
 use std::ops::Range;
 

--- a/src/md_elem/flat_inlines.rs
+++ b/src/md_elem/flat_inlines.rs
@@ -3,6 +3,7 @@ use crate::md_elem::tree::elem::{Autolink, AutolinkStyle, Image, Link, StandardL
 use crate::md_elem::tree::elem::{FootnoteId, Inline, LinkDefinition, SpanVariant, Text, TextVariant};
 use crate::output::{inlines_to_plain_string, FootnoteToString, InlineToStringOpts};
 use std::cmp::Ordering;
+use crate::output::{inlines_to_plain_string, FootnoteToString, InlineToStringOpts};
 use std::iter::Peekable;
 use std::ops::Range;
 
@@ -483,7 +484,12 @@ fn flatten_inlines(inlines: impl IntoIterator<Item = Inline>, text: &mut String)
                 // range starts outside this inline). Rather than describing a complex situation to the user, we'll just
                 // prohibit them.
                 let start_pos = text.len();
-                let content = String::from("1"); // TODO
+                let content = inlines_to_plain_string(
+                    &[&other],
+                    InlineToStringOpts {
+                        footnotes: FootnoteToString::OnlyFootnoteId,
+                    },
+                );
                 text.push_str(&content);
                 let length = content.len();
 

--- a/src/md_elem/flat_inlines.rs
+++ b/src/md_elem/flat_inlines.rs
@@ -1,6 +1,7 @@
 use crate::md_elem::tree::elem::Span;
 use crate::md_elem::tree::elem::{Autolink, AutolinkStyle, Image, Link, StandardLink};
 use crate::md_elem::tree::elem::{FootnoteId, Inline, LinkDefinition, SpanVariant, Text, TextVariant};
+use crate::output::{inlines_to_plain_string, FootnoteToString, InlineToStringOpts};
 use std::cmp::Ordering;
 use std::iter::Peekable;
 use std::ops::Range;
@@ -482,7 +483,12 @@ fn flatten_inlines(inlines: impl IntoIterator<Item = Inline>, text: &mut String)
                 // range starts outside this inline). Rather than describing a complex situation to the user, we'll just
                 // prohibit them.
                 let start_pos = text.len();
-                let content = String::from("1"); // TODO
+                let content = inlines_to_plain_string(
+                    &[&other],
+                    InlineToStringOpts {
+                        footnotes: FootnoteToString::OnlyFootnoteId,
+                    },
+                );
                 text.push_str(&content);
                 let length = content.len();
 

--- a/src/md_elem/flat_inlines.rs
+++ b/src/md_elem/flat_inlines.rs
@@ -483,12 +483,7 @@ fn flatten_inlines(inlines: impl IntoIterator<Item = Inline>, text: &mut String)
                 // range starts outside this inline). Rather than describing a complex situation to the user, we'll just
                 // prohibit them.
                 let start_pos = text.len();
-                let content = inlines_to_plain_string(
-                    &[&other],
-                    InlineToStringOpts {
-                        footnotes: FootnoteToString::OnlyFootnoteId,
-                    },
-                );
+                let content: &'static str = "1"; // TODO
                 text.push_str(&content);
                 let length = content.len();
 

--- a/src/md_elem/flat_inlines.rs
+++ b/src/md_elem/flat_inlines.rs
@@ -483,7 +483,7 @@ fn flatten_inlines(inlines: impl IntoIterator<Item = Inline>, text: &mut String)
                 // range starts outside this inline). Rather than describing a complex situation to the user, we'll just
                 // prohibit them.
                 let start_pos = text.len();
-                let content: &'static str = "1"; // TODO
+                let content = String::from("1"); // TODO
                 text.push_str(&content);
                 let length = content.len();
 

--- a/src/md_elem/tree.rs
+++ b/src/md_elem/tree.rs
@@ -1442,7 +1442,7 @@ macro_rules! m_node {
 
     // Recursive case: A::B<tail> -> A::B(B<tail>)
     ($head:ident :: $next:ident $(:: $($tail:ident)::*)? $( $( <$last_variant:ident> )? { $($args:tt)* })? ) => {
-        $head::$next( m_node!($next $(:: $($tail)::*)? $( $( <$last_variant> )? { $($args)* })?) )
+        $head::$next( crate::md_elem::m_node!($next $(:: $($tail)::*)? $( $( <$last_variant> )? { $($args)* })?) )
     };
 }
 pub(crate) use m_node;

--- a/src/select/match_replace.rs
+++ b/src/select/match_replace.rs
@@ -5,3 +5,45 @@ pub struct MatchReplace {
     pub matcher: Matcher,
     pub replacement: Option<String>,
 }
+
+#[cfg(test)]
+mod test_utils {
+    use super::*;
+    use crate::select::{Matcher, Regex};
+
+    impl MatchReplace {
+        pub(crate) fn match_any() -> MatchReplace {
+            Self::build(|b| b)
+        }
+
+        pub(crate) fn build(f: impl FnOnce(&mut MatchReplaceBuilder) -> &mut MatchReplaceBuilder) -> MatchReplace {
+            let mut builder = MatchReplaceBuilder {
+                matcher: None,
+                replacement: None,
+            };
+            f(&mut builder);
+            MatchReplace {
+                matcher: builder.matcher.unwrap_or(Matcher::Any { explicit: false }),
+                replacement: builder.replacement,
+            }
+        }
+    }
+
+    pub(crate) struct MatchReplaceBuilder {
+        matcher: Option<Matcher>,
+        replacement: Option<String>,
+    }
+
+    impl MatchReplaceBuilder {
+        pub(crate) fn match_regex(&mut self, pattern: impl AsRef<str>) -> &mut Self {
+            let re = fancy_regex::Regex::new(pattern.as_ref()).expect("test error: bad regex");
+            self.matcher = Some(Matcher::Regex(Regex { re }));
+            self
+        }
+
+        pub(crate) fn replacement(&mut self, replacement: impl Into<String>) -> &mut Self {
+            self.replacement = Some(replacement.into());
+            self
+        }
+    }
+}

--- a/src/select/match_selector.rs
+++ b/src/select/match_selector.rs
@@ -24,3 +24,11 @@ where
         }
     }
 }
+
+pub(crate) fn make_select_result<T: Into<MdElem>>(item: T, matched_any: bool) -> Select {
+    if matched_any {
+        Select::Hit(vec![item.into()])
+    } else {
+        Select::Miss(item.into())
+    }
+}

--- a/src/select/sel_code_block.rs
+++ b/src/select/sel_code_block.rs
@@ -1,7 +1,8 @@
 use crate::md_elem::elem::*;
-use crate::select::match_selector::MatchSelector;
-use crate::select::string_matcher::{StringMatchError, StringMatcher};
-use crate::select::CodeBlockMatcher;
+use crate::md_elem::MdContext;
+use crate::select::match_selector::make_select_result;
+use crate::select::string_matcher::StringMatcher;
+use crate::select::{CodeBlockMatcher, Select, TrySelector};
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct CodeBlockSelector {
@@ -18,69 +19,266 @@ impl From<CodeBlockMatcher> for CodeBlockSelector {
     }
 }
 
-impl MatchSelector<CodeBlock> for CodeBlockSelector {
-    const NAME: &'static str = "code block";
-
-    fn matches(&self, code_block: &CodeBlock) -> Result<bool, StringMatchError> {
-        let lang_matches = match &code_block.variant {
-            CodeVariant::Code(code_opts) => {
-                let actual_lang = match code_opts {
-                    Some(co) => &co.language,
-                    None => "",
-                };
-                self.lang_matcher.matches(actual_lang)?
+impl TrySelector<CodeBlock> for CodeBlockSelector {
+    fn try_select(&self, _: &MdContext, item: CodeBlock) -> crate::select::Result<Select> {
+        let (has_code_opts, language, metadata) = match item.variant {
+            CodeVariant::Code(None) => (false, String::new(), None),
+            CodeVariant::Code(Some(CodeOpts { language, metadata })) => (true, language, metadata),
+            CodeVariant::Math { .. } => {
+                return Ok(Select::Miss(item.into()));
             }
-            CodeVariant::Math { .. } => false,
         };
-        Ok(lang_matches && self.contents_matcher.matches(&code_block.value)?)
+        let lang_sel = self
+            .lang_matcher
+            .match_replace_string(language)
+            .map_err(|e| e.to_select_error("code block"))?;
+        let content_sel = self
+            .contents_matcher
+            .match_replace_string(item.value)
+            .map_err(|e| e.to_select_error("code block"))?;
+
+        let item_is_match = lang_sel.matched_any && content_sel.matched_any;
+
+        let selected_code_opts = if has_code_opts {
+            Some(CodeOpts {
+                language: lang_sel.item,
+                metadata,
+            })
+        } else {
+            None
+        };
+
+        let selected_block = CodeBlock {
+            variant: CodeVariant::Code(selected_code_opts),
+            value: content_sel.item,
+        };
+        Ok(make_select_result(selected_block, item_is_match))
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::md_elem::MdContext;
-    use crate::select::{MatchReplace, Matcher, TrySelector};
+    use crate::md_elem::{MdContext, MdElem};
+    use crate::select::{MatchReplace, Select, TrySelector};
 
     #[test]
-    fn code_block_selector_match_error() {
-        let code_block_matcher = CodeBlockMatcher {
-            language: MatchReplace {
-                matcher: Matcher::Text {
-                    case_sensitive: false,
-                    anchor_start: false,
-                    text: "rust".to_string(),
-                    anchor_end: false,
-                },
-                replacement: Some("replacement".to_string()),
+    fn both_match() {
+        let code_block = new_code_block("main()", Some("rust"));
+
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::match_any(),
+            contents: MatchReplace::match_any(),
+        })
+        .try_select(&MdContext::default(), code_block.clone())
+        .unwrap();
+
+        assert_eq!(result, Select::Hit(vec![MdElem::CodeBlock(code_block)]));
+    }
+
+    #[test]
+    fn language_match_hits() {
+        let code_block = new_code_block("main()", Some("rust"));
+
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::build(|b| b.match_regex("rust")),
+            contents: MatchReplace::match_any(),
+        })
+        .try_select(&MdContext::default(), code_block.clone())
+        .unwrap();
+
+        assert_eq!(result, Select::Hit(vec![MdElem::CodeBlock(code_block)]));
+    }
+
+    #[test]
+    fn language_match_misses() {
+        let code_block = new_code_block("main", Some("rust"));
+
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::build(|b| b.match_regex("python")),
+            contents: MatchReplace::match_any(),
+        })
+        .try_select(&MdContext::default(), code_block.clone())
+        .unwrap();
+
+        assert_eq!(result, Select::Miss(MdElem::CodeBlock(code_block)));
+    }
+
+    #[test]
+    fn contents_match_hits() {
+        let code_block = new_code_block("main()", Some("rust"));
+
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::match_any(),
+            contents: MatchReplace::build(|b| b.match_regex("main")),
+        })
+        .try_select(&MdContext::default(), code_block.clone())
+        .unwrap();
+
+        assert_eq!(result, Select::Hit(vec![MdElem::CodeBlock(code_block)]));
+    }
+
+    #[test]
+    fn contents_match_misses() {
+        let code_block = new_code_block("main()", Some("rust"));
+
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::match_any(),
+            contents: MatchReplace::build(|b| b.match_regex("println")),
+        })
+        .try_select(&MdContext::default(), code_block.clone())
+        .unwrap();
+
+        assert_eq!(result, Select::Miss(MdElem::CodeBlock(code_block)));
+    }
+
+    #[test]
+    fn language_replacement_with_match() {
+        let code_block = new_code_block("def main", Some("python"));
+
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::build(|b| b.match_regex("python").replacement("py")),
+            contents: MatchReplace::match_any(),
+        })
+        .try_select(&MdContext::default(), code_block)
+        .unwrap();
+
+        assert_eq!(
+            result,
+            Select::Hit(vec![MdElem::CodeBlock(new_code_block("def main", Some("py")))])
+        );
+    }
+
+    #[test]
+    fn language_replacement_with_miss() {
+        let code_block = new_code_block("main()", Some("rust"));
+
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::build(|b| b.match_regex("python").replacement("py")),
+            contents: MatchReplace::match_any(),
+        })
+        .try_select(&MdContext::default(), code_block.clone())
+        .unwrap();
+
+        assert_eq!(result, Select::Miss(MdElem::CodeBlock(code_block)));
+    }
+
+    #[test]
+    fn contents_replacement_with_match() {
+        let code_block = new_code_block("main()", Some("rust"));
+
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::match_any(),
+            contents: MatchReplace::build(|b| b.match_regex("main").replacement("start")),
+        })
+        .try_select(&MdContext::default(), code_block)
+        .unwrap();
+
+        assert_eq!(
+            result,
+            Select::Hit(vec![MdElem::CodeBlock(new_code_block("start()", Some("rust")))])
+        );
+    }
+
+    #[test]
+    fn contents_replacement_with_miss() {
+        let code_block = new_code_block("main()", Some("rust"));
+
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::match_any(),
+            contents: MatchReplace::build(|b| b.match_regex("println").replacement("print")),
+        })
+        .try_select(&MdContext::default(), code_block.clone())
+        .unwrap();
+
+        assert_eq!(result, Select::Miss(MdElem::CodeBlock(code_block)));
+    }
+
+    #[test]
+    fn both_replacement_with_match() {
+        let code_block = new_code_block("def main:", Some("python"));
+
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::build(|b| b.match_regex("python").replacement("py")),
+            contents: MatchReplace::build(|b| b.match_regex("def (\\w+):").replacement("$1()")),
+        })
+        .try_select(&MdContext::default(), code_block)
+        .unwrap();
+
+        assert_eq!(
+            result,
+            Select::Hit(vec![MdElem::CodeBlock(new_code_block("main()", Some("py")))])
+        );
+    }
+
+    #[test]
+    fn code_language_is_explicitly_empty() {
+        let code_block = new_code_block("text", Some(""));
+
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::match_any(),
+            contents: MatchReplace::match_any(),
+        })
+        .try_select(&MdContext::default(), code_block.clone())
+        .unwrap();
+
+        assert_eq!(result, Select::Hit(vec![MdElem::CodeBlock(code_block)]));
+    }
+
+    #[test]
+    fn no_language_code_but_match_includes_one() {
+        let code_block = new_code_block("main()", None);
+
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::build(|b| b.match_regex("rust")),
+            contents: MatchReplace::match_any(),
+        })
+        .try_select(&MdContext::default(), code_block.clone())
+        .unwrap();
+
+        assert_eq!(result, Select::Miss(MdElem::CodeBlock(code_block)));
+    }
+
+    #[test]
+    fn no_language_code_and_match_doesnt_include_one() {
+        let code_block = new_code_block("main()", None);
+
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::match_any(),
+            contents: MatchReplace::match_any(),
+        })
+        .try_select(&MdContext::default(), code_block.clone())
+        .unwrap();
+
+        assert_eq!(result, Select::Hit(vec![MdElem::CodeBlock(code_block)]));
+    }
+
+    #[test]
+    fn math_block_never_matches() {
+        let math_block = CodeBlock {
+            variant: CodeVariant::Math {
+                metadata: Some("math".to_string()),
             },
-            contents: MatchReplace {
-                matcher: Matcher::Any { explicit: false },
-                replacement: None,
-            },
+            value: "x = 1".to_string(),
         };
 
-        let code_block = CodeBlock {
-            variant: CodeVariant::Code(Some(CodeOpts {
-                language: "rust".to_string(),
+        let result = CodeBlockSelector::from(CodeBlockMatcher {
+            language: MatchReplace::match_any(),
+            contents: MatchReplace::match_any(),
+        })
+        .try_select(&MdContext::default(), math_block.clone())
+        .unwrap();
+
+        assert_eq!(result, Select::Miss(MdElem::CodeBlock(math_block)));
+    }
+
+    fn new_code_block(content: &str, language: Option<&str>) -> CodeBlock {
+        CodeBlock {
+            variant: CodeVariant::Code(language.map(|lang| CodeOpts {
+                language: lang.to_string(),
                 metadata: None,
             })),
-            value: "fn main() {}".to_string(),
-        };
-
-        let code_block_selector = CodeBlockSelector::from(code_block_matcher);
-
-        assert_eq!(
-            code_block_selector.matches(&code_block),
-            Err(StringMatchError::NotSupported)
-        );
-
-        assert_eq!(
-            code_block_selector
-                .try_select(&MdContext::default(), code_block)
-                .unwrap_err()
-                .to_string(),
-            "code block selector does not support string replace"
-        );
+            value: content.to_string(),
+        }
     }
 }

--- a/src/select/sel_link_like.rs
+++ b/src/select/sel_link_like.rs
@@ -1,40 +1,8 @@
 use crate::md_elem::elem::*;
 use crate::md_elem::MdContext;
-use crate::select::string_matcher::{StringMatchError, StringMatcher};
+use crate::select::match_selector::make_select_result;
+use crate::select::string_matcher::StringMatcher;
 use crate::select::{LinklikeMatcher, Result, Select, TrySelector};
-
-/// A macro for creating the result of a link-like selector.
-///
-/// This macro handles the common pattern of conditionally reconstructing a link-like item
-/// (Link or Image) based on whether both text and URL matching succeed. It
-/// handles the URL replacement logic, calling either `do_replace()` or `no_replace()` on
-/// the URL match result depending on whether this should be a Hit or Miss.
-///
-/// # Parameters
-///
-/// * `$text_matched` - A boolean expression indicating whether the display / alt text matched
-/// * `$url_match` - An identifier bound to a `StringMatch` result from URL matching
-/// * `$item_expr` - A block containing the item construction expression, where `$url_match`
-///   will be bound to the appropriate URL string value
-///
-/// # Returns
-///
-/// Returns `Result<Select>` where:
-/// - `Ok(Select::Hit(...))` if both text and URL matched (uses `do_replace()`)
-/// - `Ok(Select::Miss(...))` if either text or URL didn't match (uses `no_replace()`)
-macro_rules! make_result {
-    ($text_matched:expr, $url_match:ident, { $($item_expr:tt)* }) => {
-        if $text_matched && $url_match.is_match() {
-            let $url_match = $url_match.do_replace();
-            let item = $($item_expr)*;
-            Ok(Select::Hit(vec![item.into()]))
-        } else {
-            let $url_match = $url_match.no_replace();
-            let item = $($item_expr)*;
-            Ok(Select::Miss(item.into()))
-        }
-    };
-}
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct LinkSelector {
@@ -49,53 +17,66 @@ impl From<LinklikeMatcher> for LinkSelector {
 
 impl TrySelector<Link> for LinkSelector {
     fn try_select(&self, _: &MdContext, item: Link) -> Result<Select> {
-        // Check if display matcher has replacement - if so, this should fail
-        if self.matchers.display_matcher.has_replacement() {
-            return Err(StringMatchError::NotSupported.to_select_error("hyperlink"));
-        }
-
         match item {
             Link::Standard(standard_link) => {
-                let display_matched = self
+                let original_link = Link::Standard(standard_link.clone());
+
+                let display_replaced = self
                     .matchers
                     .display_matcher
-                    .matches_inlines(&standard_link.display)
+                    .match_replace_inlines(standard_link.display)
                     .map_err(|e| e.to_select_error("hyperlink"))?;
-                let url_match = self
+                let url_replaced = self
                     .matchers
                     .url_matcher
-                    .match_replace(standard_link.link.url)
+                    .match_replace_string(standard_link.link.url)
                     .map_err(|e| e.to_select_error("hyperlink"))?;
 
-                make_result!(display_matched, url_match, {
-                    Link::Standard(StandardLink {
-                        display: standard_link.display,
+                // Both matchers must match for this to be a Hit
+                let both_matched = display_replaced.matched_any && url_replaced.matched_any;
+
+                if both_matched {
+                    // Apply replacements
+                    let result = Link::Standard(StandardLink {
+                        display: display_replaced.item,
                         link: LinkDefinition {
-                            url: url_match,
+                            url: url_replaced.item,
                             title: standard_link.link.title,
                             reference: standard_link.link.reference,
                         },
-                    })
-                })
+                    });
+                    Ok(Select::Hit(vec![result.into()]))
+                } else {
+                    // Return original unchanged
+                    Ok(Select::Miss(original_link.into()))
+                }
             }
             Link::Autolink(autolink) => {
-                let display_matched = self
+                let original_link = Link::Autolink(autolink.clone());
+
+                let display_replaced = self
                     .matchers
                     .display_matcher
-                    .matches(&autolink.url)
+                    .match_replace_string(autolink.url.clone())
                     .map_err(|e| e.to_select_error("hyperlink"))?;
-                let url_match = self
+                let url_replaced = self
                     .matchers
                     .url_matcher
-                    .match_replace(autolink.url)
+                    .match_replace_string(autolink.url)
                     .map_err(|e| e.to_select_error("hyperlink"))?;
 
-                make_result!(display_matched, url_match, {
+                // Both matchers must match for this to be a Hit
+                let both_matched = display_replaced.matched_any && url_replaced.matched_any;
+
+                let result = if both_matched {
                     Link::Autolink(Autolink {
-                        url: url_match,
+                        url: url_replaced.item,
                         style: autolink.style,
                     })
-                })
+                } else {
+                    original_link
+                };
+                Ok(make_select_result(result, both_matched))
             }
         }
     }
@@ -114,32 +95,34 @@ impl From<LinklikeMatcher> for ImageSelector {
 
 impl TrySelector<Image> for ImageSelector {
     fn try_select(&self, _: &MdContext, item: Image) -> Result<Select> {
-        // Check if display matcher has replacement - if so, this should fail
-        if self.matchers.display_matcher.has_replacement() {
-            return Err(StringMatchError::NotSupported.to_select_error("image"));
-        }
+        let original_image = item.clone();
 
-        let alt_matched = self
+        let alt_replaced = self
             .matchers
             .display_matcher
-            .matches(&item.alt)
+            .match_replace_string(item.alt)
             .map_err(|e| e.to_select_error("image"))?;
-        let url_match = self
+        let url_replaced = self
             .matchers
             .url_matcher
-            .match_replace(item.link.url)
+            .match_replace_string(item.link.url)
             .map_err(|e| e.to_select_error("image"))?;
 
-        make_result!(alt_matched, url_match, {
+        let both_matched = alt_replaced.matched_any && url_replaced.matched_any;
+
+        let result = if both_matched {
             Image {
-                alt: item.alt,
+                alt: alt_replaced.item,
                 link: LinkDefinition {
-                    url: url_match,
+                    url: url_replaced.item,
                     title: item.link.title,
                     reference: item.link.reference,
                 },
             }
-        })
+        } else {
+            original_image
+        };
+        Ok(make_select_result(result, both_matched))
     }
 }
 
@@ -162,25 +145,14 @@ impl From<LinklikeMatcher> for LinkMatchers {
 mod test {
     use super::*;
     use crate::md_elem::{mdq_inline, MdElem};
-    use crate::select::{MatchReplace, Matcher};
+    use crate::select::MatchReplace;
     use crate::util::utils_for_test::unwrap;
 
     #[test]
     fn link_selector_url_replacement() {
         let link_matcher = LinklikeMatcher {
-            display_matcher: MatchReplace {
-                matcher: Matcher::Any { explicit: false },
-                replacement: None,
-            },
-            url_matcher: MatchReplace {
-                matcher: Matcher::Text {
-                    case_sensitive: false,
-                    anchor_start: false,
-                    text: "original.com".to_string(),
-                    anchor_end: false,
-                },
-                replacement: Some("newsite.com".to_string()),
-            },
+            display_matcher: MatchReplace::match_any(),
+            url_matcher: MatchReplace::build(|b| b.match_regex("original.com").replacement("newsite.com")),
         };
 
         let link = Link::Standard(StandardLink {
@@ -208,19 +180,8 @@ mod test {
     #[test]
     fn image_selector_url_replacement() {
         let image_matcher = LinklikeMatcher {
-            display_matcher: MatchReplace {
-                matcher: Matcher::Any { explicit: false },
-                replacement: None,
-            },
-            url_matcher: MatchReplace {
-                matcher: Matcher::Text {
-                    case_sensitive: false,
-                    anchor_start: false,
-                    text: "old-image.png".to_string(),
-                    anchor_end: false,
-                },
-                replacement: Some("new-image.png".to_string()),
-            },
+            display_matcher: MatchReplace::match_any(),
+            url_matcher: MatchReplace::build(|b| b.match_regex("old-image.png").replacement("new-image.png")),
         };
 
         let image = Image {
@@ -244,24 +205,8 @@ mod test {
     #[test]
     fn image_url_replaced_but_alt_does_not_match() {
         let image_matcher = LinklikeMatcher {
-            display_matcher: MatchReplace {
-                matcher: Matcher::Text {
-                    case_sensitive: false,
-                    anchor_start: true,
-                    text: "wrong alt text".to_string(),
-                    anchor_end: true,
-                },
-                replacement: None,
-            },
-            url_matcher: MatchReplace {
-                matcher: Matcher::Text {
-                    case_sensitive: false,
-                    anchor_start: false,
-                    text: "old-image.png".to_string(),
-                    anchor_end: false,
-                },
-                replacement: Some("new-image.png".to_string()),
-            },
+            display_matcher: MatchReplace::build(|b| b.match_regex("^wrong alt text$")),
+            url_matcher: MatchReplace::build(|b| b.match_regex("old-image.png").replacement("new-image.png")),
         };
 
         let original_image = Image {
@@ -285,24 +230,8 @@ mod test {
     #[test]
     fn link_url_replaced_but_display_does_not_match() {
         let link_matcher = LinklikeMatcher {
-            display_matcher: MatchReplace {
-                matcher: Matcher::Text {
-                    case_sensitive: false,
-                    anchor_start: true,
-                    text: "wrong display text".to_string(),
-                    anchor_end: true,
-                },
-                replacement: None,
-            },
-            url_matcher: MatchReplace {
-                matcher: Matcher::Text {
-                    case_sensitive: false,
-                    anchor_start: false,
-                    text: "original.com".to_string(),
-                    anchor_end: false,
-                },
-                replacement: Some("newsite.com".to_string()),
-            },
+            display_matcher: MatchReplace::build(|b| b.match_regex("^wrong display text$")),
+            url_matcher: MatchReplace::build(|b| b.match_regex("original.com").replacement("newsite.com")),
         };
 
         let original_link = Link::Standard(StandardLink {
@@ -321,5 +250,58 @@ mod test {
         unwrap!(&elem, MdElem::Inline(Inline::Link(result_link)));
 
         assert_eq!(result_link, &original_link);
+    }
+
+    #[test]
+    fn link_display_text_replacement() {
+        let link_matcher = LinklikeMatcher {
+            display_matcher: MatchReplace::build(|b| b.match_regex("old text").replacement("new text")),
+            url_matcher: MatchReplace::match_any(),
+        };
+
+        let link = Link::Standard(StandardLink {
+            display: vec![mdq_inline!("old text here")],
+            link: LinkDefinition {
+                url: "https://example.com".to_string(),
+                title: None,
+                reference: LinkReference::Inline,
+            },
+        });
+
+        let link_selector = LinkSelector::from(link_matcher);
+
+        let result = link_selector.try_select(&MdContext::default(), link);
+        unwrap!(result, Ok(Select::Hit(elems)));
+
+        assert_eq!(elems.len(), 1);
+        unwrap!(&elems[0], MdElem::Inline(Inline::Link(Link::Standard(standard_link))));
+        assert_eq!(standard_link.display, vec![mdq_inline!("new text here")]);
+        assert_eq!(standard_link.link.url, "https://example.com");
+    }
+
+    #[test]
+    fn image_alt_text_replacement() {
+        let image_matcher = LinklikeMatcher {
+            display_matcher: MatchReplace::build(|b| b.match_regex("old alt").replacement("new alt")),
+            url_matcher: MatchReplace::match_any(),
+        };
+
+        let image = Image {
+            alt: "old alt text".to_string(),
+            link: LinkDefinition {
+                url: "https://example.com/image.png".to_string(),
+                title: None,
+                reference: LinkReference::Inline,
+            },
+        };
+
+        let image_selector = ImageSelector::from(image_matcher);
+
+        let result = image_selector.try_select(&MdContext::default(), image);
+        unwrap!(result, Ok(Select::Hit(elems)));
+        assert_eq!(elems.len(), 1);
+        unwrap!(&elems[0], MdElem::Inline(Inline::Image(modified_image)));
+        assert_eq!(modified_image.alt, "new alt text");
+        assert_eq!(modified_image.link.url, "https://example.com/image.png");
     }
 }

--- a/src/select/sel_list_item.rs
+++ b/src/select/sel_list_item.rs
@@ -1,5 +1,6 @@
 use crate::md_elem::elem::List;
 use crate::md_elem::{MdContext, MdElem};
+use crate::select::match_selector::make_select_result;
 use crate::select::string_matcher::StringMatcher;
 use crate::select::{ListItemMatcher, ListItemTask, Result, Select, TrySelector};
 
@@ -46,21 +47,25 @@ impl TrySelector<List> for ListItemSelector {
         // - Otherwise, never match, but return an MdElem::Doc of the list items, each as its own list.
         //   That way, the find_children code in api.rs will recurse back into this method for each of those items, but
         //   as a single-item list for the base case.
-        let List { starting_index, items } = item;
-        match items.as_slice() {
+        let List {
+            starting_index,
+            mut items,
+        } = item;
+        match items.as_mut_slice() {
             [li] => {
-                let matched = self.li_type.matches(&starting_index)
-                    && task_matches(self.checkbox, li.checked)
-                    && self
-                        .string_matcher
-                        .matches_any(&li.item)
-                        .map_err(|e| e.to_select_error("list item"))?;
+                let (matched, items) =
+                    if !(self.li_type.matches(&starting_index) && task_matches(self.checkbox, li.checked)) {
+                        (false, items)
+                    } else {
+                        let mut replacement = self
+                            .string_matcher
+                            .match_replace_any(std::mem::take(&mut li.item))
+                            .map_err(|e| e.to_select_error("list item"))?;
+                        std::mem::swap(&mut replacement.item, &mut li.item);
+                        (replacement.matched_any, items)
+                    };
                 let list = MdElem::List(List { starting_index, items });
-                if matched {
-                    Ok(Select::Hit(vec![list]))
-                } else {
-                    Ok(Select::Miss(list))
-                }
+                Ok(make_select_result(list, matched))
             }
             _ => {
                 let mut idx = starting_index;
@@ -86,5 +91,75 @@ impl ListItemType {
             ListItemType::Ordered => idx.is_some(),
             ListItemType::Unordered => idx.is_none(),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::md_elem::elem::{ListItem, Paragraph};
+    use crate::md_elem::{inlines, md_elem};
+    use crate::select::{MatchReplace, Matcher, Regex};
+
+    #[test]
+    fn regex_match_matches() {
+        let original = list("hello, world");
+        let result = li_selector("hello", None)
+            .try_select(&MdContext::empty(), original)
+            .unwrap();
+        assert_eq!(result, Select::Hit(vec![MdElem::List(list("hello, world"))]));
+    }
+
+    #[test]
+    fn regex_match_no_match() {
+        let original = list("hello, world");
+        let result = li_selector("goodbye", None)
+            .try_select(&MdContext::empty(), original)
+            .unwrap();
+        assert_eq!(result, Select::Miss(MdElem::List(list("hello, world"))));
+    }
+
+    #[test]
+    fn regex_replace_matches() {
+        let original = list("hello, world");
+        let result = li_selector("hello", Some("Hi there"))
+            .try_select(&MdContext::empty(), original)
+            .unwrap();
+        assert_eq!(result, Select::Hit(vec![MdElem::List(list("Hi there, world"))]));
+    }
+
+    #[test]
+    fn regex_replace_no_match() {
+        let original = list("hello, world");
+        let result = li_selector("goodbye", Some("Hi there"))
+            .try_select(&MdContext::empty(), original)
+            .unwrap();
+        assert_eq!(result, Select::Miss(MdElem::List(list("hello, world"))));
+    }
+
+    fn list(contents: &str) -> List {
+        List {
+            starting_index: None,
+            items: vec![ListItem {
+                checked: None,
+                item: vec![md_elem!(Paragraph {
+                    body: inlines!(text[contents])
+                })],
+            }],
+        }
+    }
+
+    fn li_selector(pattern: &str, replacement: Option<&str>) -> ListItemSelector {
+        let matcher = ListItemMatcher {
+            ordered: false,
+            task: ListItemTask::None,
+            matcher: MatchReplace {
+                matcher: Matcher::Regex(Regex {
+                    re: fancy_regex::Regex::new(pattern).unwrap(),
+                }),
+                replacement: replacement.map(String::from),
+            },
+        };
+        ListItemSelector::from(matcher)
     }
 }

--- a/src/select/sel_section.rs
+++ b/src/select/sel_section.rs
@@ -1,7 +1,8 @@
 use crate::md_elem::elem::*;
-use crate::select::match_selector::MatchSelector;
-use crate::select::string_matcher::{StringMatchError, StringMatcher};
-use crate::select::SectionMatcher;
+use crate::md_elem::MdContext;
+use crate::select::match_selector::make_select_result;
+use crate::select::string_matcher::StringMatcher;
+use crate::select::{SectionMatcher, Select, TrySelector};
 
 #[derive(Debug, PartialEq)]
 pub(crate) struct SectionSelector {
@@ -16,49 +17,148 @@ impl From<SectionMatcher> for SectionSelector {
     }
 }
 
-impl MatchSelector<Section> for SectionSelector {
-    const NAME: &'static str = "section";
-
-    fn matches(&self, section: &Section) -> Result<bool, StringMatchError> {
-        self.matcher.matches_inlines(&section.title)
+impl TrySelector<Section> for SectionSelector {
+    fn try_select(&self, _: &MdContext, item: Section) -> crate::select::Result<Select> {
+        match self.matcher.match_replace_inlines(item.title) {
+            Ok(replacements) => {
+                let result = Section {
+                    title: replacements.item,
+                    depth: item.depth,
+                    body: item.body,
+                };
+                Ok(make_select_result(result, replacements.matched_any))
+            }
+            Err(err) => Err(err.to_select_error("section")),
+        }
     }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
-    use crate::select::{MatchReplace, Matcher, SelectError};
+    use crate::md_elem::{inlines, MdElem};
+    use crate::select::{MatchReplace, SelectError};
 
     #[test]
-    fn section_selector_match_error() {
-        use crate::md_elem::MdContext;
-        use crate::select::TrySelector;
-
+    fn section_replacement_matches_on_title() {
         let section_matcher = SectionMatcher {
-            title: MatchReplace {
-                matcher: Matcher::Text {
-                    case_sensitive: false,
-                    anchor_start: false,
-                    text: "test".to_string(),
-                    anchor_end: false,
-                },
-                replacement: Some("replacement".to_string()),
-            },
+            title: MatchReplace::build(|b| b.match_regex("Some").replacement("Great")),
         };
 
         let section = Section {
             depth: 1,
-            title: vec![],
+            title: inlines!["Some title, Some section!"],
             body: vec![],
         };
 
         let section_selector = SectionSelector::from(section_matcher);
-
-        assert_eq!(section_selector.matches(&section), Err(StringMatchError::NotSupported));
+        let replaced = section_selector.try_select(&MdContext::default(), section).unwrap();
 
         assert_eq!(
-            section_selector.try_select(&MdContext::default(), section).unwrap_err(),
-            SelectError::new("section selector does not support string replace"),
+            replaced,
+            Select::Hit(vec![MdElem::Section(Section {
+                depth: 1,
+                title: inlines!["Great title, Great section!"],
+                body: vec![],
+            })]),
+        );
+    }
+
+    #[test]
+    fn section_replacement_misses_on_title() {
+        let section_matcher = SectionMatcher {
+            title: MatchReplace::build(|b| b.match_regex("Unmatched").replacement("Great")),
+        };
+
+        let section = Section {
+            depth: 1,
+            title: inlines!["Some title, Some section!"],
+            body: vec![],
+        };
+
+        let section_selector = SectionSelector::from(section_matcher);
+        let replaced = section_selector.try_select(&MdContext::default(), section).unwrap();
+
+        assert_eq!(
+            replaced,
+            Select::Miss(MdElem::Section(Section {
+                depth: 1,
+                title: inlines!["Some title, Some section!"],
+                body: vec![],
+            })),
+        );
+    }
+
+    #[test]
+    fn section_replacement_invalid_on_title() {
+        let section_matcher = SectionMatcher {
+            title: MatchReplace::build(|b| b.match_regex("crosses boundary").replacement("Broken")),
+        };
+
+        let section = Section {
+            depth: 1,
+            title: inlines!["crosses ", link["boundary"]("https://example.com")],
+            body: vec![],
+        };
+
+        let section_selector = SectionSelector::from(section_matcher);
+        let replaced = section_selector.try_select(&MdContext::default(), section);
+
+        assert_eq!(
+            replaced,
+            Err(SelectError::new(
+                "regex replacement error in section selector: replacement crosses atomic boundary"
+            ))
+        );
+    }
+
+    #[test]
+    fn section_regex_matches() {
+        let section_matcher = SectionMatcher {
+            title: MatchReplace::build(|b| b.match_regex("Great")),
+        };
+
+        let section = Section {
+            depth: 1,
+            title: inlines!["Great title, Great section!"],
+            body: vec![],
+        };
+
+        let section_selector = SectionSelector::from(section_matcher);
+        let replaced = section_selector.try_select(&MdContext::default(), section).unwrap();
+
+        assert_eq!(
+            replaced,
+            Select::Hit(vec![MdElem::Section(Section {
+                depth: 1,
+                title: inlines!["Great title, Great section!"],
+                body: vec![],
+            })]),
+        );
+    }
+
+    #[test]
+    fn section_regex_doesnt_match() {
+        let section_matcher = SectionMatcher {
+            title: MatchReplace::build(|b| b.match_regex("Awesome")),
+        };
+
+        let section = Section {
+            depth: 1,
+            title: inlines!["Great title, Great section!"],
+            body: vec![],
+        };
+
+        let section_selector = SectionSelector::from(section_matcher);
+        let replaced = section_selector.try_select(&MdContext::default(), section).unwrap();
+
+        assert_eq!(
+            replaced,
+            Select::Miss(MdElem::Section(Section {
+                depth: 1,
+                title: inlines!["Great title, Great section!"],
+                body: vec![],
+            })),
         );
     }
 }

--- a/src/select/sel_table.rs
+++ b/src/select/sel_table.rs
@@ -1,4 +1,5 @@
-use crate::md_elem::elem::Table;
+use crate::md_elem::elem::{Table, TableCell, TableRow};
+use crate::md_elem::inline_regex_replace::Replaced;
 use crate::md_elem::*;
 use crate::select::string_matcher::StringMatcher;
 use crate::select::{Result, Select, TableMatcher, TrySelector};
@@ -15,21 +16,101 @@ impl TrySelector<Table> for TableSelector {
 
         table.normalize();
 
-        table
-            .retain_columns_by_header(|line| self.headers_matcher.matches_inlines(line))
-            .map_err(|e| e.to_select_error("table"))?;
-        if table.is_empty() {
-            return Ok(Select::Miss(orig.into()));
+        let selected = match self.replace_table(table)? {
+            None => Select::Miss(orig.into()),
+            Some(replaced) => Select::Hit(vec![replaced.into()]),
+        };
+        Ok(selected)
+    }
+}
+
+type ReplacementCell = Replaced<TableCell>;
+
+struct ReplacementRow {
+    row: Vec<ReplacementCell>,
+}
+
+impl ReplacementRow {
+    fn any_cell_matched(&self) -> bool {
+        self.row.iter().any(|cell| cell.matched_any)
+    }
+
+    fn into_row(self, allowed_cells: &[bool]) -> TableRow {
+        self.row
+            .into_iter()
+            .enumerate()
+            .filter_map(|(idx, cell)| {
+                if allowed_cells.get(idx).copied().unwrap_or(false) {
+                    Some(cell.item)
+                } else {
+                    None
+                }
+            })
+            .collect()
+    }
+}
+
+impl TableSelector {
+    fn replace_table(&self, table: Table) -> Result<Option<Table>> {
+        let row_count = table.rows.len();
+        let mut rows_iter = table.rows.into_iter();
+
+        let Some(header_row) = rows_iter.next() else {
+            return Ok(Some(Table {
+                alignments: table.alignments,
+                rows: vec![],
+            }));
+        };
+        let header_replacement = Self::replace_row(&self.headers_matcher, header_row)?;
+        if !header_replacement.any_cell_matched() {
+            return Ok(None);
         }
 
-        table
-            .retain_rows(|line| self.rows_matcher.matches_inlines(line))
-            .map_err(|e| e.to_select_error("table"))?;
-        if table.is_empty() {
-            return Ok(Select::Miss(orig.into()));
+        let mut rows = Vec::with_capacity(row_count);
+
+        let indexes_to_keep: Vec<_> = header_replacement.row.iter().map(|item| item.matched_any).collect();
+        rows.push(header_replacement.into_row(&indexes_to_keep));
+
+        let alignments = table
+            .alignments
+            .into_iter()
+            .enumerate()
+            .filter_map(|(idx, item)| {
+                if indexes_to_keep.get(idx).copied().unwrap_or(false) {
+                    Some(item)
+                } else {
+                    None
+                }
+            })
+            .collect();
+
+        if rows_iter.len() == 0 {
+            // No content rows, so just return a hit of the header rows. We don't expect this to happen, though.
+            return Ok(Some(Table { alignments, rows }));
+        }
+        for row in rows_iter {
+            let replaced_row = Self::replace_row(&self.rows_matcher, row)?;
+            if replaced_row.any_cell_matched() {
+                let replaced_row = replaced_row.into_row(&indexes_to_keep);
+                rows.push(replaced_row);
+            }
         }
 
-        Ok(Select::Hit(vec![table.into()]))
+        if rows.len() == 1 {
+            // header always matches, but do we have any content rows?
+            return Ok(None);
+        }
+
+        Ok(Some(Table { alignments, rows }))
+    }
+
+    fn replace_row(matcher: &StringMatcher, row: TableRow) -> Result<ReplacementRow> {
+        let replacement_cells: Vec<ReplacementCell> = row
+            .into_iter()
+            .map(|cell| matcher.match_replace_inlines(cell))
+            .collect::<core::result::Result<Vec<_>, _>>()
+            .map_err(|e| e.to_select_error("table"))?;
+        Ok(ReplacementRow { row: replacement_cells })
     }
 }
 
@@ -47,11 +128,11 @@ mod tests {
     use super::*;
 
     use crate::md_elem::elem::*;
-    use crate::select::TrySelector;
+    use crate::select::{MatchReplace, TrySelector};
     use crate::util::utils_for_test::*;
 
     #[test]
-    fn select_all_on_normalized_table() {
+    fn regex_matches_all_on_normalized_table() {
         let table: Table = Table {
             alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
             rows: vec![
@@ -84,7 +165,7 @@ mod tests {
     }
 
     #[test]
-    fn select_columns_on_normalized_table() {
+    fn regex_matches_columns_on_normalized_table() {
         let table: Table = Table {
             alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
             rows: vec![
@@ -108,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn select_rows_on_normalized_table() {
+    fn regex_matches_rows_on_normalized_table() {
         let table: Table = Table {
             alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
             rows: vec![
@@ -174,6 +255,190 @@ mod tests {
                 vec![cell("data 1 a"), cell("data 1 b"), Vec::new()],
             ]
         );
+    }
+
+    #[test]
+    fn matcher_matches_no_columns() {
+        let table: Table = Table {
+            alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
+            rows: vec![
+                vec![cell("header a"), cell("header b")],
+                vec![cell("data 1 a"), cell("data 1 b")],
+                vec![cell("data 2 a"), cell("data 2 b")],
+            ],
+        };
+        let selection = TableSelector {
+            headers_matcher: "NOMATCH".into(), // This won't match any headers
+            rows_matcher: ".*".into(),
+        }
+        .try_select(&MdContext::empty(), table.clone())
+        .unwrap();
+
+        unwrap!(selection, Select::Miss(MdElem::Table(returned_table)));
+        // Should return the original table unchanged
+        assert_eq!(returned_table, table);
+    }
+
+    #[test]
+    fn matcher_matches_no_rows() {
+        let table: Table = Table {
+            alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
+            rows: vec![
+                vec![cell("header a"), cell("header b")],
+                vec![cell("data 1 a"), cell("data 1 b")],
+                vec![cell("data 2 a"), cell("data 2 b")],
+            ],
+        };
+        let selection = TableSelector {
+            headers_matcher: ".*".into(),   // This matches all headers
+            rows_matcher: "NOMATCH".into(), // This won't match any data rows
+        }
+        .try_select(&MdContext::empty(), table.clone())
+        .unwrap();
+
+        unwrap!(selection, Select::Miss(MdElem::Table(returned_table)));
+        // Should return the original table unchanged
+        assert_eq!(returned_table, table);
+    }
+
+    #[test]
+    fn regex_replace_on_column_header() {
+        let table: Table = Table {
+            alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
+            rows: vec![
+                vec![cell("header a"), cell("header b")],
+                vec![cell("data 1 a"), cell("data 1 b")],
+                vec![cell("data 2 a"), cell("data 2 b")],
+            ],
+        };
+        let selection = TableSelector::from(TableMatcher {
+            headers: MatchReplace::build(|b| b.match_regex(" *header *").replacement("")),
+            rows: MatchReplace::match_any(),
+        })
+        .try_select(&MdContext::empty(), table)
+        .unwrap();
+
+        unwrap!(selection, Select::Hit(elems));
+        let table_elem = get_only(elems);
+        unwrap!(table_elem, MdElem::Table(result_table));
+
+        // Should replace "old header" with "new header"
+        assert_eq!(
+            result_table.rows(),
+            &vec![
+                vec![cell("a"), cell("b")],
+                vec![cell("data 1 a"), cell("data 1 b")],
+                vec![cell("data 2 a"), cell("data 2 b")],
+            ]
+        );
+    }
+
+    #[test]
+    fn regex_replace_on_row() {
+        let table: Table = Table {
+            alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
+            rows: vec![
+                vec![cell("header a"), cell("header b")],
+                vec![cell("old data"), cell("data 1 b")],
+                vec![cell("data 2 a"), cell("old data")],
+            ],
+        };
+        let selection = TableSelector::from(TableMatcher {
+            headers: MatchReplace::match_any(),
+            rows: MatchReplace::build(|b| b.match_regex("old").replacement("new")),
+        })
+        .try_select(&MdContext::empty(), table)
+        .unwrap();
+
+        unwrap!(selection, Select::Hit(elems));
+        let table_elem = get_only(elems);
+        unwrap!(table_elem, MdElem::Table(result_table));
+
+        // Should replace "old data" with "new data" in rows
+        assert_eq!(
+            result_table.rows(),
+            &vec![
+                vec![cell("header a"), cell("header b")],
+                vec![cell("new data"), cell("data 1 b")],
+                vec![cell("data 2 a"), cell("new data")],
+            ]
+        );
+    }
+
+    #[test]
+    fn regex_replace_on_both_header_and_row() {
+        let table: Table = Table {
+            alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
+            rows: vec![
+                vec![cell("header a"), cell("header b")],
+                vec![cell("old data"), cell("data 1 b")],
+                vec![cell("data 2 a"), cell("old data")],
+            ],
+        };
+        let selection = TableSelector::from(TableMatcher {
+            headers: MatchReplace::build(|b| b.match_regex("header (.*)").replacement(">$1<")),
+            rows: MatchReplace::build(|b| b.match_regex("old").replacement("new")),
+        })
+        .try_select(&MdContext::empty(), table)
+        .unwrap();
+
+        unwrap!(selection, Select::Hit(elems));
+        let table_elem = get_only(elems);
+        unwrap!(table_elem, MdElem::Table(result_table));
+
+        // Should replace "old" with "NEW" in headers and "new" in rows
+        assert_eq!(
+            result_table.rows(),
+            &vec![
+                vec![cell(">a<"), cell(">b<")],
+                vec![cell("new data"), cell("data 1 b")],
+                vec![cell("data 2 a"), cell("new data")],
+            ]
+        );
+    }
+
+    #[test]
+    fn regex_replace_on_column_header_no_matches() {
+        let table: Table = Table {
+            alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
+            rows: vec![
+                vec![cell("header a"), cell("header b")],
+                vec![cell("data 1 a"), cell("data 1 b")],
+                vec![cell("data 2 a"), cell("data 2 b")],
+            ],
+        };
+        let selection = TableSelector::from(TableMatcher {
+            headers: MatchReplace::build(|b| b.match_regex("NOMATCH").replacement("replacement")),
+            rows: MatchReplace::match_any(),
+        })
+        .try_select(&MdContext::empty(), table.clone())
+        .unwrap();
+
+        // Should return Miss since no headers match the pattern
+        unwrap!(selection, Select::Miss(MdElem::Table(returned_table)));
+        assert_eq!(returned_table, table);
+    }
+
+    #[test]
+    fn regex_replace_on_row_no_matches() {
+        let table: Table = Table {
+            alignments: vec![Some(ColumnAlignment::Left), Some(ColumnAlignment::Right)],
+            rows: vec![
+                vec![cell("header a"), cell("header b")],
+                vec![cell("data 1 a"), cell("data 1 b")],
+                vec![cell("data 2 a"), cell("data 2 b")],
+            ],
+        };
+        let selection = TableSelector::from(TableMatcher {
+            headers: MatchReplace::match_any(),
+            rows: MatchReplace::build(|b| b.match_regex("NOMATCH").replacement("replacement")),
+        })
+        .try_select(&MdContext::empty(), table.clone())
+        .unwrap();
+
+        // Should return Miss since no rows match the pattern
+        unwrap!(selection, Select::Miss(MdElem::Table(returned_table)));
+        assert_eq!(returned_table, table);
     }
 
     fn cell(cell_str: &str) -> TableCell {

--- a/tests/md_cases/search_replace.toml
+++ b/tests/md_cases/search_replace.toml
@@ -11,7 +11,7 @@ original code content here
 Here are some list items:
 
 - Item with **bold text** formatting
-- Item with *emphasis and **nested bold*** formatting
+- Item with _emphasis and **nested bold**_ formatting
 - ![original image alt](https://example.com/original/image.png) description
 - [original link text](https://example.com/original/page.html) description
 '''
@@ -20,45 +20,51 @@ Here are some list items:
 needed = false
 
 [expect."search-replace section title"]
-cli_args = ['# !s/Original/New/']
-expect_success = false
-output = ''
-output_err = '''Selection error:
-section selector does not support string replace
+cli_args = ['--link-format', 'keep', '# !s/Original/New/']
+output = '''
+# New Title
+
+This is a paragraph with text.
+
+```original-language
+original code content here
+```
+
+Here are some list items:
+
+- Item with **bold text** formatting
+- Item with _emphasis and **nested bold**_ formatting
+- ![original image alt](https://example.com/original/image.png) description
+- [original link text](https://example.com/original/page.html) description
 '''
 
 [expect."search-replace code block language"]
-cli_args = ['``` !s/original-.*/python/']
-expect_success = false
-output = ''
-output_err = '''Selection error:
-code block selector does not support string replace
+cli_args = ['```!s/original-.*/python/']
+output = '''
+```python
+original code content here
+```
 '''
 
 [expect."search-replace code block contents"]
 cli_args = ['``` !s/original/new/']
-expect_success = false
-output = ''
-output_err = '''Selection error:
-code block selector does not support string replace
+output = '''
+```original-language
+new code content here
+```
 '''
 
 [expect."search-replace image alt text"]
 cli_args = ['![ !s/original/new/ ]()']
-expect_success = false
-output = ''
-output_err = '''Selection error:
-image selector does not support string replace
+output = '''![new image alt][1]
+
+[1]: https://example.com/original/image.png
 '''
 
 [expect."search-replace image alt text with non-matching"]
-# Even though there's no match, it should still error. The error shouldn't have anything to do with the target Markdown.
 cli_args = ['![ !s/BOGUS/new/ ]()']
 expect_success = false
 output = ''
-output_err = '''Selection error:
-image selector does not support string replace
-'''
 
 [expect."search-replace image url"]
 cli_args = ['![](!s/original/new/)']
@@ -69,10 +75,9 @@ output = '''![original image alt][1]
 
 [expect."search-replace link text"]
 cli_args = ['[ !s/original/new/ ]()']
-expect_success = false
-output = ''
-output_err = '''Selection error:
-hyperlink selector does not support string replace
+output = '''[new link text][1]
+
+[1]: https://example.com/original/page.html
 '''
 
 [expect."search-replace link url"]
@@ -84,24 +89,19 @@ output = '''[original link text][1]
 
 [expect."search-replace straightforward formatting"]
 cli_args = ['- !s/bold/strong/']
-expect_success = false
-output = ''
-output_err = '''Selection error:
-list item selector does not support string replace
+output = '''- Item with **strong text** formatting
+
+   -----
+
+- Item with _emphasis and **nested strong**_ formatting
 '''
 
 [expect."search-replace nested formatting"]
-cli_args = ['- !s/and nested/and formerly/']
-expect_success = false
-output = ''
-output_err = '''Selection error:
-list item selector does not support string replace
+cli_args = ['- !s/and nested /and formerly /']
+output = '''- Item with _emphasis and formerly **bold**_ formatting
 '''
 
 [expect."search-replace paragraph text"]
 cli_args = ['P: !s/paragraph/text/']
-expect_success = false
-output = ''
-output_err = '''Selection error:
-paragraph selector does not support string replace
+output = '''This is a text with text.
 '''


### PR DESCRIPTION
This uses the new flat_inlines (#402) to replace all of the string-matching that the selectors had previous had, with a new regex-replace functionality. Resolves #376.