### PR TITLE
check in help text, and add CI to verify it

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -119,6 +119,8 @@ jobs:
   help-text:
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - name: Generate help text

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -138,7 +138,7 @@ jobs:
           path: /tmp/mdq-binary-${{ github.job }}
 
       - name: Make binary executable
-        run: chmod +x /tmp/mdq-binary/mdq
+        run: chmod +x /tmp/mdq-binary-${{ github.job }}/mdq
 
       - name: Generate help text
         run: /tmp/mdq-binary-${{ github.job }}/mdq --help > help.txt

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -128,6 +128,8 @@ jobs:
     needs: build
     permissions:
       contents: read
+    env:
+      UNIQUE_PATH: ${{ github.run_id }}-${{ github.run_number }}-${{ github.run_attempt }}
     steps:
       - uses: actions/checkout@v4
 
@@ -135,13 +137,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: mdq-binary
-          path: /tmp/mdq-binary-${{ github.job }}
+          path: /tmp/mdq-binary-${{ env.UNIQUE_PATH }}
 
       - name: Make binary executable
-        run: chmod +x /tmp/mdq-binary-${{ github.job }}/mdq
+        run: chmod +x /tmp/mdq-binary-${{ env.UNIQUE_PATH }}/mdq
 
       - name: Generate help text
-        run: /tmp/mdq-binary-${{ github.job }}/mdq --help > help.txt
+        run: /tmp/mdq-binary-${{ env.UNIQUE_PATH }}/mdq --help > help.txt
       - name: Check help text is committed
         run: |
           if ! git diff --exit-code help.txt; then

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -115,3 +115,17 @@ jobs:
             echo "::error title=pub-vis::some items marked pub are not actually public"
             exit 1
           fi
+
+  help-text:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+      - name: Generate help text
+        run: cargo run -- --help > help.txt
+      - name: Check help text is committed
+        run: |
+          if ! git diff --exit-code help.txt; then
+            echo "::error title=help text::help.txt is out of date. Run 'cargo run -- --help > help.txt' and commit the result."
+            exit 1
+          fi

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -31,6 +31,13 @@ jobs:
           done <<<"$(git status --porcelain)"
           exit "$exit_code"
 
+      - name: Upload binary
+        uses: actions/upload-artifact@v4
+        with:
+          name: mdq-binary
+          path: target/debug/mdq
+          retention-days: 1
+
   check:
     strategy:
       matrix:
@@ -123,8 +130,18 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+
+      - name: Download binary
+        uses: actions/download-artifact@v4
+        with:
+          name: mdq-binary
+          path: /tmp/mdq-binary-${{ github.job }}
+
+      - name: Make binary executable
+        run: chmod +x /tmp/mdq-binary/mdq
+
       - name: Generate help text
-        run: cargo run -- --help > help.txt
+        run: /tmp/mdq-binary-${{ github.job }}/mdq --help > help.txt
       - name: Check help text is committed
         run: |
           if ! git diff --exit-code help.txt; then

--- a/help.txt
+++ b/help.txt
@@ -15,14 +15,13 @@ Arguments:
           
           If these are provided, standard input will not be used unless one of the arguments is "-". Files will be processed in the order you provide them. If you provide the same file twice, mdq will process it twice, unless that file is "-"; all but the first "-" paths are ignored.
 
-          This line is intentionally added as a test. A line within the --link-pos text has been intentionally removed.
-
 Options:
       --link-pos <LINK_POS>
           Where to put link references.
           
           For links and images of style `[description][1]`, this flag controls where to put the `[1]: https://example.com` definition.
 
+          Possible values:
           - section: Show link definitions in the first section that uses the link
           - doc:     Show link definitions at the bottom of the document
           

--- a/help.txt
+++ b/help.txt
@@ -1,0 +1,80 @@
+Select and render specific elements in a Markdown document
+
+Usage: mdq [OPTIONS] [selectors] [MARKDOWN_FILE_PATHS]...
+
+Arguments:
+  [selectors]
+          The selectors string
+
+  [MARKDOWN_FILE_PATHS]...
+          An optional list of Markdown files to parse, by path. If not provided, standard input will be used.
+          
+          If these are provided, mdq will act as if they were all concatenated into a single file. For example, if you use --link-pos=doc, the link definitions for all input files will be at the very end of the output.
+          
+          A path of "-" represents standard input.
+          
+          If these are provided, standard input will not be used unless one of the arguments is "-". Files will be processed in the order you provide them. If you provide the same file twice, mdq will process it twice, unless that file is "-"; all but the first "-" paths are ignored.
+
+          This line is intentionally added as a test. A line within the --link-pos text has been intentionally removed.
+
+Options:
+      --link-pos <LINK_POS>
+          Where to put link references.
+          
+          For links and images of style `[description][1]`, this flag controls where to put the `[1]: https://example.com` definition.
+
+          - section: Show link definitions in the first section that uses the link
+          - doc:     Show link definitions at the bottom of the document
+          
+          [default: section]
+
+      --footnote-pos <FOOTNOTE_POS>
+          Where to put footnote references. Defaults to be same as --link-pos
+
+          Possible values:
+          - section: Show link definitions in the first section that uses the link
+          - doc:     Show link definitions at the bottom of the document
+
+  -l, --link-format <LINK_FORMAT>
+          Possible values:
+          - keep:         Keep links as they were in the original
+          - inline:       Turn all links into inlined form: `[link text](https://example.com)`
+          - never-inline: Never output `[inline](https://example.com)` links[default: never-inline]
+
+      --renumber-footnotes <RENUMBER_FOOTNOTES>
+          [default: true]
+          [possible values: true, false]
+
+  -o, --output <OUTPUT>
+          Specifies the output format. Defaults to markdown
+
+          Possible values:
+          - markdown: Output results as Markdown
+          - md:       Alias for markdown
+          - json:     Output results as JSON. Spans of inline elements (like within a single paragraph) will be rendered as a single string of Markdown, not as separate JSON elements
+          - plain:    Outputs just the plain text. This retrains the spacing between paragraphs and paragraph-like blocks (code blocks, block quotes, etc.) but removes all other formating, including inline formatting. Links are rendered as just their display text, and footnotes are removed entirely
+          
+          [default: markdown]
+
+      --wrap-width <WRAP_WIDTH>
+          The number of characters to wrap text at. This is only valid when the output format is markdown.
+          
+          Certain elements (like section headings and link definitions) will never be wrapped, and the wrapping will never break a word; it will only ever be along existing whitespace. In particular, this means the wrapping will never add hyphens, and it will never break URLs.
+
+  -q, --quiet
+          Quiet: do not print anything to stdout. The exit code will still be 0 if any elements match, and non-0 if none do
+
+      --[no]-br
+          Include breaks between elements in plain and markdown output mode.
+          
+          For plain, this will add a blank line between elements. For markdown, this will add a thematic break ("-----") between elements.
+          
+          This has no effect in JSON output mode.
+          
+          This defaults to true for Markdown output, and false for plain text output.
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version


### PR DESCRIPTION
This will let us track changes to `--help`. This is in service of #300, which will require a refactoring/retooling of how we generate the CLI options.